### PR TITLE
Battery API and Low Battery

### DIFF
--- a/feature-detects/battery-api.js
+++ b/feature-detects/battery-api.js
@@ -4,5 +4,5 @@
 // By: Paul Sayre
 
 Modernizr.addTest('battery',
-	!!Modernizr.prefixed('battery', navigator) || !!navigator.battery
+	!!Modernizr.prefixed('battery', navigator)
 );

--- a/feature-detects/battery-level.js
+++ b/feature-detects/battery-level.js
@@ -6,8 +6,6 @@
 
 Modernizr.addTest('lowbattery', function () {
 	var minLevel = 0.20,
-		nav = window.navigator,
-		battery = nav.battery || nav.webkitBattery || nav.mozBattery,
-		low = battery && !battery.charging && battery.level <= minLevel;
-	return !!low;
+		battery = navigator[Modernizr.prefixed('battery', navigator)];
+	return !!(battery && !battery.charging && battery.level <= minLevel);
 });


### PR DESCRIPTION
Feature detect for both existence of Battery API, and for low battery
power.
https://developer.mozilla.org/en/DOM/window.navigator.mozBattery
http://davidwalsh.name/battery-api

Using the low power detect, we can disable CPU/GPU intensive JS/CSS (especially transitions and animations) to conserve battery power.

API Status:
Right now only Firefox Aurora has support. Webkit implementation looks stalled. No details from Opera or Microsoft (as far as I can tell).
