### PR TITLE
Add feature detection for object-fit

### DIFF
--- a/feature-detects/css-objectfit.js
+++ b/feature-detects/css-objectfit.js
@@ -1,10 +1,6 @@
 
 // dev.opera.com/articles/view/css3-object-fit-object-position/
 
-Modernizr.testStyles( '#modernizr{object-fit:cover}', function( elem ) {
-	var style = window.getComputedStyle ?
-		window.getComputedStyle( elem, null )
-		: elem.currentStyle;
-		
-	Modernizr.addTest( 'objectfitcover', style.objectFit == 'cover' );
-});
+Modernizr.addTest('object-fit',
+	!!Modernizr.prefixed('objectFit')
+);


### PR DESCRIPTION
Whilst Object-fit is listed in the polyfills, there's no feature detection built in for it. Currently it's supported by Opera and HP Touchpads as a prefixed property. Let's get this added to the feature set
