### PR TITLE
fix for #520 - check for chrome frame in download test

### DIFF
--- a/feature-detects/a/download.js
+++ b/feature-detects/a/download.js
@@ -16,5 +16,5 @@ When used on an `<a>`, this attribute signifies that the resource it points to s
 
 */
 define(['Modernizr', 'createElement'], function( Modernizr, createElement ) {
-  Modernizr.addTest('adownload', 'download' in createElement('a'));
+  Modernizr.addTest('adownload', !window.externalHost && 'download' in createElement('a'));
 });


### PR DESCRIPTION
Chrome frame doesn't really support the download attribute

[forum post](https://groups.google.com/group/google-chrome-frame/tree/browse_frm/month/2012-11/3230a83b0f4826ca?rnum=51&_done=/group/google-chrome-frame/browse_frm/month/2012-11?fwc%3D1%26&pli=1)
[bug report](https://code.google.com/p/chromium/issues/detail?id=163266)

This adds a sniff (on [window.externalHost](http://www.chromium.org/developers/how-tos/chrome-frame-getting-started/understanding-chrome-frame-user-agent)), and fails if it is found.
