### PR TITLE
Fix pointerlock-test

### DIFF
--- a/feature-detects/pointerlock-api.js
+++ b/feature-detects/pointerlock-api.js
@@ -1,4 +1,4 @@
 define(['Modernizr', 'prefixed'], function( Modernizr, prefixed ) {
   // https://developer.mozilla.org/en-US/docs/API/Pointer_Lock_API
-  Modernizr.addTest('pointerlock', !!prefixed('pointerLockElement', document));
+  Modernizr.addTest('pointerlock', !!prefixed('exitPointerLock', document));
 });


### PR DESCRIPTION
The pointerlock-test was only true if you had already locked the pointer when Modernizr runs: `document.pointerLockElement` is `null` when not in pointerlock, which when cast to a bool becomes false.

Rewritten to use `exitPointerLock`, quite similar to how the fullscreen-test works.

Checked in MacOS: 
- Chrome (true) 
- Firefox (true) 
- Safari (false) 
- Opera (false)

as expected per [MDN](https://developer.mozilla.org/en-US/docs/API/Pointer_Lock_API).
