### PR TITLE
Fix cssmask test.  

### DIFF
--- a/feature-detects/css-mask.js
+++ b/feature-detects/css-mask.js
@@ -10,4 +10,4 @@
 
 // Can combine with clippaths for awesomeness: http://generic.cx/for/webkit/test.html
 
-Modernizr.addTest('cssmask', Modernizr.testAllProps('mask-repeat'));
+Modernizr.addTest('cssmask', Modernizr.testAllProps('maskRepeat'));


### PR DESCRIPTION
Test is failing in all browsers because property name is not camel case

As per http://modernizr.com/docs/:

<blockquote>Note that the property names must be provided in the
camelCase variant.</blockquote>
