### PR TITLE
getusermedia feature detect: Added test for Opera Mobile

### DIFF
--- a/feature-detects/getusermedia.js
+++ b/feature-detects/getusermedia.js
@@ -2,4 +2,4 @@
 // http://www.whatwg.org/specs/web-apps/current-work/multipage/video-conferencing-and-peer-to-peer-communication.html
 // By Eric Bidelman
 
-Modernizr.addTest('getusermedia', !!Modernizr.prefixed('getUserMedia', navigator));
+Modernizr.addTest('getusermedia', !!Modernizr.prefixed('getUserMedia', navigator) || !!navigator.getUserMedia);


### PR DESCRIPTION
Opera Mobile’s implementation does not use a prefixed method name. So I added a test for navigator.getUserMedia
