### PR TITLE
Created an alias for flexbox-legacy without a hyphen.

### DIFF
--- a/modernizr.js
+++ b/modernizr.js
@@ -430,7 +430,7 @@ window.Modernizr = (function( window, document, undefined ) {
     // The *old* flexbox
     // www.w3.org/TR/2009/WD-css3-flexbox-20090723/
 
-    tests['flexbox-legacy'] = function() {
+    tests['flexboxlegacy'] = tests['flexbox-legacy'] = function() {
         return testPropsAll('boxDirection');
     };
 


### PR DESCRIPTION
I found myself continually adding `Modernizr.flexboxlegacy = Modernizr['flexbox-legacy'];` to the all my scripts so I could use dot notation. Makes sense to me to have a hyphen-less alias for this purpose. Also for consistency since no other multi-word properties have hyphen separators.
