### PR TITLE
Fix an @font-face false-positive in Opera 9.

### DIFF
--- a/modernizr.js
+++ b/modernizr.js
@@ -584,7 +584,7 @@ window.Modernizr = (function(window,document,undefined){
                     var result = false;
                     try {
                         sheet.insertRule(rule, 0);
-                        result = !(/unknown/i).test(sheet.cssRules[0].cssText);
+                        result = (/src/i).test(sheet.cssRules[0].cssText);
                         sheet.deleteRule(sheet.cssRules.length - 1);
                     } catch(e) { }
                     return result;
@@ -593,13 +593,13 @@ window.Modernizr = (function(window,document,undefined){
                     if (!(sheet && rule)) return false;
                     sheet.cssText = rule;
                     
-                    return sheet.cssText.length !== 0 && !(/unknown/i).test(sheet.cssText) &&
+                    return sheet.cssText.length !== 0 && (/src/i).test(sheet.cssText) &&
                       sheet.cssText
                             .replace(/\r+|\n+/g, '')
                             .indexOf(rule.split(' ')[0]) === 0;
                 };
         
-        bool = supportAtRule('@font-face { font-family: "font"; src: "font.ttf"; }');
+        bool = supportAtRule('@font-face { font-family: "font"; src: url(font.ttf); }');
         head.removeChild(style);
         return bool;
     };


### PR DESCRIPTION
Modernizr incorrectly reported that Opera 9 supported the @font-face rule.  Opera 9 parsed the at-rule itself without any errors, but complained about not supporting the src property within it.  This fixes that issue so that Opera 9 reports false for Modernizr.fontface as it should according to the research done [here](http://webfonts.info/wiki/index.php?title=@font-face_browser_support).
