### PR TITLE
Use margin instead of width to test for :change pseudo-selector

### DIFF
--- a/feature-detects/css/checked.js
+++ b/feature-detects/css/checked.js
@@ -12,12 +12,12 @@
 !*/
 define(['Modernizr', 'createElement', 'testStyles'], function( Modernizr, createElement, testStyles ) {
   Modernizr.addTest('checked', function(){
-   return testStyles('#modernizr input {margin-left:10px} #modernizr :checked {margin-left:20px;display:block}', function(elem, rule){
+   return testStyles('#modernizr {position:absolute} #modernizr input {margin-left:10px} #modernizr :checked {margin-left:20px;display:block}', function(elem, rule){
       var cb = createElement('input');
       cb.setAttribute("type", "checkbox");
       cb.setAttribute("checked", "checked");
       elem.appendChild(cb);
-      return cb.offsetLeft >= 20;
+      return cb.offsetLeft === 20;
     });
   });
 });


### PR DESCRIPTION
In Firefox it's not possible to adjust the width/height of the checkbox using css, hence the test would fail while support for :checked obviously exists. I suggest using `margin-left` and measuring `offsetLeft` instead, code attached.
