### PR TITLE
test for min/max-width media query support

### DIFF
--- a/modernizr.js
+++ b/modernizr.js
@@ -1058,6 +1058,10 @@ window.Modernizr = (function( window, document, undefined ) {
     // Modernizr.mq('only screen and (max-width:768)')
     Modernizr.mq            = testMediaQuery;   
     
+    // test support for min/max-width media queries and add appropriate class
+    if ( ! Modernizr.mq('(min-width:0)') ) { classes.push('no-mq') }
+    else { classes.push('mq') }
+
     // Modernizr.hasEvent() detects support for a given event, with an optional element to test on
     // Modernizr.hasEvent('gesturestart', elem)
     Modernizr.hasEvent      = isEventSupported; 


### PR DESCRIPTION
This works and seems useful. (I'm not sure if I put this in the best place.)

```
// test support of min/max-width media queries and add appropriate class
if ( ! Modernizr.mq('(min-width:0)') ) { classes.push('no-mq') }
else { classes.push('mq') }
```
