### PR TITLE
add opus detection - fixes #699

### DIFF
--- a/feature-detects/audio.js
+++ b/feature-detects/audio.js
@@ -33,6 +33,7 @@ define(['Modernizr', 'createElement'], function( Modernizr, createElement ) {
         bool      = new Boolean(bool);
         bool.ogg  = elem.canPlayType('audio/ogg; codecs="vorbis"').replace(/^no$/,'');
         bool.mp3  = elem.canPlayType('audio/mpeg;')               .replace(/^no$/,'');
+        bool.opus  = elem.canPlayType('audio/ogg; codecs="opus"') .replace(/^no$/,'');
 
         // Mimetypes accepted:
         //   developer.mozilla.org/En/Media_formats_supported_by_the_audio_and_video_elements


### PR DESCRIPTION
just adding opus to the list of checks. 

passes only in firefox and behind a flag in chrome, which lines up with the caniuse data.
