### PR TITLE
Use `Modernizr.canvastext` instead of reinventing the wheel in the emoji 

### DIFF
--- a/feature-detects/emoji.js
+++ b/feature-detects/emoji.js
@@ -1,9 +1,11 @@
+// Requires a Modernizr build with `canvastest` included
+// http://www.modernizr.com/download/#-canvas-canvastext
 Modernizr.addTest('emoji', function() {
-  var node = document.createElement('canvas');
-  if (!(node.getContext && node.getContext('2d'))) return false;
-  var ctx = node.getContext('2d');
-  ctx.textBaseline = "top";
-  ctx.font = "32px Arial";
-  ctx.fillText("😃", 0, 0);
+  if (!Modernizr.canvastext) return false;
+  var node = document.createElement('canvas'),
+      ctx = node.getContext('2d');
+  ctx.textBaseline = 'top';
+  ctx.font = '32px Arial';
+  ctx.fillText('\ud83d\ude03', 0, 0); // "smiling face with open mouth" emoji
   return ctx.getImageData(16, 16, 1, 1).data[0] != 0;
 });


### PR DESCRIPTION
Use `Modernizr.canvastext` instead of reinventing the wheel in the emoji feature detect.

Note: The old version used `fillText` without checking if it’s actually available (and working).
