### PR TITLE
Added support to verify support for registerProtocolHandler

### DIFF
--- a/feature-detects/custom-protocol-handler.js
+++ b/feature-detects/custom-protocol-handler.js
@@ -1,0 +1,10 @@
+/*
+	Custom protocol handler support
+	http://developers.whatwg.org/timers.html#custom-handlers
+	
+	Added by @benschwarz
+*/
+
+Modernizr.addTest('customprotocolhandler', function () {
+    return !!navigator.registerProtocolHandler;
+});


### PR DESCRIPTION
Not sure if this is something that you want in core, but here it is anyway.

I couldn't tell from the test suite if you were testing just the core library or the property tests themselves, if you can put me in the right direction I'll happily add the test.
