### PR TITLE
improve custom-protocol-handler.js

### DIFF
--- a/feature-detects/custom-protocol-handler.js
+++ b/feature-detects/custom-protocol-handler.js
@@ -16,9 +16,25 @@
 !*/
 /* DOC
 
-Detects support for the `window.registerProtocolHandler()` API to allow web sites to register themselves as possible handlers for particular protocols.
+Detects support for the `window.registerProtocolHandler()` API to allow web
+sites to register themselves as possible handlers for particular protocols.
 
 */
 define(['Modernizr'], function( Modernizr ) {
-  Modernizr.addTest('customprotocolhandler', !!navigator.registerProtocolHandler);
+  Modernizr.addTest('customprotocolhandler', function() {
+    // early bailout where it doesn't exist at all
+    if ( !navigator.registerProtocolHandler ) return false;
+
+    // registerProtocolHandler was stubbed in webkit for a while, and didn't
+    // actually do anything. We intentionally set it improperly to test for
+    // the proper sort of failure
+    try {
+      navigator.registerProtocolHandler('thisShouldFail');
+    }
+    catch (e) {
+      return e instanceof TypeError;
+    }
+
+    return false;
+  });
 });


### PR DESCRIPTION
As documented in [the Undetectables](https://github.com/Modernizr/Modernizr/wiki/Undetectables)
navigator.registerProtocolHandler was stubbed in webkit for a while, and doesn't actually do anything there.
This test forces a failure and ensures it's the right type of failure.

Android 2.\* showed this behavior previously, and this test fixes that false positive.
