### PR TITLE
Low hanging fruit from Issue 129

### DIFF
--- a/modernizr.js
+++ b/modernizr.js
@@ -33,7 +33,7 @@
 window.Modernizr = (function(window,document,undefined){
     
     var version = '1.6',
-    
+
     ret = {},
 
     /**
@@ -148,10 +148,10 @@ window.Modernizr = (function(window,document,undefined){
           }
           if (element.setAttribute && element.removeAttribute) {
             element.setAttribute(eventName, '');
-            isSupported = isFunction(element[eventName]);
+            isSupported = is(element[eventName], 'function');
 
             // If property was created, "remove it" (by setting value to `undefined`)
-            if (isDefined(element[eventName])) {
+            if (!is(element[eventName], undefined)) {
               element[eventName] = undefined;
             }
             element.removeAttribute(eventName);
@@ -167,14 +167,14 @@ window.Modernizr = (function(window,document,undefined){
     
     // hasOwnProperty shim by kangax needed for Safari 2.0 support
     var _hasOwnProperty = ({}).hasOwnProperty, hasOwnProperty;
-    if (isDefined(_hasOwnProperty) && isDefined(_hasOwnProperty.call)) {
+    if (!is(_hasOwnProperty, undefined) && !is(_hasOwnProperty.call, undefined)) {
       hasOwnProperty = function (object, property) {
         return _hasOwnProperty.call(object, property);
       };
     }
     else {
       hasOwnProperty = function (object, property) { /* yes, this can give false positives/negatives, but most of the time we don't care about those */
-        return ((property in object) && !isDefined(object.constructor.prototype[property]));
+        return ((property in object) && is(object.constructor.prototype[property], undefined));
       };
     }
     
@@ -197,20 +197,6 @@ window.Modernizr = (function(window,document,undefined){
      */
     function is( obj, type ) {
         return typeof obj === type;
-    }
-
-    /**
-     * isDefined returns a boolean for if typeof obj is 'undefined'.
-     */
-    function isDefined( obj ) {
-        return !is(obj, 'undefined');
-    }
-
-    /**
-     * isFunction returns a boolean for if typeof obj is 'function'.
-     */
-    function isFunction( obj ) {
-        return is(obj, 'function');
     }
 
     /**
@@ -306,7 +292,7 @@ window.Modernizr = (function(window,document,undefined){
     };
     
     tests['canvastext'] = function() {
-        return !!(ret['canvas'] && isFunction(document.createElement( 'canvas' ).getContext('2d').fillText));
+        return !!(ret['canvas'] && is(document.createElement( 'canvas' ).getContext('2d').fillText, 'function'));
     };
     
     


### PR DESCRIPTION
http://github.com/Modernizr/Modernizr/issues/129

These 4 commits address:

• The document object is referenced by both "doc" (local) and "document" (global), standardize on "document"

_Standardized on `document`_

• Similarly I'm a "typeof" hater and typically try to wrap those in a function

_Created `is( obj, type )`_

• The head element is selected twice (line 109, 581), cache it with your locals

_Cached query result in `docHead`_
