### PR TITLE
Updates file upload user agent regexp + fixes missing brackets

### DIFF
--- a/feature-detects/forms/fileinput.js
+++ b/feature-detects/forms/fileinput.js
@@ -7,7 +7,7 @@ define(['Modernizr', 'createElement'], function( Modernizr, createElement ) {
   //  don't support it (iphone, ipad, etc).
 
   Modernizr.addTest('fileinput', function() {
-    if(navigator.userAgent.match(/(Android (1.0|1.1|1.5|1.6|2.0|2.1))|(Windows Phone (OS 7|8.0)|(XBLWP)|(ZuneWP)|(w(eb)?OSBrowser)|(webOS)|Pre\/1.2|Kindle\/(1.0|2.0|2.5|3.0))/)) {
+    if(navigator.userAgent.match(/(Android (1.0|1.1|1.5|1.6|2.0|2.1))|(Windows Phone (OS 7|8.0))|(XBLWP)|(ZuneWP)|(w(eb)?OSBrowser)|(webOS)|(Kindle\/(1.0|2.0|2.5|3.0))/)) {
         return false;
     }
     var elem = createElement('input');


### PR DESCRIPTION
This pull request fixes missing brackets in the UA regexp and removes unneeded "Pre 1.2" from it ("webOS” should already cover Pre 1.2 too).
