### PR TITLE
`datauri` test updates (fixes #321 & #362)

### DIFF
--- a/feature-detects/url/data-uri.js
+++ b/feature-detects/url/data-uri.js
@@ -4,20 +4,57 @@ define(['Modernizr', 'addTest'], function( Modernizr, addTest ) {
 
   // This test is asynchronous. Watch out.
 
-  // in IE7 in HTTPS this can cause a Mixed Content security popup.
-  //  github.com/Modernizr/Modernizr/issues/362
-  // To avoid that you can create a new iframe and inject this.. perhaps..
-
   Modernizr.addAsyncTest(function() {
+
+    // IE7 throw a mixed content warning on HTTPS for this test, so we'll
+    // just blacklist it (we know it doesn't support data URIs anyway)
+    // https://github.com/Modernizr/Modernizr/issues/362
+    if(navigator.userAgent.indexOf('MSIE 7.') !== -1) {
+      // Keep the test async
+      setTimeout(function () {
+        addTest('datauri', false);
+      }, 10);
+    }
+
     var datauri = new Image();
 
     datauri.onerror = function() {
       addTest('datauri', false);
     };
     datauri.onload = function() {
-      addTest('datauri', datauri.width == 1 && datauri.height == 1);
+      if(datauri.width == 1 && datauri.height == 1) {
+        testOver32kb();
+      }
+      else {
+        addTest('datauri', false);
+      }
     };
 
     datauri.src = "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==";
+
+    // Once we have datauri, let's check to see if we can use data URIs over
+    // 32kb (IE8 can't). https://github.com/Modernizr/Modernizr/issues/321
+    function testOver32kb(){
+
+      var datauriBig = new Image();
+
+      datauriBig.onerror = function() {
+          addTest('datauri', true);
+          Modernizr.datauri = new Boolean(true);
+          Modernizr.datauri.over32kb = false;
+      };
+      datauriBig.onload = function() {
+          addTest('datauri', true);
+          Modernizr.datauri = new Boolean(true);
+          Modernizr.datauri.over32kb = (datauriBig.width == 1 && datauriBig.height == 1);
+      };
+
+      var base64str = "R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==";
+      while (base64str.length < 33000) {
+        base64str = "\r\n" + base64str;
+      }
+      datauriBig.src= "data:image/gif;base64," + base64str;
+    }
+
   });
 });


### PR DESCRIPTION
- Added `over32kb` aspect (managed to avoid making it "doubly" asynchronous)
- Added blacklist for IE7 to avoid warnings on HTTPS
