### PR TITLE
making sure contextmenu feature test can be run in the head

### DIFF
--- a/feature-detects/contextmenu.js
+++ b/feature-detects/contextmenu.js
@@ -2,7 +2,7 @@
 // Demo at http://thewebrocks.com/demos/context-menu/
 Modernizr.addTest(
   'contextmenu', 
-  ('contextMenu' in document.body && 'HTMLMenuItemElement' in window) 
+  ('contextMenu' in document.documentElement && 'HTMLMenuItemElement' in window) 
 );
 
 


### PR DESCRIPTION
swapped out document.body for document.documentElement so the contextmenu feature test can
be run in the head tag.
