### PR TITLE
csstransforms3d fix for chrome win xp w/o 3d acceleration.

### DIFF
--- a/modernizr.js
+++ b/modernizr.js
@@ -297,7 +297,7 @@ window.Modernizr = (function( window, document, undefined ) {
             }
 
              /*>>touch*/          Modernizr['touch'] = ('ontouchstart' in window) || window.DocumentTouch && document instanceof DocumentTouch || (hash['touch'] && hash['touch'].offsetTop) === 9; /*>>touch*/
-            /*>>csstransforms3d*/ Modernizr['csstransforms3d'] = (hash['csstransforms3d'] && hash['csstransforms3d'].offsetLeft) === 9;          /*>>csstransforms3d*/
+            /*>>csstransforms3d*/ Modernizr['csstransforms3d'] = (hash['csstransforms3d'] && hash['csstransforms3d'].offsetLeft) === 9 && hash['csstransforms3d'].offsetHeight === 3;          /*>>csstransforms3d*/
             /*>>generatedcontent*/Modernizr['generatedcontent'] = (hash['generatedcontent'] && hash['generatedcontent'].offsetHeight) >= 1;       /*>>generatedcontent*/
             /*>>fontface*/        Modernizr['fontface'] = /src/i.test(cssText) &&
                                                                   cssText.indexOf(rule.split(' ')[0]) === 0;        /*>>fontface*/
@@ -311,7 +311,7 @@ window.Modernizr = (function( window, document, undefined ) {
                                 '{#touch{top:9px;position:absolute}}'].join('')           /*>>touch*/
                                 
         /*>>csstransforms3d*/ ,['@media (',prefixes.join('transform-3d),('),mod,')',
-                                '{#csstransforms3d{left:9px;position:absolute}}'].join('')/*>>csstransforms3d*/
+                                '{#csstransforms3d{left:9px;position:absolute;height:3px;}}'].join('')/*>>csstransforms3d*/
                                 
         /*>>generatedcontent*/,['#generatedcontent:after{content:"',smile,'";visibility:hidden}'].join('')  /*>>generatedcontent*/
     ],


### PR DESCRIPTION
We hit a false positive on csstransforms3d when a client had chrome installed on an older machine without 3d acceleration. huge thanks to desandro. He used some modernizr code to detect 3d and his example, and now it seems some tweaks are making their way back @

http://desandro.github.com/3dtransforms/examples/perspective-03.html

In a VM without 3d Acceleration, this test fails, same VM with 3d Acceleration enabled passes.

NOTE: I've added an offsetHeight test, and didn't want to replace anything, since I was unaware of why offsetLeft or a value of 9 was used originally.
