### PR TITLE
Add feature detect for lossless WebP images

### DIFF
--- a/feature-detects/img-webp-lossless.js
+++ b/feature-detects/img-webp-lossless.js
@@ -1,0 +1,20 @@
+// code.google.com/speed/webp/
+// tests for lossless webp support, as detailed in https://developers.google.com/speed/webp/docs/webp_lossless_bitstream_specification
+// by @amandeep - based off of the img-webp-test
+
+// This test is asynchronous. Watch out.
+
+(function(){
+
+  var image = new Image();
+
+  image.onerror = function() {
+      Modernizr.addTest('webp-lossless', false);
+  };  
+  image.onload = function() {
+      Modernizr.addTest('webp-lossless', function() { return image.width == 1; });
+  };
+
+  image.src = 'data:image/webp;base64,UklGRhoAAABXRUJQVlA4TA0AAAAvAAAAEAcQERGIiP4HAA==';
+
+}());


### PR DESCRIPTION
This adds detection for the [new lossless format](https://developers.google.com/speed/webp/docs/webp_lossless_bitstream_specification) for WebP images [introduced by Google](http://googledevelopers.blogspot.ca/2012/08/lossless-and-transparency-modes-in-webp.html), on Aug. 30, 2012.

Reports true on Chrome Dev (v23), as it should.
Reports false on Chrome Stable (v20) and Firefox 16, as it should.

Created the base64 image by making a 1x1 PNG image in GIMP, then running:

```
$ cwebp -lossless small.png -o small.webp
$ base64 small.webp
```
