### PR TITLE
Fullscreen API

### DIFF
--- a/feature-detects/fullscreen-api.js
+++ b/feature-detects/fullscreen-api.js
@@ -1,6 +1,7 @@
-Modernizr.addTest('fullscreen',function(){
-     for(var i = 0, len = Modernizr._domPrefixes.length; i < len; i++) {
-          if(document[Modernizr._domPrefixes[i].toLowerCase() + 'CancelFullScreen'] || document[Modernizr._domPrefixes[i].toLowerCase() + 'ExitFullscreen']) {
+Modernizr.addTest('fullscreen',function() {
+     for(var i = 0, len = Modernizr._domPrefixes.length, pfx; i < len; i++) {
+          pfx = Modernizr._domPrefixes[i].toLowerCase();
+          if(document[pfx + 'CancelFullScreen'] || document[pfx + 'ExitFullscreen']) {
                return true;
           }
      }


### PR DESCRIPTION
Adds fullscreen test, does not increment version number.  Tested in Chrome 15, Safari 5.1, Firefox 7 (Yes, Yes, No).
