### PR TITLE
improve contenteditable test

### DIFF
--- a/feature-detects/contenteditable.js
+++ b/feature-detects/contenteditable.js
@@ -14,8 +14,15 @@
 Detects support for the `contenteditable` attribute of elements, allowing their DOM text contents to be edited directly by the user.
 
 */
-define(['Modernizr', 'createElement'], function( Modernizr, createElement ) {
+define(['Modernizr', 'createElement', 'docElement'], function( Modernizr, createElement, docElement ) {
   Modernizr.addTest('contenteditable', function() {
+    // early bail out
+    if (!('contentEditable' in docElement)) return;
+
+    // some mobile browsers (android < 3.0, iOS < 5) claim to support
+    // contentEditable, but but don't really. This test checks to see
+    // confirms wether or not it actually supports it.
+
     var div = createElement('div');
     div.contentEditable = true;
     return div.contentEditable === "true";


### PR DESCRIPTION
I was annoyed that I couldn't get contenteditable checks on mobile
without UA sniffing,

So, it turns out, this is true - http://goo.gl/RJh7r (check it out on
ios <= 4, or android <= 2.3);

this is about an order of maginude  slower than a basic contentElement
in docElement, but it works in all mobile browsers correctly. =D
