### PR TITLE
Detect touch events correctly in Qt's Webkit

### DIFF
--- a/feature-detects/touchevents.js
+++ b/feature-detects/touchevents.js
@@ -39,7 +39,7 @@ define(['Modernizr', 'prefixes', 'testStyles'], function( Modernizr, prefixes, t
   // Chrome (desktop) used to lie about its support on this, but that has since been rectified: http://crbug.com/36415
   Modernizr.addTest('touchevents', function() {
     var bool;
-    if(('ontouchstart' in window) || window.DocumentTouch && document instanceof DocumentTouch) {
+    if(('ontouchstart' in window && window.ontouchstart != null) || window.DocumentTouch && document instanceof DocumentTouch) {
       bool = true;
     } else {
       var query = ['@media (',prefixes.join('touch-enabled),('),'heartz',')','{#modernizr{top:9px;position:absolute}}'].join('');


### PR DESCRIPTION
Modernizer always detects that touch events are in use in QtWebKit. This change fixes that. For details see:
- https://bugs.webkit.org/show_bug.cgi?id=60879
- http://stackoverflow.com/questions/13347617/fancybox2-determines-qtwebkit-as-touch-device
