### PR TITLE
Bower Component.json

### DIFF
--- a/component.json
+++ b/component.json
@@ -1,0 +1,9 @@
+{
+  "name": "modernizr",
+  "version": "2.6.2",
+  "main":"./modernizr.js",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/Modernizr/Modernizr.git"
+  }
+}


### PR DESCRIPTION
I added component.json to the repo which [bower](https://github.com/twitter/bower) uses. I took the standard component.json file created and added `main`.

Without `main` modernizer has no file to point.

```
thomas@workstation:~/Desktop/fathoms/landing$ bower list --path
{
  "bootstrap": [
    "components/bootstrap/docs/assets/js/bootstrap.js",
    "components/bootstrap/docs/assets/css/bootstrap.css"
  ],
  "jquery": "components/jquery/jquery.js",
  "modernizr": "components/modernizr"
}
```

With `main` bower knows which file is the one.

```
thomas@workstation:~/Desktop/fathoms/landing$ bower list --path
{
  "bootstrap": [
    "components/bootstrap/docs/assets/js/bootstrap.js",
    "components/bootstrap/docs/assets/css/bootstrap.css"
  ],
  "jquery": "components/jquery/jquery.js",
  "modernizr": "components/modernizr/modernizr.js"
}
```
