### PR TITLE
history check for version of Android 4.0.x aswell

### DIFF
--- a/feature-detects/history.js
+++ b/feature-detects/history.js
@@ -5,14 +5,14 @@ define(['Modernizr'], function( Modernizr ) {
   // http://dev.w3.org/html5/spec/history.html#the-history-interface
   Modernizr.addTest('history', function() {
     // Issue #733
-    // The stock browser on Android 2.2 & 2.3 returns positive on history support
+    // The stock browser on Android 2.2, 2.3 and 4.0.x returns positive on history support
     // Unfortunately support is really buggy and there is no clean way to detect
     // these bugs, so we fall back to a user agent sniff :(
     var ua = navigator.userAgent;
 
-    // We only want Android 2, stock browser, and not Chrome which identifies
+    // We only want Android 2 and 4.0, stock browsers, and not Chrome which identifies
     // itself as 'Mobile Safari' as well
-    if (ua.indexOf('Android 2') !== -1 &&
+    if ( (ua.indexOf('Android 2') !== -1 )|| (ua.indexOf('Android 4.0') !== -1) &&
         ua.indexOf('Mobile Safari') !== -1 &&
           ua.indexOf('Chrome') === -1) {
       return false;


### PR DESCRIPTION
Modernizr.history returns a false positive with Android 4.0.4 stock browser.
This fixes it for Android 4.0.x more generally.

Main reasons why I track all 4.0.x versions here is:
Many people noticed Android 4.0.x stock browser is not fully supporting history.
More specifically, the address bar is not correctly updated.

StackOverflow:
http://stackoverflow.com/questions/10620843/pushstate-in-android-4-0.

Android project issues reports : 
https://code.google.com/p/android/issues/detail?id=17471
https://code.google.com/p/android/issues/detail?id=23979
