### PR TITLE
Fix Audio Data API test to detect API, not Audio element

### DIFF
--- a/feature-detects/audio-audiodata-api.js
+++ b/feature-detects/audio-audiodata-api.js
@@ -1,4 +1,4 @@
 // Mozilla Audio Data API
 // https://wiki.mozilla.org/Audio_Data_API
 // by Addy Osmani
-Modernizr.addTest('audiodata', !!(new window.Audio()).mozSetup);
+Modernizr.addTest('audiodata', !!(window.Audio && (new window.Audio()).mozSetup));


### PR DESCRIPTION
As it was, `!!(window.Audio)` in the Audio Data API test will return true for any browser that supports Audio elements (Chrome, Safari, Firefox..), not the Mozilla Audio Data API. As per the spec, Audio objects in Firefox 4+ support the `mozSetup` method, and pass in FF4+, and fail (appropriately) in other browsers.
