### PR TITLE
add ie10 support to form validation

### DIFF
--- a/feature-detects/forms/validation.js
+++ b/feature-detects/forms/validation.js
@@ -21,7 +21,10 @@ define(['Modernizr', 'createElement', 'docElement', 'testStyles'], function( Mod
       if ( !('checkValidity' in form) || !('addEventListener' in form) ) {
         return false;
       }
-      var invaildFired = false;
+      if ('reportValidity' in form) {
+        return true;
+      }
+      var invalidFired = false;
       var input;
 
       Modernizr.formvalidationapi =  true;
@@ -47,7 +50,7 @@ define(['Modernizr', 'createElement', 'docElement', 'testStyles'], function( Mod
 
         // Record whether "invalid" event is fired
         input.addEventListener('invalid', function(e) {
-          invaildFired = true;
+          invalidFired = true;
           e.preventDefault();
           e.stopPropagation();
         }, false);
@@ -59,6 +62,6 @@ define(['Modernizr', 'createElement', 'docElement', 'testStyles'], function( Mod
         form.getElementsByTagName('button')[0].click();
       });
 
-      return invaildFired;
+      return invalidFired;
     });
 });


### PR DESCRIPTION
fixes #1057 
fixes #957 as well

[This is how microsoft demos it](http://ie.microsoft.com/testdrive/HTML5/Forms/) (go to `New DOM Properties and Events`)

They are just adding an onclick handler to the submit button, that runs `checkValidity()` on each input element.

``` javascript
for (var i = 0; i < form.elements.length; i++) { 
  if (!form.elements[i].checkValidity()) {
    formValidity = false;
  }
}
```
