### PR TITLE
Avoid activating geolocation in WebKit

### DIFF
--- a/modernizr.js
+++ b/modernizr.js
@@ -481,6 +481,9 @@ window.Modernizr = (function( window, document, undefined ) {
      *   code.google.com/p/geo-location-javascript/
      * or view a fallback solution using google's geo API:
      *   gist.github.com/366184
+     *
+     * Directly accessing geolocation in WebKit disables page caching:
+     *   https://bugs.webkit.org/show_bug.cgi?id=43956
      */
     tests['geolocation'] = function() {
         return 'geolocation' in navigator;


### PR DESCRIPTION
Accessing geolocation activates the geolocation service which currently blocks page caching. Checking for the `geolocation` property avoids this.

https://bugs.webkit.org/show_bug.cgi?id=43956
