### PR TITLE
removed dependencies from other test

### DIFF
--- a/feature-detects/forms-placeholder.js
+++ b/feature-detects/forms-placeholder.js
@@ -1,6 +1,10 @@
 // testing for placeholder attribute in inputs and textareas
 // re-using Modernizr.input if available
 
-Modernizr.addTest('placeholder', function(){  
-  return !!('placeholder' in (Modernizr.input || document.createElement('input')) && 'placeholder' in (Modernizr.textarea || document.createElement('textarea')) );
+Modernizr.addTest('placeholder', function(){
+
+  return !!( 'placeholder' in ( Modernizr.input    || document.createElement('input')    ) && 
+             'placeholder' in ( Modernizr.textarea || document.createElement('textarea') )
+           );
+
 });


### PR DESCRIPTION
The placeholder test can be used now without the input test. But if available it will reuse it's test markup

(See: https://github.com/Modernizr/Modernizr/issues/480 )
