### PR TITLE
convert webp lossless test to a non alpha image

### DIFF
--- a/feature-detects/img/webp-lossless.js
+++ b/feature-detects/img/webp-lossless.js
@@ -16,7 +16,7 @@
 !*/
 /* DOC
 
-Tests for lossless webp support.
+Tests for non-alpha lossless webp support.
 
 */
 define(['Modernizr', 'addTest'], function( Modernizr, addTest ) {
@@ -31,6 +31,6 @@ define(['Modernizr', 'addTest'], function( Modernizr, addTest ) {
       addTest('webplossless', image.width == 1, { aliases: ['webp-lossless'] });
     };
 
-    image.src = 'data:image/webp;base64,UklGRhoAAABXRUJQVlA4TA0AAAAvAAAAEAcQERGIiP4HAA==';
+    image.src = 'data:image/webp;base64,UklGRh4AAABXRUJQVlA4TBEAAAAvAAAAAAfQ//73v/+BiOh/AAA=';
   });
 });


### PR DESCRIPTION
thanks to @kristerkari for [pointing it out](https://github.com/Modernizr/Modernizr/issues/1023#issuecomment-22939414).

conveniently shaves a few bytes off, as well.

``` bash
  convert -size 1x1 canvas:white white.jpg
  cwebp -lossless -noalpha /private/tmp/white.jpg -o losslessNoAlpha.webp
```
