### PR TITLE
Add a check for Content Security Policy (CSP).

### DIFF
--- a/feature-detects/contentsecuritypolicy.js
+++ b/feature-detects/contentsecuritypolicy.js
@@ -1,0 +1,10 @@
+// Test for (experimental) Content Security Policy 1.1 support.
+//
+// This feature is still quite experimental, but is available now in Chrome 22.
+// If the `SecurityPolicy` property is available, you can be sure the browser
+// supports CSP. If it's not available, the browser still might support an
+// earlier version of the CSP spec.
+//
+// Editor's Draft: https://dvcs.w3.org/hg/content-security-policy/raw-file/tip/csp-specification.dev.html
+
+Modernizr.addTest('contentsecuritypolicy', 'SecurityPolicy' in document);


### PR DESCRIPTION
The current editor's draft of the Content Security Policy 1.1 spec defines an
experimental feature detection API[1](https://dvcs.w3.org/hg/content-security-policy/raw-file/tip/csp-specification.dev.html). The feature is implemented in WebKit
behind a flag. Currently, only Chrome 22+ has that flag enabled by
default, but let's hope that changes going forward.

Thanks!
