### PR TITLE
detect whether or not ES5 Shim / Sham are needed

### DIFF
--- a/feature-detects/es5/array.js
+++ b/feature-detects/es5/array.js
@@ -3,16 +3,17 @@
   "name": "ES5 Array",
   "property": "es5array",
   "notes": [{
-    "name": "ES5 Shim documentation",
-    "href": "https://github.com/kriskowal/es5-shim"
-  }, {
     "name": "ECMAScript 5.1 Language Specification",
     "href": "http://www.ecma-international.org/ecma-262/5.1/"
   }],
- "async": false,
- "authors": ["Ron Waldon (@jokeyrhyme)"],
- "knownBugs": [],
- "tags": []
+  "polyfills": [{
+    "name": "ES5 Shim",
+    "href": "https://github.com/kriskowal/es5-shim"
+  }],
+  "async": false,
+  "authors": ["Ron Waldon (@jokeyrhyme)"],
+  "knownBugs": [],
+  "tags": []
 }
 !*/
 /* DOC

--- a/feature-detects/es5/date.js
+++ b/feature-detects/es5/date.js
@@ -3,16 +3,17 @@
   "name": "ES5 Date",
   "property": "es5date",
   "notes": [{
-    "name": "ES5 Shim documentation",
-    "href": "https://github.com/kriskowal/es5-shim"
-  }, {
     "name": "ECMAScript 5.1 Language Specification",
     "href": "http://www.ecma-international.org/ecma-262/5.1/"
   }],
- "async": false,
- "authors": ["Ron Waldon (@jokeyrhyme)"],
- "knownBugs": [],
- "tags": []
+  "polyfills": [{
+    "name": "ES5 Shim",
+    "href": "https://github.com/kriskowal/es5-shim"
+  }],
+  "async": false,
+  "authors": ["Ron Waldon (@jokeyrhyme)"],
+  "knownBugs": [],
+  "tags": []
 }
 !*/
 /* DOC

--- a/feature-detects/es5/function.js
+++ b/feature-detects/es5/function.js
@@ -3,16 +3,17 @@
   "name": "ES5 Function",
   "property": "es5function",
   "notes": [{
-    "name": "ES5 Shim documentation",
-    "href": "https://github.com/kriskowal/es5-shim"
-  }, {
     "name": "ECMAScript 5.1 Language Specification",
     "href": "http://www.ecma-international.org/ecma-262/5.1/"
   }],
- "async": false,
- "authors": ["Ron Waldon (@jokeyrhyme)"],
- "knownBugs": [],
- "tags": []
+  "polyfills": [{
+    "name": "ES5 Shim",
+    "href": "https://github.com/kriskowal/es5-shim"
+  }],
+  "async": false,
+  "authors": ["Ron Waldon (@jokeyrhyme)"],
+  "knownBugs": [],
+  "tags": []
 }
 !*/
 /* DOC

--- a/feature-detects/es5/object.js
+++ b/feature-detects/es5/object.js
@@ -3,16 +3,20 @@
   "name": "ES5 Object",
   "property": "es5object",
   "notes": [{
-    "name": "ES5 Shim documentation",
-    "href": "https://github.com/kriskowal/es5-shim"
-  }, {
     "name": "ECMAScript 5.1 Language Specification",
     "href": "http://www.ecma-international.org/ecma-262/5.1/"
   }],
- "async": false,
- "authors": ["Ron Waldon (@jokeyrhyme)"],
- "knownBugs": [],
- "tags": []
+  "polyfills": [{
+    "name": "ES5 Shim: only provides Object.keys()",
+    "href": "https://github.com/kriskowal/es5-shim"
+  }, {
+    "name": "ES5 Sham: adds the rest of Object, read carefully before using",
+    "href": "https://github.com/kriskowal/es5-shim"
+  }],
+  "async": false,
+  "authors": ["Ron Waldon (@jokeyrhyme)"],
+  "knownBugs": [],
+  "tags": []
 }
 !*/
 /* DOC

--- a/feature-detects/es5/string.js
+++ b/feature-detects/es5/string.js
@@ -3,16 +3,17 @@
   "name": "ES5 String",
   "property": "es5string",
   "notes": [{
-    "name": "ES5 Shim documentation",
-    "href": "https://github.com/kriskowal/es5-shim"
-  }, {
     "name": "ECMAScript 5.1 Language Specification",
     "href": "http://www.ecma-international.org/ecma-262/5.1/"
   }],
- "async": false,
- "authors": ["Ron Waldon (@jokeyrhyme)"],
- "knownBugs": [],
- "tags": []
+  "polyfills": [{
+    "name": "ES5 Shim",
+    "href": "https://github.com/kriskowal/es5-shim"
+  }],
+  "async": false,
+  "authors": ["Ron Waldon (@jokeyrhyme)"],
+  "knownBugs": [],
+  "tags": []
 }
 !*/
 /* DOC


### PR DESCRIPTION
I personally find this test quite useful, so I thought I'd share this upstream.

These detects allow one to avoid loading in https://github.com/kriskowal/es5-shim when that would be unnecessary.

If this is beyond the scope of Modernizr, then I completely understand. Figured it was worth checking. :) <3
