### PR TITLE
New datauri tests: datauri5k datauri33k

### DIFF
--- a/feature-detects/url/data-uri.js
+++ b/feature-detects/url/data-uri.js
@@ -5,19 +5,47 @@ define(['Modernizr', 'addTest'], function( Modernizr, addTest ) {
   // This test is asynchronous. Watch out.
 
   // in IE7 in HTTPS this can cause a Mixed Content security popup.
-  //  github.com/Modernizr/Modernizr/issues/362
+  // github.com/Modernizr/Modernizr/issues/362
   // To avoid that you can create a new iframe and inject this.. perhaps..
 
   Modernizr.addAsyncTest(function() {
-    var datauri = new Image();
+    var datauri 		= new Image();
+    var datauri5k 		= new Image();
+    var datauri33k 		= new Image();
+    var imgstr 			= "R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==";
+    
+    datauri.src 		= "data:image/gif;base64,"+imgstr;
+    
+    while (imgstr.length < 5000) {
+        imgstr 			= "\r\n" + imgstr;
+    }
+    datauri5k.src		= "data:image/gif;base64,"+imgstr;
+    
+    while (imgstr.length < 33000) {
+        imgstr 			= "\r\n" + imgstr;
+    }
+    datauri33k.src		= "data:image/gif;base64,"+imgstr;
 
-    datauri.onerror = function() {
+    datauri.onerror		= function() {
       addTest('datauri', false);
     };
-    datauri.onload = function() {
+    datauri.onload 		= function() {
       addTest('datauri', datauri.width == 1 && datauri.height == 1);
     };
+    
+    datauri5k.onerror	= function() {
+	    addTest('datauri5k', false);
+	};
+	datauri5k.onload 	= function() {
+		addTest('datauri5k', datauri5k.width == 1 && datauri5k.height == 1);
+	};
 
-    datauri.src = "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==";
+	datauri33k.onerror	= function() {
+	    addTest('datauri33k', false);
+	};
+	datauri33k.onload	= function() {
+		addTest('datauri33k', datauri33k.width == 1 && datauri33k.height == 1);
+	};
+    
   });
 });


### PR DESCRIPTION
Opera and IE8 support data-uri data, but only up to a given size: 4K for
Opera and 32K for IE8.

These tests allow checking for these cases specifically.

First commit to Modernizr, so please direct any questions/concerns or
provide any feedback to zac@zacwolf.com
