### PR TITLE
Generated content and improvements to injecting elements with styles

### DIFF
--- a/modernizr.js
+++ b/modernizr.js
@@ -128,6 +128,7 @@ window.Modernizr = (function(window,document,undefined){
       docElement.appendChild(div);
       
       ret = callback(div,rule);
+      div.parentNode.removeChild(div);
       
       return !!ret;
     
@@ -154,8 +155,6 @@ window.Modernizr = (function(window,document,undefined){
             cache[mq] = (window.getComputedStyle ? 
                       getComputedStyle(node, null) : 
                       node.currentStyle)['position'] == 'absolute';
-                      
-            node.parentNode.removeChild(node);
           });
         }
         return cache[mq];
@@ -292,15 +291,13 @@ window.Modernizr = (function(window,document,undefined){
             while(len--) {
                 hash[children[len].id] = children[len];
             }
-            
+                
             /*>>touch*/ret["touch"] = ('ontouchstart' in window) || hash["touch"].offsetTop === 9;/*>>touch*/
             /*>>csstransforms3d*/ret["csstransforms3d"] = hash["csstransforms3d"].offsetLeft === 9;/*>>csstransforms3d*/
             /*>>generatedcontent*/ret["generatedcontent"] = hash["generatedcontent"].offsetHeight >= 1;/*>>generatedcontent*/
             /*>>fontface*/ret["fontface"] = (new RegExp("src","i")).test(cssText) &&
                  cssText
                     .indexOf(rule.split(' ')[0]) === 0;/*>>fontface*/
-
-            node.parentNode.removeChild(node);
         }, len, tests);
         
     })([


### PR DESCRIPTION
# Still a work in progress
- Added method <code>injectElementWithStyles()</code> to refactor tests that need to insert and apply styles.
- Test for CSS generated content, <del>CSS3 generated content</del>.
- fontface test changed to use <code>injectElementWithStyles()</code> method.
- <del><code>testMediaQuery()</code> is a pointer to <code>injectElementWithStyles()</code>, should we keep it? It's not exposed to the external API so it shouldn't be a problem removing it?</del> <ins>Removed it for now.</ins>
- <code>test_bundle</code> bundles all tests that use <code>injectElementWithStyles()</code> in single call so all these test inject once into the DOM. Improved slightly by isolating bundle tests to their own nodes this way the method will scale for further possible additions.
## Some ideas
- Bundle fontface, generated content and any other tests that would use <code>injectElementWithStyles()</code> so the DOM is only touched once.
- <ins>Removed css3 generated content test.</ins> <del>Not sure if I should bother keeping the test for css3 generated content since Opera is the only browser to support it.<del>
- Add a hook so the builder will only include <code>injectElementWithStyles()</code> if the user selects any tests that use it.
