### PR TITLE
Add input[directory] test

### DIFF
--- a/feature-detects/forms/fileinputdirectory.js
+++ b/feature-detects/forms/fileinputdirectory.js
@@ -1,0 +1,31 @@
+/*!
+{
+  "name": "input[directory] Attribute",
+  "property": "directory",
+  "authors": ["silverwind"],
+  "tags": ["file", "input", "attribute"]
+}
+!*/
+/* DOC
+
+When used on an `<input type="file">`, the `directory` attribute instructs
+the user agent to present a directory selection dialog instead of the usual
+file selection dialog.
+
+*/
+define(['Modernizr', 'createElement', 'domPrefixes'], function( Modernizr, createElement, domPrefixes ) {
+  Modernizr.addTest('fileinputdirectory', function() {
+    var elem = createElement('input'), dir = 'directory';
+    elem.type = 'file';
+    if (dir in elem) {
+      return true;
+    } else {
+      for (var i = 0, len = domPrefixes.length; i < len; i++) {
+        if (domPrefixes[i] + dir in elem) {
+          return true;
+        }
+      }
+    }
+    return false;
+  });
+});


### PR DESCRIPTION
Here's a v3 test, based on the recommendations in #675 (which hasn't seen activity in a while).

All attribute names except `webkitdirectory` and `directory` are guesses for now, as only Webkit implements this attribute (thought, Mozilla should [have an implementation soon](https://bugzilla.mozilla.org/show_bug.cgi?id=846931)).

Let me know if there's anything wrong with it.
