### PR TITLE
Feature detect text-align-last property

### DIFF
--- a/feature-detects/css-textalignlast.js
+++ b/feature-detects/css-textalignlast.js
@@ -1,0 +1,4 @@
+
+// text-align-last
+
+Modernizr.addTest('textalignlast', Modernizr.testAllProps('textAlignLast'));


### PR DESCRIPTION
Feature detect text-align-last CSS property.

Feature currently unsupported by Webkit.
## 

Fixes #715 
