### PR TITLE
Added test for transparent Webp images

### DIFF
--- a/feature-detects/img/webp-alpha.js
+++ b/feature-detects/img/webp-alpha.js
@@ -1,0 +1,40 @@
+/*!
+{
+  "name": "Webp Alpha",
+  "async": true,
+  "property": "webpalpha",
+  "aliases": ["webp-alpha"],
+  "tags": ["image"],
+  "authors": ["Krister Kari", "Rich Bradshaw", "Ryan Seddon", "Paul Irish"],
+  "notes": [{
+    "name": "WebP Info",
+    "href": "http://code.google.com/speed/webp/"
+  },{
+    "name": "Article about WebP support on Android browsers",
+    "href": "http://www.wope-framework.com/en/2013/06/24/webp-support-on-android-browsers/"
+  },{
+    "name": "Chormium WebP announcement",
+    "href": "http://blog.chromium.org/2011/11/lossless-and-transparency-encoding-in.html?m=1"
+  }]
+}
+!*/
+/* DOC
+
+Tests for transparent webp support.
+
+*/
+define(['Modernizr', 'addTest'], function( Modernizr, addTest ) {
+  Modernizr.addAsyncTest(function(){
+    var image = new Image();
+
+    image.onerror = function() {
+      addTest('webpalpha', false, { aliases: ['webp-alpha'] });
+    };
+
+    image.onload = function() {
+      addTest('webpalpha', image.width == 1, { aliases: ['webp-alpha'] });
+    };
+
+    image.src = 'data:image/webp;base64,UklGRkoAAABXRUJQVlA4WAoAAAAQAAAAAAAAAAAAQUxQSAwAAAABBxAR/Q9ERP8DAABWUDggGAAAADABAJ0BKgEAAQADADQlpAADcAD++/1QAA==';
+  });
+});

--- a/lib/config-all.json
+++ b/lib/config-all.json
@@ -121,6 +121,7 @@
     "test/iframe/srcdoc",
     "test/img/apng",
     "test/img/webp-lossless",
+    "test/img/webp-alpha",
     "test/img/webp",
     "test/indexedDB",
     "test/input",


### PR DESCRIPTION
Let me know if there is something to fix. The datauri could probably be even smaller. 

Related issue #1023
