### PR TITLE
add unicode-range test

### DIFF
--- a/feature-detects/unicode-range.js
+++ b/feature-detects/unicode-range.js
@@ -1,0 +1,37 @@
+/*!
+{
+  "name": "Unicode Range",
+  "property": "unicoderange",
+  "notes": [{
+    "name" : "W3C reference",
+    "href": "http://www.w3.org/TR/2013/CR-css-fonts-3-20131003/#descdef-unicode-range"
+  }, {
+    "name" : "24 Way article",
+    "href": "http://24ways.org/2011/creating-custom-font-stacks-with-unicode-range"
+  }]
+}
+!*/
+define(['Modernizr', 'testStyles', 'createElement'], function (Modernizr, testStyles, createElement) {
+  Modernizr.addTest('unicoderange', function () {
+
+    return Modernizr.testStyles('@font-face{font-family:"unicodeRange";src:local("Arial");unicode-range:U+002E}#modernizr span{font-size:10px;display:inline-block;font-family:"unicodeRange",monospace}#modernizr .mono{font-family:monospace}', function (elem) {
+
+      // we use specify a unicode-range of 002E (the `.` glyph,
+      // and a monospace font as the fallback. If the first of
+      // these test glyphs is a different width than the other
+      // the other three (which are all monospace), then we 
+      // have a winner.
+      var testGlyphs = ['.', '.', 'm', 'm'];
+
+      for (var i = 0; i < testGlyphs.length; i++) {
+        var elm = createElement('span');
+        elm.innerHTML = testGlyphs[i];
+        elm.className = i % 2 ? 'mono' : '';
+        elem.appendChild(elm);
+        testGlyphs[i] = elm.clientWidth;
+      }
+
+      return (testGlyphs[0] !== testGlyphs[1] && testGlyphs[2] === testGlyphs[3]);
+    });
+  });
+});

--- a/lib/config-all.json
+++ b/lib/config-all.json
@@ -162,6 +162,7 @@
     "test/touchevents",
     "test/typed-arrays",
     "test/unicode",
+    "test/unicode-range",
     "test/url/data-uri",
     "test/userdata",
     "test/vibration",


### PR DESCRIPTION
fixes #1058

This test embeds a base64'd truetype font with two characters, the `<space>` and `m` specifically, specifying the unicode-range to only use the `<space>` (U+002E) . It then creates four elements, two of each, one with the font and without, adds them to the DOM, and check their width. If the space changes width, and the m doesn't, then we have a winner.
