### PR TITLE
add jpeg xr test

### DIFF
--- a/feature-detects/img/jpegxr.js
+++ b/feature-detects/img/jpegxr.js
@@ -1,0 +1,30 @@
+/*!
+{
+  "name": "JPEG XR (extended range)",
+  "async": true,
+  "aliases": ["jpeg-xr"],
+  "property": "jpegxr",
+  "tags": ["image"],
+  "notes": [{
+    "name": "Wikipedia Article",
+    "href": "http://en.wikipedia.org/wiki/JPEG_XR"
+  }]
+}
+!*/
+/* DOC
+
+Test for JPEG XR support
+
+*/
+define(['Modernizr', 'addTest'], function( Modernizr, addTest ) {
+
+  Modernizr.addAsyncTest(function() {
+    var image = new Image();
+
+    image.onload = image.onerror = function() {
+      addTest('jpegxr', image.width == 1, { aliases: ['jpeg-xr'] });
+    };
+
+    image.src = 'data:image/vnd.ms-photo;base64,SUm8AQgAAAAFAAG8AQAQAAAASgAAAIC8BAABAAAAAQAAAIG8BAABAAAAAQAAAMC8BAABAAAAWgAAAMG8BAABAAAAHwAAAAAAAAAkw91vA07+S7GFPXd2jckNV01QSE9UTwAZAYBxAAAAABP/gAAEb/8AAQAAAQAAAA==';
+  });
+});


### PR DESCRIPTION
just an update to #895. Rebased the current master to fix failing tests,
added metadata
