### PR TITLE
Feature detection for CSS3 Gradients with ANGLES

### DIFF
--- a/feature-detects/css-anglegradients.js
+++ b/feature-detects/css-anglegradients.js
@@ -1,0 +1,31 @@
+
+//
+// One of the most important lack of -webkit-gradient
+// versus it's modern successors is angle gradients
+// There is no way you can have your gradient work natively
+// in a browser that only supports -webkit-gradient
+// For example, Blackberry 6 and 7 are a good example
+// So, in order to provide fallback for those browsers
+// we need this separate test
+//
+// For differences between
+// -webkit-gradient function
+// and more specific functions like
+// -webkit-linear-gradient or -webkit-radial-gradient
+// see:
+// https://www.webkit.org/blog/1424/css3-gradients/
+//
+
+Modernizr.addTest('cssanglegradients', function() {
+
+    var str1    = 'background-image:',
+        str2    = 'linear-gradient(45deg,#9f9, white);',
+
+        css     = Modernizr._prefixes.join(str2 + str1).slice(0, -str1.length),
+        elem    = document.createElement('div'),
+        style   = elem.style;
+    style.cssText = css;
+
+    // IE6 returns undefined so cast to string
+    return ('' + style.backgroundImage).indexOf('gradient') > -1;
+});


### PR DESCRIPTION
Left comments in the code, however just in 2 words: it's not enough to have general css gradients detection as there are some browsers (like Blackberry) that DO support -webkit-gradient but DON'T support -webkit-linear-gradient which in case you use ANGLES for your gradient means your gradient will not work. So there SHOULD be separate feature detection, and that is what I added. It works for me like a charm so hopefully it will be helpful to others.
