### PR TITLE
perform checkValidity on input elements which allow invalid values to be set

### DIFF
--- a/modernizr.js
+++ b/modernizr.js
@@ -814,10 +814,6 @@ window.Modernizr = (function( window, document, undefined ) {
                       // Interestingly, opera fails the earlier test, so it doesn't
                       //  even make it here.
 
-                    } else if ( /^(url|email)$/.test(inputElemType) ) {
-                      // Real url and email support comes with prebaked validation.
-                      bool = inputElem.checkValidity && inputElem.checkValidity() === false;
-
                     } else if ( /^color$/.test(inputElemType) ) {
                         // chuck into DOM and force reflow for Opera bug in 11.00
                         // github.com/Modernizr/Modernizr/issues#issue/159
@@ -827,8 +823,11 @@ window.Modernizr = (function( window, document, undefined ) {
                         docElement.removeChild(inputElem);
 
                     } else {
-                      // If the upgraded input compontent rejects the :) text, we got a winner
-                      bool = inputElem.value != smile;
+                      // If the upgraded input component rejects the :) text,
+                      // we got a winner. Otherwise, check prebaked validation.
+                      bool = inputElem.value != smile
+                             ? true
+                             : (inputElem.checkValidity && inputElem.checkValidity() === false);
                     }
                 }
 


### PR DESCRIPTION
Some browsers allow invalid values into input elements, but will still do the right thing on a call to checkValidity, indicating HTML5 input validation support.

On browsers like Chrome, the 'date' input element for example will _not_ allow non-spec dates to validate when checkValidity is called (indicating support), but still allows the user to initially enter invalid values, such that the method of setting the ':)' and then checking to see if it is actually shows up will result in a false negative test for HTML5 support of that element.
