### PR TITLE
Incorrect event suggested for transitions in IE

### DIFF
--- a/modernizr.js
+++ b/modernizr.js
@@ -1347,7 +1347,7 @@ window.Modernizr = (function( window, document, undefined ) {
     //       'WebkitTransition' : 'webkitTransitionEnd',
     //       'MozTransition'    : 'transitionend',
     //       'OTransition'      : 'oTransitionEnd',
-    //       'msTransition'     : 'MSTransitionEnd',
+    //       'msTransition'     : 'transitionend',
     //       'transition'       : 'transitionend'
     //     },
     //     transEndEventName = transEndEventNames[ Modernizr.prefixed('transition') ];


### PR DESCRIPTION
IE issues the transitionend event after transitions, not the MSTransitionEnd event (contrary to some earlier publications on MSDN). This can be tested and confirmed here: http://jsfiddle.net/jonathansampson/9eMSb/

The correct event name is found within more recent, official, documentation: http://msdn.microsoft.com/en-us/library/ie/hh673535(v=vs.85).aspx#mstransitionend
