### PR TITLE
Display table test improvement

### DIFF
--- a/feature-detects/css-displaytable.js
+++ b/feature-detects/css-displaytable.js
@@ -12,13 +12,13 @@ Modernizr.addTest( "display-table",function(){
       child = doc.createElement( "div" ),
       childb  = doc.createElement( "div" ),
       ret;
+  
+  parent.style.cssText = "display: table";
+  child.style.cssText = childb.style.cssText = "display: table-cell; padding: 10px";    
           
   parent.appendChild( child );
   parent.appendChild( childb );
   docElem.insertBefore( parent, docElem.firstChild );
-  
-  parent.style.cssText = "display: table";
-  child.style.cssText = childb.style.cssText = "display: table-cell; padding: 10px";
   
   ret = child.offsetLeft < childb.offsetLeft;
   docElem.removeChild(parent);


### PR DESCRIPTION
IE7 and 6 too (I think) were throwing an error "Could not get the display property. Invalid argument." Using cssText dodges that problem.
