### PR TITLE
Use `{}.toString` instead of `Object.prototype.toString`. OMG BYTEZ

### DIFF
--- a/modernizr.js
+++ b/modernizr.js
@@ -48,7 +48,7 @@ window.Modernizr = (function( window, document, undefined ) {
 
     smile = ':)',
 
-    toString = ({}).toString,
+    toString = {}.toString,
 
     // List of property values to set for css tests. See ticket #21
     prefixes = ' -webkit- -moz- -o- -ms- -khtml- '.split(' '),


### PR DESCRIPTION
Use `{}.toString` instead of `Object.prototype.toString`. Works even if `Object` is something else at that point, plus it saves some bytes.
