### PR TITLE
Simplified 'pointer-events' test

### DIFF
--- a/feature-detects/css-pointerevents.js
+++ b/feature-detects/css-pointerevents.js
@@ -1,18 +1,2 @@
 // developer.mozilla.org/en/CSS/pointer-events
-// github.com/ausi/Feature-detection-technique-for-pointer-events
-Modernizr.addTest('pointerevents', function(){
-    var element = document.createElement('x'),
-        documentElement = document.documentElement,
-        getComputedStyle = window.getComputedStyle,
-        supports;
-    if(!('pointerEvents' in element.style)){
-        return false;
-    }
-    element.style.pointerEvents = 'auto';
-    element.style.pointerEvents = 'x';
-    documentElement.appendChild(element);
-    supports = getComputedStyle && 
-        getComputedStyle(element, '').pointerEvents === 'auto';
-    documentElement.removeChild(element);
-    return !!supports;
-});
+Modernizr.addTest('pointerevents', Modernizr.testAllProps('pointer-events'));


### PR DESCRIPTION
I updated the detection for CSS pointer-events support with a simpler method.
This works also correct for Opera which supports pointer-events in SVG, but not in HTML yet.

This has been reviewed by @miketaylr (Mike Taylor (Opera))
