### PR TITLE
add drag and drop files test - fixes #57

### DIFF
--- a/feature-detects/draganddropfiles.js
+++ b/feature-detects/draganddropfiles.js
@@ -1,0 +1,20 @@
+/*!
+{
+  "name": "Drag & Drop",
+  "property": "draganddropfiles",
+  "notes": [{
+    "name": "W3C spec",
+    "href": "http://www.w3.org/TR/2010/WD-html5-20101019/dnd.html"
+  }]
+}
+!*/
+/* DOC
+
+Detects support for native drag & drop file upload.
+
+*/
+define(['Modernizr', 'test/draganddrop'], function( Modernizr ) {
+  Modernizr.addTest('draganddropfiles', function() {
+   return (Modernizr.draganddrop && 'FileList' in window);
+  });
+});

--- a/lib/config-all.json
+++ b/lib/config-all.json
@@ -88,6 +88,7 @@
     "test/dom/dataset",
     "test/dom/microdata",
     "test/draganddrop",
+    "test/draganddropfiles",
     "test/elem/datalist",
     "test/elem/details",
     "test/elem/output",


### PR DESCRIPTION
just trying to relieve some of the work @stucox has to do for 3.0 release. 

see #57 for actual information.

I did confirm in local Safari 4 and a local Safari 5 that image upload works in both, and both pass this test.
