### PR TITLE
Addition to test for "rem" css3 value

### DIFF
--- a/modernizr.js
+++ b/modernizr.js
@@ -544,7 +544,17 @@ window.Modernizr = (function( window, document, undefined ) {
     tests['textshadow'] = function() {
         return document.createElement('div').style.textShadow === '';
     };
+    
+    tests['rem'] = function() {
+        // "The 'rem' unit ('root em') is relative to the computed 
+        // value of the 'font-size' value of the root element."
+        // http://www.w3.org/TR/css3-values/#relative0
+        // you can test by checking if the prop was ditched
 
+        setCss('font-size: 3rem');
+
+        return contains(mStyle.fontSize, 'rem');
+    };
 
     tests['opacity'] = function() {
         // Browsers that actually have CSS Opacity implemented have done so


### PR DESCRIPTION
Adding a test for the `rem` css3 value. the test checks to see if the property is ditched when it is used on an element's font-size.

The `rem` addresses the issue of compounding/inherited font-size definitions when using ems, instead, the rem is always tied to the font-size of 'html'/:root or 'medium' if the html element is sized in rems. It's described here:

http://www.w3.org/TR/css3-values/#relative0

I woud normally have left this as an external test, but the addition to modernizr is _so_ trivial that it seems like there's little reason not to test for it. Tested (successfully) on safari 5.05, firefox 3.5,3.6,4, opera 11.10, internet explorer 8,9.

The one thing that i'm not totally sold on is the test's name, _rem_ lacks too much context (for now), so maybe _fontsizerem_ or _remsize_ or... i don't know. ideas? Also, i put it near the text-shadow test, but i'm sure it could go anywhere if these sorts of attributes are placed anywhere specific (i couldn't immediately tell).

hope it's useful,
--marcos
