### PR TITLE
Fixed path to test directory in README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -58,7 +58,7 @@ grunt qunit
 ```shell
 grunt build
 serve .
-visit <url>/tests
+visit <url>/test
 ```
 
 ### To see simple build in browser:


### PR DESCRIPTION
The path to the tests is actually _test_, not _tests_.
