### PR TITLE
Add 'transform-style: preserve-3d' test - fixes #762

### DIFF
--- a/feature-detects/css/transformstylepreserve3d.js
+++ b/feature-detects/css/transformstylepreserve3d.js
@@ -1,0 +1,23 @@
+/*!
+{
+  "name": "CSS Transform Style preserve-3d",
+  "property": "preserve3d",
+  "authors": ["edmellum"],
+  "tags": ["css"],
+  "notes": [{
+    "name": "MDN Docs",
+    "href": "https://developer.mozilla.org/en-US/docs/Web/CSS/transform-style"
+  },{
+    "name": "Related Github Issue",
+    "href": "https://github.com/Modernizr/Modernizr/issues/762"
+  }]
+}
+!*/
+/* DOC
+
+Detects support for `transform-style: preserve-3d`, for getting a proper 3D perspective on elements.
+
+*/
+define(['Modernizr', 'testAllProps'], function( Modernizr, testAllProps ) {
+  Modernizr.addTest('preserve3d', testAllProps('transformStyle', 'preserve-3d'));
+});

--- a/lib/config-all.json
+++ b/lib/config-all.json
@@ -74,6 +74,7 @@
     "test/css/supports",
     "test/css/textshadow",
     "test/css/transforms",
+    "test/css/transformstylepreserve3d",
     "test/css/transforms3d",
     "test/css/transitions",
     "test/css/userselect",


### PR DESCRIPTION
IE10 doesn't support `transform-style: preserve-3d` but does support 3D transforms. More info at #762.
