### PR TITLE
Fix a fontface detection bug that causes IE6 to crash and switch to data URLs to prevent extra HTTP requests

### DIFF
--- a/modernizr.js
+++ b/modernizr.js
@@ -599,7 +599,7 @@ window.Modernizr = (function(window,document,undefined){
                             .indexOf(rule.split(' ')[0]) === 0;
                 };
         
-        bool = supportAtRule('@font-face { font-family: "font"; src: url(font.ttf); }');
+        bool = supportAtRule('@font-face { font-family: "font"; src: url(data:,); }');
         head.removeChild(style);
         return bool;
     };


### PR DESCRIPTION
It seems that IE6 would crash if the previously used test.ttf didn't exist on the server, and plus, why are we trying to load in a real font anyway, why not use a data URL and prevent that extra HTTP request!  Even though IE6 doesn't support data URLs, it still reports the expected result for the fontface test!
