### PR TITLE
Last-child pseudo selector test

### DIFF
--- a/feature-detects/css-lastchild.js
+++ b/feature-detects/css-lastchild.js
@@ -1,34 +1,3 @@
-// :last-child pseudo selector test.
-// By @laustdeleuran and @emilchristensen
-// Please see http://reference.sitepoint.com/css/pseudoclass-lastchild for weird :last-child behaviour in FireFox below 2.0 and Safari below 2.0.
-// Original Modernizr test here: http://jsfiddle.net/laustdeleuran/3rEVe/ and Pure JS here: http://jsfiddle.net/laustdeleuran/hvZ3J/
-Modernizr.addTest('lastchild', function () {
-    var hasLastChild,
-        rules = ['#modernizr-last-child li{display:block;width:100px;height:100px;}','#modernizr-last-child li:last-child{width:200px;}'],
-        head = document.getElementsByTagName('head')[0] || (function () {
-            return document.documentElement.appendChild(document.createElement('head'));
-        }()),
-        root = document.body || (function () {
-            return document.documentElement.appendChild(document.createElement('body'));
-        }()),
-        list = document.createElement('ul'),
-        firstChild = document.createElement('li'),
-        lastChild = document.createElement('li'),
-        style = document.createElement('style');
-        
-    style.type = "text/css";
-    if(style.styleSheet){ style.styleSheet.cssText = rules.join(''); } 
-    else {style.appendChild(document.createTextNode(rules.join(''))); }
-    head.appendChild(style);
-    
-    list.id = "modernizr-last-child";
-    list.appendChild(firstChild);
-    list.appendChild(lastChild);
-    root.appendChild(list);
-    hasLastChild = lastChild.offsetWidth > firstChild.offsetWidth;
-    
-    head.removeChild(style);
-    root.removeChild(list);
-    
-    return hasLastChild;
-});
+Modernizr.testStyles("#modernizr div {width:100px} #modernizr :last-child{width:200px;display:block}", function(elem) {
+    return elem.lastChild.offsetWidth > elem.firstChild.offsetWidth;
+}, 1);


### PR DESCRIPTION
I don't know how this is merged into Modernizr, but I've added the last-child pseudo selector test the feature-detection folder. The script has been tested in FireFox 3.0+, Chrome 7, 10, 11,12, IE6-9, Safari 4.0+ and Opera 11.

It would probably be a good idea to test the script in FireFox 1.0-2.0 and Safari 1.3-2.0. I haven't been able to perform test in those browsers.
