### PR TITLE
fix the assumption that arguments to testProp (etc.) are strings

### DIFF
--- a/modernizr.js
+++ b/modernizr.js
@@ -325,7 +325,7 @@ window.Modernizr = (function( window, document, undefined ) {
     function testProps( props, prefixed ) {
         for ( var i in props ) {
             var prop = props[i];
-            if ( prop.indexOf("-") == -1 && mStyle[prop] !== undefined ) {
+            if ( !contains(prop, "-") && mStyle[prop] !== undefined ) {
                 return prefixed == 'pfx' ? prop : true;
             }
         }


### PR DESCRIPTION
I realized that my change that you merged earlier today introduced a new assumption that the arguments to testProp (etc.) are strings.  It occurs to me that this is an additional (and unnecessary) incompatibility with prior versions of Modernizr, so this fixes it to use contains(), which also matches local style better.
