### PR TITLE
Added Navigation API (performance) and performance memory

### DIFF
--- a/feature-detects/performance-memory.js
+++ b/feature-detects/performance-memory.js
@@ -1,5 +1,0 @@
-// Navigation Timing (Performance)
-// http://www.html5rocks.com/en/tutorials/webperformance/basics/
-// Currently only available in Chrome
-// By Scott Murphy (uxder)
-Modernizr.addTest('performancememory', !!(window.performance.memory));

--- a/feature-detects/performance.js
+++ b/feature-detects/performance.js
@@ -2,4 +2,4 @@
 // https://dvcs.w3.org/hg/webperf/raw-file/tip/specs/NavigationTiming/
 // http://www.html5rocks.com/en/tutorials/webperformance/basics/
 // By Scott Murphy (uxder)
-Modernizr.addTest('performance', !!(window.performance));
+Modernizr.addTest('performance', !!Modernizr.prefixed('performance', window));


### PR DESCRIPTION
In response to #450 here are tests for the navigation time API which falls under window.performance.

Chrome is the only browser with window.performance.memory which isn't in the spec so I've put that as a separate file.
