### PR TITLE
Modernizr crashes on Firefox with hidden iframe

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ build
 dist
 tmp
 .DS_Store
+.project

--- a/src/testMediaQuery.js
+++ b/src/testMediaQuery.js
@@ -6,7 +6,7 @@ define(['injectElementWithStyles'], function( injectElementWithStyles ) {
     var matchMedia = window.matchMedia || window.msMatchMedia;
     var bool;
     if ( matchMedia ) {
-      return matchMedia(mq).matches;
+      return matchMedia(mq) && matchMedia(mq).matches || false;
     }
 
     injectElementWithStyles('@media ' + mq + ' { #modernizr { position: absolute; } }', function( node ) {


### PR DESCRIPTION
On Firefox, with hidden iframes, matchMedia returns null, thus trying to access .matches crashes things. Added extra check to make sure we stay
up and running. Also, added .project to gitignore
