### PR TITLE
Set ASCII-only option in Uglify - fixes #899

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -50,6 +50,9 @@ module.exports = function( grunt ) {
         banner: '<%= banner.compact %>',
         mangle: {
           except: ['Modernizr']
+        },
+        beautify: {
+          ascii_only: true
         }
       },
       dist: {


### PR DESCRIPTION
Because otherwise the emoji test breaks (see #899)

Increases the minified build size by 8 bytes... no drama.
