### PR TITLE
Adding a test for radial gradients

### DIFF
--- a/modernizr.js
+++ b/modernizr.js
@@ -525,13 +525,6 @@ window.Modernizr = (function(window,document,undefined){
     
     
     tests['cssradialgradients'] = function() {
-        /**
-         * For CSS Gradients syntax, please see:
-         * http://webkit.org/blog/175/introducing-css-gradients/
-         * https://developer.mozilla.org/en/CSS/-moz-linear-gradient
-         * https://developer.mozilla.org/en/CSS/-moz-radial-gradient
-         * http://dev.w3.org/csswg/css3-images/#gradients-
-         */
         
         var str1 = 'background-image:',
             str2 = 'gradient(radial, 0 0, 0, 0 0, 20, from(#9f9),to(white));',


### PR DESCRIPTION
The upcoming release of Opera 11.1 beta (Barracuda) will feature support for linear gradients but not radial gradients. I added a test for radial gradient which would add a class 'cssradialgradients'  which could be used to test for radial gradient support. 

The original gradients test only tests for linear gradients.  
