### PR TITLE
Explicitly reject tests of CSS properties that have dashes

### DIFF
--- a/modernizr.js
+++ b/modernizr.js
@@ -315,10 +315,18 @@ window.Modernizr = (function( window, document, undefined ) {
     // on our modernizr element, but instead just testing undefined vs
     // empty string.
 
+    // Because the testing of the CSS property names (with "-", as
+    // opposed to the camelCase DOM properties) is non-portable and
+    // non-standard but works in WebKit and IE (but not Gecko or Opera),
+    // we explicitly reject properties with dashes so that authors
+    // developing in WebKit or IE first don't end up with
+    // browser-specific content by accident.
+
     function testProps( props, prefixed ) {
         for ( var i in props ) {
-            if ( mStyle[ props[i] ] !== undefined ) {
-                return prefixed == 'pfx' ? props[i] : true;
+            var prop = props[i];
+            if ( prop.indexOf("-") == -1 && mStyle[prop] !== undefined ) {
+                return prefixed == 'pfx' ? prop : true;
             }
         }
         return false;

--- a/test/js/unit.js
+++ b/test/js/unit.js
@@ -482,6 +482,8 @@ test('Modernizr.testProp()',function(){
   equals(true, Modernizr.testProp('margin'), 'Everyone supports margin');
 
   equals(false, Modernizr.testProp('happiness'), 'Nobody supports the happiness style. :(');
+  equals(true, Modernizr.testProp('fontSize'), 'Everyone supports fontSize');
+  equals(false, Modernizr.testProp('font-size'), 'Nobody supports font-size');
 
   equals('pointerEvents' in  document.createElement('div').style,
          Modernizr.testProp('pointerEvents'),
@@ -496,6 +498,8 @@ test('Modernizr.testAllProps()',function(){
   equals(true, Modernizr.testAllProps('margin'), 'Everyone supports margin');
 
   equals(false, Modernizr.testAllProps('happiness'), 'Nobody supports the happiness style. :(');
+  equals(true, Modernizr.testAllProps('fontSize'), 'Everyone supports fontSize');
+  equals(false, Modernizr.testAllProps('font-size'), 'Nobody supports font-size');
 
   equals(Modernizr.csstransitions, Modernizr.testAllProps('transition'), 'Modernizr result matches API result: csstransitions');
 


### PR DESCRIPTION
Explicitly reject tests of CSS properties that have dashes (rather than camelCase) because such tests work on some browsers but are non-portable.

This change is backwards-incompatible, but won't break previously-portable code (except perhaps for code that tests for multiple prefixed properties and only uses dashes for the -webkit-prefixed ones).

This pattern has been observed in the wild, e.g., on http://getcrackin.angrybirds.com/
