### PR TITLE
Added text-stroke

### DIFF
--- a/modernizr.js
+++ b/modernizr.js
@@ -560,6 +560,9 @@ window.Modernizr = (function(window,doc,undefined){
         
     };
     
+    tests['textstroke'] = function() {
+        return test_props_all( 'textStroke' );
+    };
 
     // These tests evaluate support of the video/audio elements, as well as
     // testing what types of content they support.


### PR DESCRIPTION
Webkit has begun to support text-stroke in builds as recent as Safari 3.

http://webkit.org/blog/85/introducing-text-stroke/
