### PR TITLE
upload test

### DIFF
--- a/feature-detects/upload.js
+++ b/feature-detects/upload.js
@@ -1,3 +1,14 @@
+/**
+ * File upload support
+ *
+ * It's useful if you want to hide the upload feature of your app on devices that
+ * don't support it (iphone, ipad, etc).
+ * 
+ * Detection is made by testing if the new created upload field is disabled or not.
+ * If it's disabled, most likely the browser does not support upload.
+ *
+ * By Mircea Georgescu
+  */
 Modernizr.addTest('upload', function(){
   var el = document.createElement('input');
   el.setAttribute('type', 'file');


### PR DESCRIPTION
I needed a quick way to find out if the browser supports file upload so I did this test. On iPad and iPhone this test returns false as input["type=file"] are disabled.

I thought this could be useful to someone as I couldn't find anything like this on community add-ons.
