### PR TITLE
hasEvent() - add tagName capability and fail faster

### DIFF
--- a/src/isEventSupported.js
+++ b/src/isEventSupported.js
@@ -29,8 +29,6 @@ define(['ModernizrProto', 'createElement'], function( ModernizrProto, createElem
       if ( !eventName ) { return false; }
       if ( !element || typeof element === 'string' ) {
         element = createElement(element || TAGNAMES[eventName] || 'div');
-      } else if ( typeof element !== 'object' ) {
-        return false; // `element` was invalid type
       }
 
       // Testing via the `in` operator is sufficient for modern browsers and IE.


### PR DESCRIPTION
I made 2 changes to [Modernizr.hasEvent()](http://modernizr.com/docs/#hasevent)

**1** - The optional `elem` param can now be an element **or** a tag name:

``` js
Modernizr.hasEvent('click', document.createElement('a'));
Modernizr.hasEvent('click', 'a');
```

**2** - It now detects the need for the [setAttribute fix](http://perfectionkills.com/detecting-event-support-without-browser-sniffing/) ahead of time so that it can `return false` faster in browsers that don't need the fix. I tested this in FF3 / FF12 / IE7 / IE8 / Chrome / Opera / Safari and in all cases tried it behaves like the `Modernizr.hasEvent()` from version 2.5.3.

``` js
('onblur' in document.documentElement) // true => ok // false => needs fix
```
