### PR TITLE
fileinput-directory test

### DIFF
--- a/feature-detects/fileinput-directory.js
+++ b/feature-detects/fileinput-directory.js
@@ -6,5 +6,5 @@
 Modernizr.addTest('fileinputdirectory', function() {
   var el = document.createElement('input');
   el.type = 'file';
-  return typeof el.webkitdirectory !== 'undefined' || typeof el.directory !== 'undefined';
+  return typeof el.webkitdirectory !== 'undefined' || typeof el.mozdirectory !== 'undefined' || typeof el.directory !== 'undefined';
 });


### PR DESCRIPTION
Hello,
We are using Modernizr in production on www.centraldesktop.com - thank you for all the work involved in creating it! 
Recently we found that we need to detect ability to select folders in <input type="file"> by reading `webkitdirectory` or `directory` attribute on file input. Because this test is missing in Modernizr, we have created it and would like to contribute it to community tests.
Thank you for your consideration.
Alexander
