### PR TITLE
Remove "no-<feature>" classes if feature is detected

### DIFF
--- a/src/setClasses.js
+++ b/src/setClasses.js
@@ -3,10 +3,9 @@ define(['Modernizr', 'docElement', 'classes'], function( Modernizr, docElement, 
   // if you'd like to change the classe on
   // something other than the html element.
   function setClasses( elem ) {
-    var theElem = elem || docElement;
-
-    var features = classes.concat('js')
-    var featurePattern = new RegExp('(^|\\s)no-(' + features.join('|') + ')(\\s|$)', 'g')
+    var theElem = elem || docElement,
+        features = classes.concat('js'),
+        featurePattern = new RegExp('(^|\\s)no-(' + features.join('|') + ')(\\s|$)', 'g')
 
     theElem.className =
       // Remove relevant 'no-<feature>' classes


### PR DESCRIPTION
This fixes #808

I had some temporary junky tests to develop this (adding a "no-canvas" class to test/js/index.html), because I couldn't quickly see a good way to inject a specific "no-something" class during the tests. If you could point me in the right direction I'm happy to add a proper test. 
