### PR TITLE
feature-detect for Document Fragments

### DIFF
--- a/feature-detects/dom/documentfragment.js
+++ b/feature-detects/dom/documentfragment.js
@@ -1,0 +1,31 @@
+/*!
+{
+  "name": "Document Fragment",
+  "property": "documentfragment",
+  "notes": [{
+    "name": "W3C DOM Level 1 Reference",
+    "href": "http://www.w3.org/TR/REC-DOM-Level-1/level-one-core.html#ID-B63ED1A3"
+  }, {
+    "name": "SitePoint Reference",
+    "href": "http://reference.sitepoint.com/javascript/DocumentFragment"
+  }, {
+    "name": "QuirksMode Compatibility Tables",
+    "href": "http://www.quirksmode.org/m/w3c_core.html#t112"
+  }],
+  "authors": ["Ron Waldon (@jokeyrhyme)"],
+  "knownBugs": ["false-positive on Blackberry 9500, see QuirksMode note"],
+  "tags": []
+}
+!*/
+/* DOC
+
+Append multiple elements to the DOM within a single insertion.
+
+*/
+define(['Modernizr', 'docElement'], function(Modernizr, docElement) {
+  Modernizr.addTest('documentfragment', function() {
+    return 'createDocumentFragment' in document &&
+      'appendChild' in docElement;
+  });
+});
+


### PR DESCRIPTION
reports true as expected in IE 6-10, Chrome, Opera, probably in Firefox
reports false on a few old Nokia handsets in the office, probably on old Blackberries too

As using Document Fragments is considered a performance and stability best-practice for DOM manipulation, I think it's worth knowing when you can actually use this technique safely.

I have probably been a little too pedantic, so do let me know if some of the tests ought to be trimmed.
