### PR TITLE
You cannot test flexbox-legacy with JavaScript because of the dash

### DIFF
--- a/modernizr.js
+++ b/modernizr.js
@@ -430,7 +430,7 @@ window.Modernizr = (function( window, document, undefined ) {
     // The *old* flexbox
     // www.w3.org/TR/2009/WD-css3-flexbox-20090723/
 
-    tests['flexbox-legacy'] = function() {
+    tests['flexboxlegacy'] = function() {
         return testPropsAll('boxDirection');
     };
 


### PR DESCRIPTION
Also, no other tests uses the dash, it makes no sense.
