### PR TITLE
Modernizr.stringify

### DIFF
--- a/modernizr.stringify.js
+++ b/modernizr.stringify.js
@@ -38,3 +38,5 @@ Modernizr.serialize = function (onlyTrueVariables, replacer, space) {
 	};
 	return JSON.stringify(Modernizr, replacer, space);
 };
+// Sample usage
+// console.log(Modernizr.serialize(true, null, "\t"));


### PR DESCRIPTION
Added Modernizr.serialize plugin that serializes the Modernizr features as JSON. There is an option to select only true variables in the serialized JSON object, called onlyTrueVariables.
