### PR TITLE
Test added for `font-smoothing`

### DIFF
--- a/modernizr.js
+++ b/modernizr.js
@@ -560,6 +560,9 @@ window.Modernizr = (function(window,doc,undefined){
         
     };
     
+		tests['fontsmoothing'] = function () {
+			return test_props_all('fontSmoothing');
+		};
 
     // These tests evaluate support of the video/audio elements, as well as
     // testing what types of content they support.


### PR DESCRIPTION
`font-smoothing` can be used to change the antialiasing applied to text (examples) 
As far as I am aware it will only be available to webkit browsers at this point in time so have added the test using `test_props_all()`. 

There doesn't appear to be any documentation about supplying patches for modernizr on your readme, so if you'd like me to provide this in some other way, please let me know. 
