### PR TITLE
second argument of "is" should be string

### DIFF
--- a/modernizr.js
+++ b/modernizr.js
@@ -161,7 +161,7 @@ window.Modernizr = (function( window, document, undefined ) {
             isSupported = is(element[eventName], 'function');
 
             // If property was created, "remove it" (by setting value to `undefined`)
-            if ( !is(element[eventName], undefined) ) {
+            if ( !is(element[eventName], 'undefined') ) {
               element[eventName] = undefined;
             }
             element.removeAttribute(eventName);
@@ -176,14 +176,14 @@ window.Modernizr = (function( window, document, undefined ) {
 
     // hasOwnProperty shim by kangax needed for Safari 2.0 support
     var _hasOwnProperty = ({}).hasOwnProperty, hasOwnProperty;
-    if ( !is(_hasOwnProperty, undefined) && !is(_hasOwnProperty.call, undefined) ) {
+    if ( !is(_hasOwnProperty, 'undefined') && !is(_hasOwnProperty.call, 'undefined') ) {
       hasOwnProperty = function (object, property) {
         return _hasOwnProperty.call(object, property);
       };
     }
     else {
       hasOwnProperty = function (object, property) { /* yes, this can give false positives/negatives, but most of the time we don't care about those */
-        return ((property in object) && is(object.constructor.prototype[property], undefined));
+        return ((property in object) && is(object.constructor.prototype[property], 'undefined'));
       };
     }
 


### PR DESCRIPTION
second argument (type) of `function is( obj, type )` should be always string.
because `typeof obj === undefined` is always false (even if object is undefined)
so, everywhere `is(smth, undefined)` changed to `is(smth, "undefined")`
