### PR TITLE
Tweak to csstransforms3d test for issue #760

### DIFF
--- a/feature-detects/css-transforms3d.js
+++ b/feature-detects/css-transforms3d.js
@@ -12,8 +12,8 @@ Modernizr.addTest('csstransforms3d', function() {
       // Webkit allows this media query to succeed only if the feature is enabled.
       // `@media (transform-3d),(-webkit-transform-3d){ ... }`
       // If loaded inside the body tag and the test element inherits any padding, margin or borders it will fail #740
-      Modernizr.testStyles('@media (transform-3d),(-webkit-transform-3d){#modernizr{left:9px;position:absolute;height:3px;margin:0;padding:0;border:0}}', function( node, rule ) {
-        ret = node.offsetLeft === 9 && node.offsetHeight === 3;
+      Modernizr.testStyles('@media (transform-3d),(-webkit-transform-3d){#modernizr{left:9px;position:absolute;height:5px;margin:0;padding:0;border:0}}', function( node, rule ) {
+        ret = node.offsetLeft === 9 && node.offsetHeight === 5;
       });
     }
     return ret;


### PR DESCRIPTION
Tweaked csstransforms3d style test numbers to work around rounding bug in Chrome 23.0 when zoomed - see #760
