### PR TITLE
Allow class namespacing via the html[data-modernizr-namespace] option.

### DIFF
--- a/modernizr.js
+++ b/modernizr.js
@@ -34,6 +34,8 @@ window.Modernizr = (function( window, document, undefined ) {
     docElement = document.documentElement,
     docHead = document.head || document.getElementsByTagName('head')[0],
 
+    classNamespace = docElement.getAttribute('data-modernizr-namespace') || '',
+
     /**
      * Create our "modernizr" element that we do most feature tests on.
      */
@@ -1126,7 +1128,7 @@ window.Modernizr = (function( window, document, undefined ) {
     docElement.className = docElement.className.replace(/(^|\s)no-js(\s|$)/, '$1$2')
                             
                             // Add the new classes to the <html> element.
-                            + (enableClasses ? ' js ' + classes.join(' ') : '');
+                            + (enableClasses ? ' ' + [ classNamespace + 'js' ].concat(classes).join(' ' + classNamespace) : '');
 
     return Modernizr;
 


### PR DESCRIPTION
This allows you to set a namespace in the <html> element via a
data-modernizr-namespace attribute. The default is simply a blank
string for backwards compatibility.

I found myself wanting this option too, and while I see that namespacing was brought up in issue #219, I figured I'd take a crack at an implementation anyways. I'm not really sure I know how I would add a unit test for this option, but the implementation itself is a simple two-liner.
