### PR TITLE
Fixing a scoping issue with multiple `Modernizr.on()` callbacks for a single test

### DIFF
--- a/src/addTest.js
+++ b/src/addTest.js
@@ -35,14 +35,14 @@ define(['ModernizrProto', 'Modernizr', 'hasOwnProp', 'setClasses'], function( Mo
     var cb;
     var i;
 
-    /* jshint -W083 */
-    for (i = 0; i < cbs.length; i++) {
-      cb = cbs[i];
-      // Force async
-      setTimeout(function() {
+    // Force async
+    setTimeout(function() {
+      var i, cb;
+      for (i = 0; i < cbs.length; i++) {
+        cb = cbs[i];
         cb(res);
-      },0);
-    }
+      }
+    },0);
 
     // Don't trigger these again
     delete this._l[test];


### PR DESCRIPTION
There's a scoping issue in `src/addTest.js`:

If there are multiple callbacks for a test, the value of `cb` in this scope will be changed to the 2nd (then 3rd, then 4th etc) callback before the deferred function is executed even once – so the last callback gets executed multiple times, rather than each callback being called.

This PR fixes this.

+@SlexAxton
