### PR TITLE
JavaScript strict mode compatibility

### DIFF
--- a/src/html5printshiv.js
+++ b/src/html5printshiv.js
@@ -499,6 +499,6 @@ define(function() {
     // shiv for print
     shivPrint(document);
 
-  }(this, document));
+  }(window, document));
   return html5;
 });

--- a/src/html5shiv.js
+++ b/src/html5shiv.js
@@ -301,7 +301,7 @@ define(function() {
     // shiv the document
     shivDocument(document);
 
-  }(this, document));
+  }(window, document));
 
   return html5;
 });


### PR DESCRIPTION
This pull-request may be nitpicky, but I noticed that strict mode would return an error when modernizr was set to use it.

The problem was the HTML5 shiv functions were being passed 'this' as the window parameter which, [per the specification of strict mode (page 235)](http://www.ecma-international.org/publications/files/ECMA-ST/Ecma-262.pdf):

> If this is evaluated within strict mode code, then the this value is not coerced to an object. A this value of null or undefined is not converted to the global object and primitive values are not converted to wrapper objects. The this value passed via a function call (including calls made using Function.prototype.apply and Function.prototype.call) do not coerce the passed this value to an object (10.4.3, 11.1.1, 15.3.4.3, 15.3.4.4).

This quick change fixes this.
