### PR TITLE
Nokia E52 failed on an undefined style variable

### DIFF
--- a/modernizr.js
+++ b/modernizr.js
@@ -266,7 +266,7 @@ window.Modernizr = (function( window, document, undefined ) {
                 // IE8 will bork if you create a custom build that excludes both fontface and generatedcontent tests.
                 // So we check for cssRules and that there is a rule available
                 // More here: github.com/Modernizr/Modernizr/issues/288 & github.com/Modernizr/Modernizr/issues/293
-                cssText = style ? (style.cssRules && style.cssRules[0] ? style.cssRules[0].cssText : style.cssText) : "",
+                cssText = style ? (style.cssRules && style.cssRules[0] ? style.cssRules[0].cssText : style.cssText || "") : "",
                 children = node.childNodes, hash = {};
 
             while ( len-- ) {


### PR DESCRIPTION
Additional check added to test if style is defined. Works on the Nokia now. Also tested on FF7 and Chrome 13
