### PR TITLE
Test for `draggable` attribute rather than event support

### DIFF
--- a/modernizr.js
+++ b/modernizr.js
@@ -457,7 +457,8 @@ window.Modernizr = (function( window, document, undefined ) {
     };
 
     tests['draganddrop'] = function() {
-        return 'draggable' in document.createElement('div');
+        var div = document.createElement('div');
+        return ('draggable' in div) || ('ondragstart' in div && 'ondrop' in div);
     };
 
     // Mozilla is targeting to land MozWebSocket for FF6


### PR DESCRIPTION
Checking for attribute support tends to be more reliable than testing event support.

Related to issue #352 about CSP.
