### PR TITLE
Further grunting

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -12,7 +12,7 @@ module.exports = function( grunt ) {
       full: '/*!\n' +
         ' * <%= pkg.name %> v<%= pkg.version %>\n' +
         ' * modernizr.com\n *\n' +
-        ' * Copyright (c) <%= pkg.author %>\n' +
+        ' * Copyright (c) <%= _.pluck(pkg.contributors, "name").join(", ") %>\n' +
         ' * <%= pkg.license %> License\n */' +
         ' \n' +
         '/*\n' +
@@ -26,10 +26,6 @@ module.exports = function( grunt ) {
         ' * `Modernizr.load()`, based on [Yepnope.js](http://yepnopejs.com). You can get a\n' +
         ' * build that includes `Modernizr.load()`, as well as choosing which feature tests\n' +
         ' * to include on the [Download page](http://www.modernizr.com/download/).\n' +
-        ' *\n' +
-        ' *\n' +
-        ' * Authors        <%= pkg.author %>\n' +
-        ' * Contributors   <%= pkg.contributors %>\n' +
         ' */'
     },
     meta: {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,18 @@
     "browser",
     "feature detection"
   ],
-  "author": "Faruk Ates, Paul Irish, Alex Sexton, Ryan Seddon, Alexander Farkas",
-  "contributors": "Ben Alman",
+  "author": {
+    "name": "Modernizr",
+    "url": "http://modernizr.com/"
+  },
+  "contributors": [
+    { "name": "Faruk Ates" },
+    { "name": "Paul Irish" }, 
+    { "name": "Alex Sexton" }, 
+    { "name": "Ryan Seddon" }, 
+    { "name": "Alexander Farkas" }, 
+    { "name": "Ben Alman" }, 
+    { "name": "Stu Cox" }
+  ],
   "license": "MIT"
 }


### PR DESCRIPTION
- Cleanup license/banners
- Add info to package.json

I think the authors/contributors section needs a look because according to the [spec](https://npmjs.org/doc/json.html#people-fields-author-contributors) authors should be a single [person](https://github.com/gruntjs/grunt/blob/master/package.json#L5) or [group](https://github.com/jquery/jquery-mobile/blob/master/package.json#L8)
