### PR TITLE
Fix exception when looking up indexedDB when disabled in Firefox.

### DIFF
--- a/src/testDOMProps.js
+++ b/src/testDOMProps.js
@@ -8,9 +8,7 @@ define(['is', 'fnBind'], function( is ) {
       var item;
       try {
         item = obj[props[i]];
-      } catch (e) {
-        continue;
-      }
+      } catch (e) { }
       if ( item !== undefined) {
 
         // return the property name as a string


### PR DESCRIPTION
Firefox will sometimes throw an exception when looking up known but
disabled features in the dom. This commit catches exceptions when
looking up properties in testDOMProps.

While this fix could be more specific, putting it in the testDOMProps function will help prevent bugs like this from being introduced in the future.
