### PR TITLE
If the test added via addTest is NOT a function or Boolean Modernizr die...

### DIFF
--- a/modernizr.js
+++ b/modernizr.js
@@ -902,7 +902,7 @@ window.Modernizr = (function( window, document, undefined ) {
          test = typeof test == 'function' ? test() : test;
 
          docElement.className += ' ' + (test ? '' : 'no-') + feature;
-         Modernizr[feature] = !!test;
+         Modernizr[feature] = test;
 
        }
 


### PR DESCRIPTION
...s.

Prevent cases such as `Modernizr.addTest("breakeverything", undefined);` from annihilating the internet.
