### PR TITLE
Adds `<meter>` and `<progress>` detection

### DIFF
--- a/modernizr.js
+++ b/modernizr.js
@@ -722,6 +722,15 @@ window.Modernizr = (function(window,document,undefined){
         // Possibly returns a false positive in Safari 3.2?
         return !!document.createElementNS && /SVG/.test(tostring.call(document.createElementNS(ns.svg,'clipPath')));
     };
+    
+    // Added by David Kendal
+    tests['meter'] = function(){
+        return 'value' in document.createElement('meter');
+    }
+    
+    tests['progress'] = function(){
+        return 'value' in document.createElement('progress');
+    }
 
 
     // input features and input types go directly onto the ret object, bypassing the tests loop.


### PR DESCRIPTION
Commit adds support for the detection of support for the `<meter>` and `<progress>` elements. Has been tested in Safari 5 (correctly reports no support for both), Chrome 8.0.552.231 (correctly reports support for both), Firefox 3.6 and 4 (correctly reports no support for both), all on Mac OS X. Not tested in IE but I assume it correctly reports no support for both.
