### PR TITLE
background-size:cover test returns wrong result in FF and Opera

### DIFF
--- a/feature-detects/css-backgroundsizecover.js
+++ b/feature-detects/css-backgroundsizecover.js
@@ -1,11 +1,9 @@
 
 // developer.mozilla.org/en/CSS/background-size
 
-Modernizr.testStyles(' #modernizr { background-size: cover; } ', function(elem, rule){ 
-
-  var bool = (window.getComputedStyle ?
-              getComputedStyle(elem, null) :
-              elem.currentStyle)['background-size'] == 'cover';
-            
-  Modernizr.addTest('bgsizecover', bool);
+Modernizr.testStyles( '#modernizr{background-size:cover}', function( elem ) { 
+	var style = window.getComputedStyle
+		? window.getComputedStyle( elem, null )
+		: elem.currentStyle;
+	Modernizr.addTest( 'bgsizecover', style.backgroundSize == 'cover' );
 });


### PR DESCRIPTION
Hello,
I've noticed a bug in the background-size:cover feature detection test...

The current implementation is testing for the value of the "background-size" key of the CSSStyleDeclaration object (getComputedStyle) to be equal to the string "cover". But the right name of this css property is "backgroundSize" and so the result of the test is wrong in all browsers except chrome. Here both keys "background-size" and "backgroundSize" exist and so there is no problem.

To fix this issue, simply change the key "background-size" to "backgroundSize".
