### PR TITLE
Changing transition end event names in comment/example to match MDC

### DIFF
--- a/modernizr.js
+++ b/modernizr.js
@@ -1119,8 +1119,8 @@ window.Modernizr = (function( window, document, undefined ) {
     //       'WebkitTransition' : 'webkitTransitionEnd',
     //       'MozTransition'    : 'transitionend',
     //       'OTransition'      : 'oTransitionEnd',
-    //       'msTransition'     : 'msTransitionEnd', // maybe?
-    //       'transition'       : 'transitionEnd'
+    //       'msTransition'     : 'MsTransitionEnd',
+    //       'transition'       : 'transitionend'
     //     },
     //     transEndEventName = transEndEventNames[ Modernizr.prefixed('transition') ];
     


### PR DESCRIPTION
https://developer.mozilla.org/en/CSS/CSS_transitions#Browser_compatibility
