### PR TITLE
TypedArrays feature-detection

### DIFF
--- a/feature-detects/typed-arrays.js
+++ b/feature-detects/typed-arrays.js
@@ -14,9 +14,9 @@
 // Blackberry Browser < 10.0
 // CanIUse Compatibility Reference: http://caniuse.com/typedarrays
 // Mozilla Developer Network:
-// 		https://developer.mozilla.org/en-US/docs/JavaScript_typed_arrays
+//   https://developer.mozilla.org/en-US/docs/JavaScript_typed_arrays
 // TypedArray Specification:
-// 		http://www.khronos.org/registry/typedarray/specs/latest/
+//   http://www.khronos.org/registry/typedarray/specs/latest/
 //
 // by Stanley Stuart <fivetanley>
 


### PR DESCRIPTION
### Why test for TypedArrays? We have a DataView test!

Some browsers support manipulating binary data using various views of `ArrayBuffer`s (e.g., `UInt8Array`), but do not support the more low-level `DataView` API.  Firefox, for example, does not have an implementation for `DataView` in versions <= 14 (current version).
#### References:

[Typed Arrays Specification](http://www.khronos.org/registry/typedarray/specs/latest/)
[CanIUse: TypedArrays](http://caniuse.com/typedarrays)
[Mozilla Developer Network: TypedArrays](https://developer.mozilla.org/en-US/docs/JavaScript_typed_arrays)
