### PR TITLE
whitespace/tab fixes - fixes 728

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -91,6 +91,7 @@ module.exports = function( grunt ) {
         noarg: true,
         smarttabs: true,
         sub: true,
+        trailing: true,
         undef: true,
         globals: {
           Modernizr: true,
@@ -105,7 +106,7 @@ module.exports = function( grunt ) {
       files: [
         'Gruntfile.js',
         'src/*.js',
-        'feature-detects/*.js'
+        'feature-detects/**/*.js'
       ],
       tests: {
         options: {

--- a/feature-detects/audio/loop.js
+++ b/feature-detects/audio/loop.js
@@ -7,4 +7,4 @@
 !*/
 define(['Modernizr', 'createElement'], function( Modernizr, createElement ) {
     Modernizr.addTest('audioloop', 'loop' in createElement('audio'));
-}); 
+});

--- a/feature-detects/audio/preload.js
+++ b/feature-detects/audio/preload.js
@@ -7,4 +7,4 @@
 !*/
 define(['Modernizr', 'createElement'], function( Modernizr, createElement ) {
     Modernizr.addTest('audiopreload', 'preload' in createElement('audio'));
-}); 
+});

--- a/feature-detects/url/data-uri.js
+++ b/feature-detects/url/data-uri.js
@@ -25,6 +25,7 @@ Modernizr.datauri.over32kb  // false in IE8
 define(['Modernizr', 'addTest'], function( Modernizr, addTest ) {
   // https://github.com/Modernizr/Modernizr/issues/14
   Modernizr.addAsyncTest(function() {
+    /* jshint -W053 */
 
     // IE7 throw a mixed content warning on HTTPS for this test, so we'll
     // just blacklist it (we know it doesn't support data URIs anyway)

--- a/feature-detects/video/loop.js
+++ b/feature-detects/video/loop.js
@@ -7,4 +7,4 @@
 !*/
 define(['Modernizr', 'createElement'], function( Modernizr, createElement ) {
     Modernizr.addTest('videoloop', 'loop' in createElement('video'));
-}); 
+});

--- a/feature-detects/video/preload.js
+++ b/feature-detects/video/preload.js
@@ -7,4 +7,4 @@
 !*/
 define(['Modernizr', 'createElement'], function( Modernizr, createElement ) {
     Modernizr.addTest('videopreload', 'preload' in createElement('video'));
-}); 
+});

--- a/feature-detects/webgl/extensions.js
+++ b/feature-detects/webgl/extensions.js
@@ -31,6 +31,7 @@ define(['Modernizr', 'createElement', 'test/webgl'], function( Modernizr, create
 
   // Not Async but handles it's own self
   Modernizr.addAsyncTest(function() {
+    /* jshint -W053 */
 
     // Not a good candidate for css classes, so we avoid addTest stuff
     Modernizr.webglextensions = new Boolean(false);

--- a/src/load.js
+++ b/src/load.js
@@ -210,7 +210,7 @@ var docElement            = doc.documentElement,
         if ( first ) {
           if ( elem != "img" ) {
             sTimeout( function () {
-                insBeforeObj.removeChild( preloadElem ); 
+                insBeforeObj.removeChild( preloadElem );
               }, 50);
           }
 
@@ -495,7 +495,7 @@ var docElement            = doc.documentElement,
         // the always stuff always loads second.
         always && handleGroup( always );
 
-	// If complete callback is used without loading anything
+  // If complete callback is used without loading anything
         !always && !!testObject['complete'] && handleGroup('');
 
     }


### PR DESCRIPTION
This fixes the reported issue in 728.
The good news is the amount of mixed tabs and trailing whitespace is much
smaller than it was at the time the initial report. The only outstanding
files are from caniuse, and node_modules.
