### PR TITLE
Update metadata regular expression parsing

### DIFF
--- a/lib/generate-meta.js
+++ b/lib/generate-meta.js
@@ -12,9 +12,9 @@ file.walkSync(viewRoot, function (start, dirs, files) {
     }
     var test = fs.readFileSync(start + '/' + file, 'utf8');
     // TODO :: make this regex not suck
-    var metaRE = /\/\*\!([^\!\*]*)\!\*\//m;
+    var metaRE = /\/\*\!([\s\S]*)\!\*\//m;
     var matches = test.match(metaRE);
-    var docRE = /\/\*\sDOC([^\!\*]*)\*\//m;
+    var docRE = /\/\*\sDOC([\s\S]*)\*\//m;
     var docmatches = test.match(docRE);
     var depRE = /define\((\[[^\]]*\]),/;
     var depMatches = test.match(depRE);


### PR DESCRIPTION
Updates the regular expressions in `lib/generate-meta.js` to "match everything until", instead of "match everything except". This resolves issues with using asterisks inside metadata.

@StuCox I noticed you worked around the issue in 9dad6bb4, but I believe the issue also affects the documentation meta. This might be a better solution.
