### PR TITLE
Fix touch detection for QtWebKit

### DIFF
--- a/feature-detects/touchevents.js
+++ b/feature-detects/touchevents.js
@@ -39,7 +39,7 @@ define(['Modernizr', 'prefixes', 'testStyles'], function( Modernizr, prefixes, t
   // Chrome (desktop) used to lie about its support on this, but that has since been rectified: http://crbug.com/36415
   Modernizr.addTest('touchevents', function() {
     var bool;
-    if(('ontouchstart' in window) || window.DocumentTouch && document instanceof DocumentTouch) {
+    if(('ontouchstart' in window && window.ontouchstart != null) || window.DocumentTouch && document instanceof DocumentTouch) {
       bool = true;
     } else {
       var query = ['@media (',prefixes.join('touch-enabled),('),'heartz',')','{#modernizr{top:9px;position:absolute}}'].join('');


### PR DESCRIPTION
See similar changes made to https://github.com/johndyer/mediaelement/pull/939 and other open source JS projects.

According to the discussion in the linked PR, QtWebKit's behavior here is in line with the specification and not a bug.

Doing some other tests:
-Chrome 28 on a Windows Surface has window.ontouchstart == null
-Firefox 20 on a Windows Surface has window.ontouchstart == null
-IE 10 on a Windows Surface doesn't define window.ontouchstart
