### PR TITLE
Added support for 'rem' unit detection

### DIFF
--- a/modernizr.js
+++ b/modernizr.js
@@ -632,6 +632,14 @@ window.Modernizr = (function( window, document, undefined ) {
     };
     /*>>fontface*/
 
+    // Test for support for the 'rem' unit
+    // Based on http://ahedg.es/w/rem.html
+    tests['remunit'] = function () {
+        var elem = document.createElement('p');
+        elem.style.cssText = 'font-size: 1.5rem;';
+        return elem.style.fontSize.indexOf('rem') > -1;
+    };
+
     // CSS generated content detection
     tests['generatedcontent'] = function() {
         return Modernizr['generatedcontent'];


### PR DESCRIPTION
Jonathan Snook wrote a blog post a couple of days ago about the 'root em' unit, which allows relative sizes to always be relative to the root element. It's only supported in very recent browsers, so a test for this would be useful.
