### PR TITLE
Minified version number is out of sync with non-minified

### DIFF
--- a/grunt.js
+++ b/grunt.js
@@ -4,7 +4,7 @@ module.exports = function( grunt ) {
 
     grunt.initConfig({
         meta: {
-          version: '2.5.3',
+          version: '2.6.2pre',
           banner: '/*!\n' +
             ' * Modernizr v<%= meta.version %>\n' +
             ' * www.modernizr.com\n *\n' +


### PR DESCRIPTION
Minified Modernizr.js contains an incorrect version, due to the grunt file banner version being out of sync.
