### PR TITLE
Updated flexbox tests to better capture all 3 specs; fixes #812

### DIFF
--- a/feature-detects/css/flexbox.js
+++ b/feature-detects/css/flexbox.js
@@ -11,5 +11,5 @@
 }
 !*/
 define(['Modernizr', 'testAllProps'], function( Modernizr, testAllProps ) {
-  Modernizr.addTest('flexbox', testAllProps('flexWrap'));
+  Modernizr.addTest('flexbox', testAllProps('flexBasis', '1px', true));
 });

--- a/feature-detects/css/flexboxlegacy.js
+++ b/feature-detects/css/flexboxlegacy.js
@@ -11,5 +11,5 @@
 }
 !*/
 define(['Modernizr', 'testAllProps'], function( Modernizr, testAllProps ) {
-  Modernizr.addTest('flexboxlegacy', testAllProps('boxDirection'));
+  Modernizr.addTest('flexboxlegacy', testAllProps('boxDirection', 'reverse', true));
 });

--- a/feature-detects/css/flexboxtweener.js
+++ b/feature-detects/css/flexboxtweener.js
@@ -1,0 +1,15 @@
+/*!
+{
+  "name": "Flexbox (tweener)",
+  "property": "flexboxtweener",
+  "tags": ["css"],
+  "polyfills": ["flexie"],
+  "notes": [{
+    "name": "The _inbetween_ flexbox",
+    "href": "http://www.w3.org/TR/2011/WD-css3-flexbox-20111129/"
+  }]
+}
+!*/
+define(['Modernizr', 'testAllProps'], function( Modernizr, testAllProps ) {
+  Modernizr.addTest('flexboxtweener', testAllProps('flexAlign', 'end', true));
+});

--- a/lib/config-all.json
+++ b/lib/config-all.json
@@ -44,6 +44,7 @@
     "test/css/filters",
     "test/css/flexbox",
     "test/css/flexboxlegacy",
+    "test/css/flexboxtweener",
     "test/css/fontface",
     "test/css/generatedcontent",
     "test/css/gradients",


### PR DESCRIPTION
Fixes #812.

Now have 3 flexbox tests:

``` javascript
Modernizr.addTest('flexbox', testAllProps('flexBasis'));
```

``` javascript
Modernizr.addTest('flexboxlegacy', testAllProps('boxDirection'));
```

``` javascript
Modernizr.addTest('flexboxtweener', testAllProps('flexAlign'));
```

Uses new `testAllProps()` syntax so should probably wait until #933 is merged in.
