### PR TITLE
Update WebSockets detection to the latest version

### DIFF
--- a/feature-detects/websockets.js
+++ b/feature-detects/websockets.js
@@ -1,9 +1,6 @@
-
-// FF3.6 was EOL'ed on 4/24/12, but the ESR version of FF10
-// will be supported until FF19 (2/12/13), at which time, ESR becomes FF17.
-// FF10 still uses prefixes, so check for it until then.
-// for more ESR info, see: mozilla.org/en-US/firefox/organizations/faq/
+// Latest revision of WebSockets (Candidate Recommendation - http://www.w3.org/TR/2012/CR-websockets-20120920/)
+// adds a "CLOSING" state which allows us to detect unprefixed and old version in Safari 5.1
 
 Modernizr.addTest('websockets', function() {
-	return 'WebSocket' in window || 'MozWebSocket' in window;
+	return 'WebSocket' in window && window.WebSocket.CLOSING === 2;
 });


### PR DESCRIPTION
The previous detection code was for older, deprecated versions of WebSockets. The latest standard is unprefixed in all browsers(starts with version 11 for Firefox). The only exception is in Safari 5.1 which this patch walks around by checking the newly added "CLOSING" state.
