### PR TITLE
test_hyphens_find() was causing a scroll to the bottom of the page. 

### DIFF
--- a/feature-detects/hyphens.js
+++ b/feature-detects/hyphens.js
@@ -89,6 +89,7 @@
 			}
 			document.body.removeChild(div);
 			document.body.removeChild(dummy);
+			window.scroll(0,0);
 			return result;
 		} catch(e) {
 			return false;


### PR DESCRIPTION
Added window.scroll(0,0) to stop it.
