### PR TITLE
Fix peerconnection interface test

### DIFF
--- a/feature-detects/webrtc/peerconnection.js
+++ b/feature-detects/webrtc/peerconnection.js
@@ -1,7 +1,15 @@
-define(['Modernizr', 'prefixed'], function( Modernizr, prefixed ) {
-  // RTCPeerConnection
-  // http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcpeerconnection-interface
-  // By Ankur Oberoi
-
-  Modernizr.addTest('peerconnection', !!prefixed('RTCPeerConnection', window));
+/*!
+{
+  "name": "RTCPeerConnection Interface",
+  "property": "peerconnection",
+  "tags": ["rtc", "media"],
+  "authors": ["Ankur Oberoi", "Matthew Robertson"],
+  "notes": [{
+    "name": "HTML5 Spec",
+    "href": "http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcpeerconnection-interface"
+  }]
+}
+!*/
+define(['Modernizr'], function( Modernizr ) {
+  Modernizr.addTest('peerconnection', !!(window.webkitRTCPeerConnection || window.RTCPeerConnection));
 });


### PR DESCRIPTION
Currently, with the code as it is, including the `RTCPeerConnection` test in a Modernizr build causes the following exception to be thrown:

```
Uncaught TypeError: Object function RTCPeerConnection() { [native code] } has no method 'bind' 
```

I changed the test to use lookup the properties on `window` manually instead of using `prefixed` and added some docs for it.

I can confirm the test is working properly in Chrome and the Firefox nightly (which have web RTC) as well Safari and Firefox stable (which do not have web RTC)
