### PR TITLE
SubPixel Font Rendering

### DIFF
--- a/feature-detects/css-subpixelfont.js
+++ b/feature-detects/css-subpixelfont.js
@@ -1,31 +1,23 @@
 /*
  * Test for SubPixel Font Rendering
  * (to infer if GDI or DirectWrite is used on Windows)
- * Authors: @derSchepp, @gerritvanaaken, @rodneyrehm, @yatil
+ * Authors: @derSchepp, @gerritvanaaken, @rodneyrehm, @yatil, @ryanseddon
  * Web: https://github.com/gerritvanaaken/subpixeldetect
  */
+Modernizr.addTest('subpixelfont', function() {
+    var bool,
+        styles = "#modernizr{position: absolute; top: -10em; visibility:hidden; font: normal 10px arial;}#subpixel{float: left; font-size: 33.3333%;}";
+    
+    // see https://github.com/Modernizr/Modernizr/blob/master/modernizr.js#L97
+    Modernizr.testStyles(styles, function(elem) {
+        var subpixel = elem.firstChild;
 
-Modernizr.addTest('subpixelfont',  function() {
-	var container = document.createElement('div'),
-		inner = document.createElement('div'),
-		hasSubpixelFontRendering;
+        subpixel.innerHTML = 'This is a text written in Arial';
 
-	// style and content
-	container.style.cssText = 'position: absolute; top: -10em; visibility:hidden; font: normal 10px arial;';
-	inner.style.cssText = 'float: left; font-size: 33.3333%;';
-	inner.textContent = 'This is a text written in Arial';
+        bool = window.getComputedStyle
+            ? window.getComputedStyle(subpixel, null).getPropertyValue("width") !== '44px'
+            : false;   
+    }, 1, ['subpixel']);
 
-	// add test <div>s to the DOM
-	container.appendChild(inner);
-	document.body.appendChild(container);
-
-	// get actual width of text
-	hasSubpixelFontRendering = window.getComputedStyle 
-		? window.getComputedStyle(inner,null).getPropertyValue("width") !== '44px'
-		: false;
-
-	// clean up
-	container.parentNode.removeChild(container);
-
-	return hasSubpixelFontRendering;
+    return bool;
 });


### PR DESCRIPTION
Here's a test to determine if a browser has support for SubPixel Font Rendering. (DirectWrite vs. GDI on Windows, for example).

This could be used to switch fonts in case SubPixel Font Rendering is not supported and another font would look better.
