### PR TITLE
Adding loop support for audio/video

### DIFF
--- a/modernizr.js
+++ b/modernizr.js
@@ -654,7 +654,7 @@ window.Modernizr = (function(window,document,undefined){
             
             bool.webm = elem.canPlayType('video/webm; codecs="vp8, vorbis"');
             
-            bool.loop = elem.loop;
+            bool.loop = !is(elem.loop, undefined);
         }
         return bool;
     };
@@ -674,7 +674,7 @@ window.Modernizr = (function(window,document,undefined){
             bool.wav  = elem.canPlayType('audio/wav; codecs="1"');
             bool.m4a  = elem.canPlayType('audio/x-m4a;') || elem.canPlayType('audio/aac;');
             
-            bool.loop = elem.loop;
+            bool.loop = !is(elem.loop, undefined);
         }
         return bool;
     };


### PR DESCRIPTION
Firefox doesn't support native looping as of 4.0b7. Though it sees the `loop` attr, it'll return `undefined` for its value.

To be honest I'm not sure if `Modernizr.audio/video.loop` is the appropriate place for this boolean. The only feature detection currently done is in regard to codec support which I've piggybacked on, but now `Modernizr.audio/video` stores "codecs & other stuff" which conceptually might be suboptimal.
