### PR TITLE
Remove BSD license and improve readme

### DIFF
--- a/grunt.js
+++ b/grunt.js
@@ -7,9 +7,9 @@ module.exports = function( grunt ) {
           version: '2.6.3pre',
           banner: '/*!\n' +
             ' * Modernizr v<%= meta.version %>\n' +
-            ' * www.modernizr.com\n *\n' +
+            ' * modernizr.com\n *\n' +
             ' * Copyright (c) Faruk Ates, Paul Irish, Alex Sexton\n' +
-            ' * Available under the BSD and MIT licenses: www.modernizr.com/license/\n */'
+            ' * MIT License\n */'
         },
         qunit: {
             files: ['test/index.html']

--- a/modernizr.js
+++ b/modernizr.js
@@ -1,22 +1,23 @@
 /*!
  * Modernizr v2.6.3pre
- * www.modernizr.com
+ * modernizr.com
  *
  * Copyright (c) Faruk Ates, Paul Irish, Alex Sexton
- * Available under the BSD and MIT licenses: www.modernizr.com/license/
+ * MIT License
  */
 
 /*
- * Modernizr tests which native CSS3 and HTML5 features are available in
- * the current UA and makes the results available to you in two ways:
- * as properties on a global Modernizr object, and as classes on the
- * <html> element. This information allows you to progressively enhance
- * your pages with a granular level of control over the experience.
+ * Modernizr tests which native CSS3 and HTML5 features are available in the
+ * current UA and makes the results available to you in two ways: as properties on
+ * a global `Modernizr` object, and as classes on the `<html>` element. This
+ * information allows you to progressively enhance your pages with a granular level
+ * of control over the experience.
  *
- * Modernizr has an optional (not included) conditional resource loader
- * called Modernizr.load(), based on Yepnope.js (yepnopejs.com).
- * To get a build that includes Modernizr.load(), as well as choosing
- * which tests to include, go to www.modernizr.com/download/
+ * Modernizr has an optional (*not included*) conditional resource loader called
+ * `Modernizr.load()`, based on [Yepnope.js](http://yepnopejs.com). You can get a
+ * build that includes `Modernizr.load()`, as well as choosing which feature tests
+ * to include on the [Download page](http://www.modernizr.com/download/).
+ *
  *
  * Authors        Faruk Ates, Paul Irish, Alex Sexton
  * Contributors   Ryan Seddon, Ben Alman

--- a/readme.md
+++ b/readme.md
@@ -1,28 +1,20 @@
-Modernizr [![Build Status](https://secure.travis-ci.org/Modernizr/Modernizr.png?branch=master)](http://travis-ci.org/Modernizr/Modernizr)
-=========
+# Modernizr [![Build Status](https://secure.travis-ci.org/Modernizr/Modernizr.png?branch=master)](http://travis-ci.org/Modernizr/Modernizr)
 
-### a JavaScript library allowing you to use CSS3 & HTML5 while maintaining control over unsupported browsers 
+##### JavaScript library that detects HTML5 and CSS3 features in the user’s browser
 
-Modernizr tests which native CSS3 and HTML5 features are available in
-the current UA and makes the results available to you in two ways:
-as properties on a global `Modernizr` object, and as classes on the
-`<html>` element. This information allows you to progressively enhance
-your pages with a granular level of control over the experience.
+- [Website](http://www.modernizr.com)
+- [Documentation](http://www.modernizr.com/docs/)
 
-Modernizr has an optional (*not included*) conditional resource loader
-called `Modernizr.load()`, based on Yepnope.js ([yepnopejs.com](http://yepnopejs.com/)).
-To get a build that includes `Modernizr.load()`, as well as choosing
-which tests to include, go to [www.modernizr.com/download/](http://www.modernizr.com/download/)
+Modernizr tests which native CSS3 and HTML5 features are available in the current UA and makes the results available to you in two ways: as properties on a global `Modernizr` object, and as classes on the `<html>` element. This information allows you to progressively enhance your pages with a granular level of control over the experience.
 
-[Full documentation on modernizr.com/docs/](http://www.modernizr.com/docs/)
-
-* * *
-
-Modernizr is dual-licensed under the [BSD and MIT licenses](http://www.modernizr.com/license/).
-
-[modernizr.com](http://www.modernizr.com/)
+Modernizr has an optional (*not included*) conditional resource loader called `Modernizr.load()`, based on [Yepnope.js](http://yepnopejs.com). You can get a build that includes `Modernizr.load()`, as well as choosing which feature tests to include on the [Download page](http://www.modernizr.com/download/).
 
 
-#### Try it out: 
+## Test suite
 
-Run the test suite: [http://modernizr.github.com/Modernizr/test/](http://modernizr.github.com/Modernizr/test/)
+Run the [test suite](http://modernizr.github.com/Modernizr/test/)
+
+
+## License
+
+MIT license


### PR DESCRIPTION
Fixes #679

Couldn't help myself and improved the readme a little bit.

No need to link to a license. Just stating that it's MIT License is enough.
