### PR TITLE
Adding Unicode Characters Support Detection

### DIFF
--- a/feature-detects/unicode.js
+++ b/feature-detects/unicode.js
@@ -16,7 +16,7 @@ Modernizr.addTest('unicode', function() {
 		
 		star = document.createElement('span');
 
-	Modernizr.testStyles('#modernizr{font-family:Arial,sans;}', function(node) {
+	Modernizr.testStyles('#modernizr{font-family:Arial,sans;font-size:300em;}', function(node) {
 
 		missingGlyph.innerHTML = '&#5987';
 		star.innerHTML = '&#9734';		


### PR DESCRIPTION
This test will test the rendering between a star ☆ and the missing glyph box &#5987; rendered by browsers unsupporting unicode characters.

As far as I tested this test was negative with <= IE8 and positive on Chrome/Safari/FF (Win&OSX)
