### PR TITLE
Updating the inputtypes check

### DIFF
--- a/modernizr.js
+++ b/modernizr.js
@@ -803,8 +803,9 @@ window.Modernizr = (function( window, document, undefined ) {
                       // Interestingly, opera fails the earlier test, so it doesn't
                       //  even make it here.
 
-                    } else if ( /^(url|email)$/.test(inputElemType) ) {
-                      // Real url and email support comes with prebaked validation.
+                    } else if ( /^(url|email|datetime|date|month|week|time|datetime-local|number)$/.test(inputElemType) ) {
+                      // Real url, email, datetime, date, month, week, time, datetime-local, number
+                      // support come with prebaked validation.
                       bool = inputElem.checkValidity && inputElem.checkValidity() === false;
 
                     } else if ( /^color$/.test(inputElemType) ) {


### PR DESCRIPTION
Along with url and email, the following fields have prebaked validation: datetime, date, month, week, time, datetime-local, number. The current method of detection fails in Chromium 15.0.874.106. The new code has been tested in Chromium 15.0.874.106 and Opera 11.60 where these inputtypes are supported. Firefox 8.0 does not have support and returns true.
