### PR TITLE
Fixed bug with setting a style property to a unknown value in IE8 and lower

### DIFF
--- a/src/testProps.js
+++ b/src/testProps.js
@@ -56,7 +56,10 @@ define(['contains', 'mStyle', 'createElement', 'nativeTestProps', 'is'], functio
 
         // If value to test has been passed in, do a set-and-check test
         if (!skipValueTest && !is(value, 'undefined')) {
-          mStyle.style[prop] = value;
+          // Needs a try catch block because of IE
+          try {
+            mStyle.style[prop] = value;
+          } catch (e) {}
 
           if (mStyle.style[prop] != before) {
             cleanElems();


### PR DESCRIPTION
IE8 and lower throws an error if you try to set a style property to an unknown or invalid value. Can be tested with these two lines:

``` javascript
var element = document.createElement('div');
element.style.backgroundRepeat = 'round';
```
