### PR TITLE
Add better async test support. Fixes #969.

### DIFF
--- a/feature-detects/canvas/todataurl.js
+++ b/feature-detects/canvas/todataurl.js
@@ -3,7 +3,6 @@
   "name": "canvas.toDataURL type support",
   "property": ["todataurljpeg", "todataurlpng", "todataurlwebp"],
   "tags": ["canvas"],
-  "async" : false,
   "notes": [{
     "name": "HTML5 Spec",
     "href": "http://www.w3.org/TR/html5/the-canvas-element.html#dom-canvas-todataurl"

--- a/feature-detects/css/hyphens.js
+++ b/feature-detects/css/hyphens.js
@@ -5,6 +5,7 @@
   "property": ["csshyphens", "softhyphens", "softhyphensfind"],
   "tags": ["css"],
   "authors": ["David Newton"],
+  "async", true,
   "warnings": [
     "These tests currently require document.body to be present",
     "If loading Hyphenator.js via Modernizr.load, be cautious of issue 158: http://code.google.com/p/hyphenator/issues/detail?id=158",
@@ -34,8 +35,11 @@
 }
 !*/
 define(['Modernizr', 'prefixes', 'createElement', 'testAllProps', 'addTest'], function( Modernizr, prefixes, createElement, testAllProps, addTest ) {
-
-  Modernizr.addAsyncTest(function() {
+  // This test is weird and tests three separate things, none of which are named 'hyphens'
+  // - As a supported hack, since they have shared helper functions, we've added two of the
+  // tests as 'aliases' even though they aren't aliases. Those are sent in as options in the
+  // third argument to addAsyncTest.
+  Modernizr.addAsyncTest('csshyphens', function() {
     var waitTime = 300;
     setTimeout(runHyphenTest, waitTime);
     // Wait 1000ms so we can hope for document.body
@@ -191,7 +195,7 @@ define(['Modernizr', 'prefixes', 'createElement', 'testAllProps', 'addTest'], fu
         }
       }
 
-      addTest("csshyphens", function() {
+      addTest('csshyphens', function() {
 
         if (!testAllProps('hyphens')) return false;
 
@@ -205,7 +209,7 @@ define(['Modernizr', 'prefixes', 'createElement', 'testAllProps', 'addTest'], fu
         }
       });
 
-      addTest("softhyphens", function() {
+      addTest('softhyphens', function() {
         try {
           // use numeric entity instead of &shy; in case it's XHTML
           return test_hyphens('&#173;', true) && test_hyphens('&#8203;', false);
@@ -214,7 +218,7 @@ define(['Modernizr', 'prefixes', 'createElement', 'testAllProps', 'addTest'], fu
         }
       });
 
-      addTest("softhyphensfind", function() {
+      addTest('softhyphensfind', function() {
         try {
           return test_hyphens_find('&#173;') && test_hyphens_find('&#8203;');
         } catch(e) {
@@ -223,5 +227,7 @@ define(['Modernizr', 'prefixes', 'createElement', 'testAllProps', 'addTest'], fu
       });
 
     }
+  }, {
+    aliases: ['softhyphens','softhyphensfind']
   });
 });

--- a/feature-detects/exif-orientation.js
+++ b/feature-detects/exif-orientation.js
@@ -26,7 +26,7 @@ define(['Modernizr', 'addTest'], function( Modernizr, addTest ) {
   //    bugzil.la/298619 (unimplemented)
   //    crbug.com/56845 (looks incomplete)
   //    webk.it/19688 (available upstream but its up all ports to turn on individually)
-  Modernizr.addAsyncTest(function() {
+  Modernizr.addAsyncTest('exiforientation', function() {
     var img = new Image();
 
     img.onerror = function() {
@@ -39,5 +39,7 @@ define(['Modernizr', 'addTest'], function( Modernizr, addTest ) {
 
     // There may be a way to shrink this more, it's a 1x2 white jpg with the orientation flag set to 6
     img.src = "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQEAYABgAAD/4QAiRXhpZgAASUkqAAgAAAABABIBAwABAAAABgASAAAAAAD/2wBDAAEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQH/2wBDAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQH/wAARCAABAAIDASIAAhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEAAwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSExBhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD+/iiiigD/2Q==";
+  },{
+    aliases: ['exif-orientation']
   });
 });

--- a/feature-detects/img/apng.js
+++ b/feature-detects/img/apng.js
@@ -16,7 +16,7 @@ Test for animated png support.
 
 */
 define(['Modernizr', 'createElement', 'addTest', 'test/canvas'], function( Modernizr, createElement, addTest ) {
-  Modernizr.addAsyncTest(function () {
+  Modernizr.addAsyncTest('apng', function () {
     if (!Modernizr.canvas) {
       return false;
     }

--- a/feature-detects/img/webp-lossless.js
+++ b/feature-detects/img/webp-lossless.js
@@ -20,7 +20,7 @@ Tests for lossless webp support.
 
 */
 define(['Modernizr', 'addTest'], function( Modernizr, addTest ) {
-  Modernizr.addAsyncTest(function(){
+  Modernizr.addAsyncTest('webplossless', function(){
     var image = new Image();
 
     image.onerror = function() {
@@ -32,5 +32,7 @@ define(['Modernizr', 'addTest'], function( Modernizr, addTest ) {
     };
 
     image.src = 'data:image/webp;base64,UklGRhoAAABXRUJQVlA4TA0AAAAvAAAAEAcQERGIiP4HAA==';
+  },{
+    aliases: ['webp-lossless']
   });
 });

--- a/feature-detects/img/webp.js
+++ b/feature-detects/img/webp.js
@@ -17,7 +17,7 @@ Tests for webp support.
 
 */
 define(['Modernizr', 'addTest'], function( Modernizr, addTest ) {
-  Modernizr.addAsyncTest(function(){
+  Modernizr.addAsyncTest('webp', function(){
     var image = new Image();
 
     image.onerror = function() {

--- a/feature-detects/mathml.js
+++ b/feature-detects/mathml.js
@@ -3,6 +3,7 @@
   "name": "MathML",
   "property": "mathml",
   "caniuse": "mathml",
+  "async": true,
   "authors": ["Addy Osmani", "Davide P. Cervone", "David Carlisle"],
   "notes": [{
     "name": "W3C spec",
@@ -31,7 +32,7 @@ define(['Modernizr', 'createElement', 'addTest'], function( Modernizr, createEle
         setTimeout(runMathMLTest, waitTime);
         return;
       }
-      addTest(function () {
+      addTest('mathml', function () {
         var hasMathML = false;
         if ( document.createElementNS ) {
           var ns = "http://www.w3.org/1998/Math/MathML";

--- a/feature-detects/svg/asimg.js
+++ b/feature-detects/svg/asimg.js
@@ -15,7 +15,7 @@
 define(['Modernizr', 'addTest'], function( Modernizr, addTest ) {
   // Assumes data URI support, but according to caniuse every browser which
   // supports SVG in an <img> also supports data URIs
-  Modernizr.addAsyncTest(function () {
+  Modernizr.addAsyncTest('svgasimg', function() {
     var img = new Image();
 
     img.onerror = function () {

--- a/feature-detects/url/data-uri.js
+++ b/feature-detects/url/data-uri.js
@@ -24,7 +24,7 @@ Modernizr.datauri.over32kb  // false in IE8
 */
 define(['Modernizr', 'addTest'], function( Modernizr, addTest ) {
   // https://github.com/Modernizr/Modernizr/issues/14
-  Modernizr.addAsyncTest(function() {
+  Modernizr.addAsyncTest('datauri', function() {
 
     // IE7 throw a mixed content warning on HTTPS for this test, so we'll
     // just blacklist it (we know it doesn't support data URIs anyway)
@@ -50,11 +50,11 @@ define(['Modernizr', 'addTest'], function( Modernizr, addTest ) {
       }
     };
 
-    datauri.src = "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==";
+    datauri.src = 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==';
 
     // Once we have datauri, let's check to see if we can use data URIs over
     // 32kb (IE8 can't). https://github.com/Modernizr/Modernizr/issues/321
-    function testOver32kb(){
+    function testOver32kb() {
 
       var datauriBig = new Image();
 
@@ -69,11 +69,11 @@ define(['Modernizr', 'addTest'], function( Modernizr, addTest ) {
           Modernizr.datauri.over32kb = (datauriBig.width == 1 && datauriBig.height == 1);
       };
 
-      var base64str = "R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==";
+      var base64str = 'R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==';
       while (base64str.length < 33000) {
-        base64str = "\r\n" + base64str;
+        base64str = '\r\n' + base64str;
       }
-      datauriBig.src= "data:image/gif;base64," + base64str;
+      datauriBig.src= 'data:image/gif;base64,' + base64str;
     }
 
   });

--- a/feature-detects/video/autoplay.js
+++ b/feature-detects/video/autoplay.js
@@ -3,7 +3,7 @@
   "name": "Video Autoplay",
   "property": "videoautoplay",
   "tags": ["video"],
-  "async" : false,
+  "async" : true,
   "warnings": ["This test is very large – only include it if you absolutely need it"],
   "notes": [{
     "name" : "Article: 'Dispelling the Android CSS animation myths'",
@@ -18,7 +18,7 @@ Checks for support of the autoplay attribute of the video element.
 */
 define(['Modernizr', 'addTest', 'docElement', 'createElement', 'test/video'], function( Modernizr, addTest, docElement, createElement ) {
 
-  Modernizr.addAsyncTest(function() {
+  Modernizr.addAsyncTest('videoautoplay', function() {
     var timeout;
     var waitTime = 300;
     var elem = document.createElement('video');

--- a/feature-detects/webgl/extensions.js
+++ b/feature-detects/webgl/extensions.js
@@ -19,8 +19,6 @@
 
 Detects support for OpenGL extensions in WebGL. It's `true` if the [WebGL extensions API](https://developer.mozilla.org/en-US/docs/Web/WebGL/Using_Extensions) is supported, then exposes the supported extensions as subproperties, e.g.:
 
-Currently, this is an async test, but it
-
 ```javascript
 if (Modernizr.webglextensions) {
   // WebGL extensions API supported

--- a/feature-detects/webgl/extensions.js
+++ b/feature-detects/webgl/extensions.js
@@ -4,7 +4,11 @@
   "property": "webglextensions",
   "tags": ["webgl", "graphics"],
   "authors": ["Ilmari Heikkinen"],
-  "knownBugs": [],
+  "knownBugs": [
+    "This async test does not fire a callback",
+    "This test does not add classes to the html element"
+  ],
+  "async": true,
   "notes": [{
     "name": "Kronos extensions registry",
     "href": "http://www.khronos.org/registry/webgl/extensions/"
@@ -14,6 +18,8 @@
 /* DOC
 
 Detects support for OpenGL extensions in WebGL. It's `true` if the [WebGL extensions API](https://developer.mozilla.org/en-US/docs/Web/WebGL/Using_Extensions) is supported, then exposes the supported extensions as subproperties, e.g.:
+
+Currently, this is an async test, but it
 
 ```javascript
 if (Modernizr.webglextensions) {
@@ -30,7 +36,7 @@ define(['Modernizr', 'createElement', 'test/webgl'], function( Modernizr, create
   // code.google.com/p/graphics-detect/source/browse/js/detect.js
 
   // Not Async but handles it's own self
-  Modernizr.addAsyncTest(function() {
+  Modernizr.addAsyncTest('webglextensions', function() {
 
     // Not a good candidate for css classes, so we avoid addTest stuff
     Modernizr.webglextensions = new Boolean(false);

--- a/feature-detects/workers/blobworkers.js
+++ b/feature-detects/workers/blobworkers.js
@@ -19,7 +19,7 @@ Detects support for creating Web Workers from Blob URIs.
 
 */
 define(['Modernizr', 'addTest'], function( Modernizr, addTest ) {
-  Modernizr.addAsyncTest(function() {
+  Modernizr.addAsyncTest('blobworkers', function() {
     try {
       // we're avoiding using Modernizr._domPrefixes as the prefix capitalization on
       // these guys are notoriously peculiar.

--- a/feature-detects/workers/dataworkers.js
+++ b/feature-detects/workers/dataworkers.js
@@ -19,7 +19,7 @@ Detects support for creating Web Workers from Data URIs.
 
 */
 define(['Modernizr', 'addTest'], function( Modernizr, addTest ) {
-  Modernizr.addAsyncTest(function() {
+  Modernizr.addAsyncTest('dataworkers', function() {
     try {
       var data    = 'Modernizr',
       worker  = new Worker('data:text/javascript;base64,dGhpcy5vbm1lc3NhZ2U9ZnVuY3Rpb24oZSl7cG9zdE1lc3NhZ2UoZS5kYXRhKX0=');

--- a/src/ModernizrProto.js
+++ b/src/ModernizrProto.js
@@ -31,8 +31,10 @@ define(['tests'], function ( tests ) {
       tests.push({name : name, fn : fn, options : options });
     },
 
-    addAsyncTest: function (fn) {
-      tests.push({name : null, fn : fn});
+    addAsyncTest: function (name, fn, options) {
+      options = options || {};
+      options.async = true;
+      tests.push({name : name, fn : fn, options: options});
     }
   };
 

--- a/src/addTest.js
+++ b/src/addTest.js
@@ -56,7 +56,7 @@ define(['ModernizrProto', 'Modernizr', 'hasOwnProp', 'setClasses'], function( Mo
    * @param feature - String naming the feature
    * @param test - Function returning true if feature is supported, false if not
    */
-  function addTest( feature, test ) {
+  function addTest( feature, test, options ) {
     if ( typeof feature == 'object' ) {
       for ( var key in feature ) {
         if ( hasOwnProp( feature, key ) ) {
@@ -80,9 +80,22 @@ define(['ModernizrProto', 'Modernizr', 'hasOwnProp', 'setClasses'], function( Mo
 
       // Set the value (this is the magic, right here).
       Modernizr[feature] = test;
+      var prefix = test ? '' : 'no-';
+      var classes = [];
 
       // Set a single class (either `feature` or `no-feature`)
-      setClasses([(test ? '' : 'no-') + feature]);
+      classes.push(prefix + feature);
+
+      // Add in aliased names
+      if (options && options.aliases) {
+        for(var i = 0; i < options.aliases.length; i++) {
+          Modernizr[options.aliases[i]] = test;
+          classes.push(prefix + options.aliases[i]);
+        }
+      }
+
+      // Set all added classes at once
+      setClasses(classes);
 
       // Trigger the event
       Modernizr._trigger(feature, test);

--- a/src/testRunner.js
+++ b/src/testRunner.js
@@ -12,28 +12,28 @@ define(['tests', 'Modernizr', 'classes', 'is'], function( tests, Modernizr, clas
       // run the test, throw the return value into the Modernizr,
       //   then based on that boolean, define an appropriate className
       //   and push it into an array of classes we'll join later.
-      //
-      //   If there is no name, it's an 'async' test that is run,
-      //   but not directly added to the object. That should
-      //   be done with a post-run addTest call.
-      if ( feature.name ) {
-        featureNames.push(feature.name.toLowerCase());
+      featureNames.push(feature.name.toLowerCase());
 
-        if (feature.options && feature.options.aliases && feature.options.aliases.length) {
-          // Add all the aliases into the names list
-          for (aliasIdx = 0; aliasIdx < feature.options.aliases.length; aliasIdx++) {
-            featureNames.push(feature.options.aliases[aliasIdx].toLowerCase());
-          }
+      if (feature.options && feature.options.aliases && feature.options.aliases.length) {
+        // Add all the aliases into the names list
+        for (aliasIdx = 0; aliasIdx < feature.options.aliases.length; aliasIdx++) {
+          featureNames.push(feature.options.aliases[aliasIdx].toLowerCase());
         }
       }
 
+      // Async tests are set to undefined at first, defined later: Issue #969
       // Run the test, or use the raw value if it's not a function
-      result = is(feature.fn, 'function') ? feature.fn() : feature.fn;
+      result = feature.async ? undefined : (is(feature.fn, 'function') ? feature.fn() : feature.fn);
 
       // Set each of the names on the Modernizr object
       for (nameIdx = 0; nameIdx < featureNames.length; nameIdx++) {
         Modernizr[featureNames[nameIdx]] = result;
-        classes.push((Modernizr[featureNames[nameIdx]] ? '' : 'no-') + featureNames[nameIdx]);
+
+        // Don't add classes when async
+        // We've considered some initial state class, but so far haven't loved any solutions
+        if (!feature.async) {
+          classes.push((Modernizr[featureNames[nameIdx]] ? '' : 'no-') + featureNames[nameIdx]);
+        }
       }
     }
   }

--- a/test/js/unit.js
+++ b/test/js/unit.js
@@ -232,7 +232,7 @@ test('Modernizr.audio and Modernizr.video',function(){
   for (var i = -1, len = TEST.audvid.length; ++i < len;){
     var prop = TEST.audvid[i];
 
-    if (Modernizr[prop].toString() == 'true'){
+    if (Modernizr[prop] && Modernizr[prop].toString() == 'true'){
 
       ok(Modernizr[prop], 'Modernizr.'+prop+' is truthy.');
       /* jshint -W041 */


### PR DESCRIPTION
This probably needs a decent read-through @stucox -- but I think it's what you want. I haven't quite been bothered to rewrite the tests that this fails. They are generally expecting false values for async tests, and now getting explicit `undefined`s. But as far as I can tell, that's desired functionality now. Went through and converted all async tests to the new format.
