### PR TITLE
Tweak network connection speed test

### DIFF
--- a/feature-detects/network-connection.js
+++ b/feature-detects/network-connection.js
@@ -18,5 +18,5 @@ Modernizr.addTest('lowbandwidth', function() {
 
   return connection.type == 3 // connection.CELL_2G 
       || connection.type == 4 // connection.CELL_3G
-      || /^(?:2g|3g)$/.test(connection.type); // string value in new spec
+      || /^[23]g$/.test(connection.type); // string value in new spec
 });


### PR DESCRIPTION
Network connection speed test: Use `RegExp#test` instead of `String#match` and remove the unused `UNKNOWN` property from the fallback `connection` object.

https://github.com/Modernizr/Modernizr/commit/c56fb8b09515f629806ca44742932902ac145302#commitcomment-771524
