### PR TITLE
Noticed the logic to remove no-js class is a little fragile

### DIFF
--- a/modernizr.js
+++ b/modernizr.js
@@ -1108,7 +1108,7 @@ window.Modernizr = (function( window, document, undefined ) {
 
 
     // Remove "no-js" class from <html> element, if it exists:
-    docElement.className = docElement.className.replace(/\bno-js\b/, '')
+    docElement.className = docElement.className.replace(/(^|\s)no-js(\s|$)/, '$1$2')
                             
                             // Add the new classes to the <html> element.
                             + (enableClasses ? ' js ' + classes.join(' ') : '');

--- a/test/index.html
+++ b/test/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="no-js">
+<html class="+no-js no-js- no-js i-has-no-js">
 <head>
   <meta charset="UTF-8">
   <title>Modernizr Test Suite</title>

--- a/test/js/unit.js
+++ b/test/js/unit.js
@@ -37,12 +37,21 @@ test("document.documentElement is valid and correct",1, function() {
 
 test("no-js class is gone.", function() {
   
-	equals(document.documentElement.className.indexOf('no-js') , -1,
-	       'no-js is gone.'); 
+	ok(!/(?:^|\s)no-js(?:^|\s)/.test(document.documentElement.className),
+	   'no-js class is gone');
 	       
-	ok(/\bjs /.test(document.documentElement.className),
-	   'html.js class is present')
-	
+	ok(/(?:^|\s)js(?:^|\s)/.test(document.documentElement.className),
+	   'html.js class is present');
+
+	ok(/(?:^|\s)\+no-js(?:\s|$)/.test(document.documentElement.className),
+	   'html.+no-js class is still present');
+
+	ok(/(?:^|\s)no-js-(?:\s|$)/.test(document.documentElement.className),
+	   'html.no-js- class is still present');
+
+	ok(/(?:^|\s)i-has-no-js(?:\s|$)/.test(document.documentElement.className),
+	   'html.i-has-no-js class is still present');
+
 	if (document.querySelector){
 	  ok(document.querySelector('html.js') == document.documentElement, 
 	     "document.querySelector('html.js') matches.");
@@ -109,7 +118,8 @@ test('html classes are looking good',function(){
   for (var i = 0, len = classes.length, aclass; i <len; i++){
     aclass = classes[i];
     
-    if (aclass === 'js') continue;
+    // Skip js related classes.
+    if (/^(?:js|\+no-js|no-js-|i-has-no-js)$/.test(aclass)) continue;
     
     if (aclass.indexOf('no-') === 0){
       aclass = aclass.replace('no-','');
@@ -128,9 +138,13 @@ test('html classes are looking good',function(){
     equals(classes[i],classes[i].toLowerCase(),'all classes are lowerCase.');
   }
   
-  equals(/[^\s]no-/.test(document.documentElement.className),false,
-         'whitespace between all classes.');
-  
+  // Remove fake no-js classes before test.
+  var docElClass = document.documentElement.className;
+  $.each(['\\+no-js', 'no-js-', 'i-has-no-js'], function(i, fakeClass) {
+    docElClass = docElClass.replace(new RegExp('(^|\\s)' + fakeClass + '(\\s|$)', 'g'), '$1$2');
+  });
+  equals(/[^\s]no-/.test(docElClass), false, 'whitespace between all classes.');
+
   
 })
 


### PR DESCRIPTION
Hey dudes,

I noticed that at the end of Modernizr, there's a replacement of the `documentElement.className` with the regular expression `\bno-js\b`.  This work most of the time, but `\b` also matches `-` or `+`, which might not be cool if somebody's got a `if-no-js` class or something like that.  So, check out my patch and accept it if you want (and the tests pass for you -- they should, but only tried them in Chrome 13, which could have a slightly different RegExp implementation).
