### PR TITLE
Added test for navigator.onLine

### DIFF
--- a/feature-detects/online.js
+++ b/feature-detects/online.js
@@ -1,0 +1,4 @@
+// onLine
+// http://www.whatwg.org/specs/web-apps/current-work/#dom-navigator-online
+// by Connor Montgomery
+Modernizr.addTest('onLine', 'onLine' in window.navigator);


### PR DESCRIPTION
Simply checks to see if `onLine` is in `navigator`.

http://www.whatwg.org/specs/web-apps/current-work/#dom-navigator-online

On that note - I didn't find any add-a-feature-if-youre-not-a-core-team-member kind of documentation, so please let me know if you guys want any tests written for this or anything. I just followed the link from the modernizr site to the "community driven add-ons".

<3
