### PR TITLE
Removed `touch` alias for `Modernizr.touchevents`

### DIFF
--- a/feature-detects/touchevents.js
+++ b/feature-detects/touchevents.js
@@ -42,7 +42,5 @@ define(['Modernizr', 'prefixes', 'testStyles'], function( Modernizr, prefixes, t
       });
     }
     return bool;
-  }, {
-    aliases : ['touch']
   });
 });


### PR DESCRIPTION
Ref #548, implementation in #800 and a plethora of other tickets

I see no good reason to leave `Modernizr.touch` as an alias. There's still too much confusion around, I think we should just kill it in v3.0.
