### PR TITLE
polyfill HTML5-History-API falls at initialization in IE6+

### DIFF
--- a/feature-detects/history.js
+++ b/feature-detects/history.js
@@ -37,6 +37,6 @@ define(['Modernizr'], function( Modernizr ) {
     }
 
     // Return the regular check
-    return (window.history && 'pushState' in history);
+    return (window.history && 'pushState' in window.history);
   });
 });


### PR DESCRIPTION
polyfill [HTML5-History-API](https://github.com/devote/HTML5-History-API) creates a new `history` object by means of VBScript, and if there was an appeal to the property `history` as global variable omitting the `window.` Library [HTML5-History-API](https://github.com/devote/HTML5-History-API) initialization fails.
