### PR TITLE
Update WebSockets detection

### DIFF
--- a/feature-detects/websockets.js
+++ b/feature-detects/websockets.js
@@ -1,7 +1,14 @@
+/*!
+{
+  "name": "WebSockets Support",
+  "property": "websockets",
+  "authors": ["Phread [fearphage]", "Mike Sherov [mikesherov]", "Burak Yigit Kaya [BYK]"],
+  "caniuse": "websockets",
+  "warnings": "This test will reject any old version of WebSockets even if it is not prefixed such as in Safari 5.1",
+  "notes": "More info about the CLOSING state can be found at the spec: http://www.w3.org/TR/websockets/#the-websocket-interface",
+  "tags": ["html5"]
+}
+!*/
 define(['Modernizr'], function( Modernizr ) {
-  // FF3.6 was EOL'ed on 4/24/12, but the ESR version of FF10
-  // will be supported until FF19 (2/12/13), at which time, ESR becomes FF17.
-  // FF10 still uses prefixes, so check for it until then.
-  // for more ESR info, see: mozilla.org/en-US/firefox/organizations/faq/
-  Modernizr.addTest('websockets', 'WebSocket' in window || 'MozWebSocket' in window);
+  Modernizr.addTest('websockets', 'WebSocket' in window && window.WebSocket.CLOSING === 2);
 });


### PR DESCRIPTION
Update Websockets detection so that it rejects out of date implementations with or without prefixes such as in Safari 5.1
