### PR TITLE
Add a small regression test to -wrap-flow property testing

### DIFF
--- a/feature-detects/css/wrapflow.js
+++ b/feature-detects/css/wrapflow.js
@@ -9,10 +9,16 @@ define(['Modernizr', 'prefixed', 'docElement'], function( Modernizr, prefixed, d
 
         var wrapFlowProperty = prefixedProperty.replace(/([A-Z])/g, function (str, m1) { return '-' + m1.toLowerCase(); }).replace(/^ms-/, '-ms-');
 
+        /* If the CSS parsing is there we need to determine if wrap-flow actually works to avoid false positive cases, e.g. the browser parses
+           the property, but it hasn't got the implementation for the functionality yet. */
         var container = createElement('div');
         var exclusion = createElement('div');
         var content = createElement('span');
 
+        /* First we create a div with two adjacent divs inside it. The first div will be the content, the second div will be the exclusion area.
+           We use the "wrap-flow: end" property to test the actual behavior. (http://dev.w3.org/csswg/css3-exclusions/#wrap-flow-property)
+           The wrap-flow property is applied to the exclusion area what has a 50px left offset and a 100px width.
+           If the wrap-flow property is working correctly then the content should start after the exclusion area, so the content's left offset should be 150px. */
         exclusion.style.cssText = 'position: absolute; left: 50px; width: 100px; height: 20px;' + wrapFlowProperty + ':end;';
         content.innerText = 'X';
 


### PR DESCRIPTION
We need to extend the wrap-flow testing with a small regression test to get the accurate result. Testing only the property parsing is not enough anymore.
