### PR TITLE
Add check to verify that enableClasses has been initialized. 

### DIFF
--- a/modernizr.js
+++ b/modernizr.js
@@ -979,7 +979,7 @@ window.Modernizr = (function( window, document, undefined ) {
 
          test = typeof test == 'function' ? test() : test;
 
-         if (enableClasses) {
+         if (typeof enableClasses !== "undefined" && enableClasses) {
            docElement.className += ' ' + (test ? '' : 'no-') + feature;
          }
          Modernizr[feature] = test;


### PR DESCRIPTION
During custom builds of Modernizr that do not have the "add css class" functionality, the enableClasses variable is never initialized, causing errors to be raised on this line. This patch verifies that enableClasses is initialized before testing the value of enableClasses.
