### PR TITLE
Scope & iframe issues with Modernizr

### DIFF
--- a/lib/processbuild.js
+++ b/lib/processbuild.js
@@ -7,7 +7,7 @@ var mod = fs.readFileSync(__dirname + '/dist/modernizr-build.js', 'utf8');
 var license = fs.readFileSync(__dirname + '/LICENSE', 'utf8');
 
 mod = mod.replace('define("modernizr-init",[], function(){});', '');
-mod = license + "\n;(function(window, document, undefined){\n" + mod + "\n})(this, document);";
+mod = license + "\n;(function(window, document, undefined){\n" + mod + "\n})((this.self === this ? this : window), (this.self === this ? this : window).document);";
 
 fs.writeFileSync(__dirname + '/dist/modernizr-build.js', mod, 'utf8');
 

--- a/src/testMediaQuery.js
+++ b/src/testMediaQuery.js
@@ -11,7 +11,7 @@ define(['injectElementWithStyles'], function( injectElementWithStyles ) {
 
     injectElementWithStyles('@media ' + mq + ' { #modernizr { position: absolute; } }', function( node ) {
       bool = (window.getComputedStyle ?
-              getComputedStyle(node, null) :
+              window.getComputedStyle(node, null) :
               node.currentStyle)['position'] == 'absolute';
     });
 


### PR DESCRIPTION
Fixed issue where Modernizr is run within another scope, where this -keyword might not point to a window

Fixed issue with first testing for window.getComputedStyle and then using getComputedStyle directly (with for example iframes)