### PR TITLE
Adding checks for interesting `iframe` attributes.

### DIFF
--- a/feature-detects/iframe-sandbox.js
+++ b/feature-detects/iframe-sandbox.js
@@ -1,0 +1,5 @@
+// Test for `sandbox` attribute in iframes.
+//
+// Spec: http://www.whatwg.org/specs/web-apps/current-work/multipage/the-iframe-element.html#attr-iframe-sandbox
+
+Modernizr.addTest('sandbox', 'sandbox' in document.createElement('iframe'));

--- a/feature-detects/iframe-seamless.js
+++ b/feature-detects/iframe-seamless.js
@@ -1,0 +1,5 @@
+// Test for `seamless` attribute in iframes.
+//
+// Spec: http://www.whatwg.org/specs/web-apps/current-work/multipage/the-iframe-element.html#attr-iframe-seamless
+
+Modernizr.addTest('seamless', 'seamless' in document.createElement('iframe'));

--- a/feature-detects/iframe-srcdoc.js
+++ b/feature-detects/iframe-srcdoc.js
@@ -1,0 +1,5 @@
+// Test for `srcdoc` attribute in iframes.
+//
+// Spec: http://www.whatwg.org/specs/web-apps/current-work/multipage/the-iframe-element.html#attr-iframe-srcdoc
+
+Modernizr.addTest('srcdoc', 'srcdoc' in document.createElement('iframe'));


### PR DESCRIPTION
Good morning, lovely Modernizr folks. This patch adds support for a few interesting `iframe` attributes:
-   `@sandbox` enables granular restriction of the permissions with which
  framed content is allowed to run.
-   `@seamless` renders `iframe` elements as though they were part of the
  containing document. CSS bleeds through, and links open in the parent
  window, for instance.
-   `@srcdoc` provides the content that the frame ought to display.

All three are implemented in WebKit, and are specified in the ["The iframe
element" section of the WHATWG HTML living standard](http://www.whatwg.org/specs/web-apps/current-work/multipage/the-iframe-element.html).

Thanks!
