### PR TITLE
shrink webp detect by a few bytes

### DIFF
--- a/feature-detects/img/webp.js
+++ b/feature-detects/img/webp.js
@@ -13,7 +13,7 @@
 !*/
 /* DOC
 
-Tests for webp support.
+Tests for lossy, non-alpha webp support.
 
 */
 define(['Modernizr', 'addTest'], function( Modernizr, addTest ) {
@@ -28,6 +28,6 @@ define(['Modernizr', 'addTest'], function( Modernizr, addTest ) {
       addTest('webp', image.width == 1);
     };
 
-    image.src = 'data:image/webp;base64,UklGRiwAAABXRUJQVlA4ICAAAAAUAgCdASoBAAEAL/3+/3+CAB/AAAFzrNsAAP5QAAAAAA==';
+    image.src = 'data:image/webp;base64,UklGRiQAAABXRUJQVlA4IBgAAAAwAQCdASoBAAEAAwA0JaQAA3AA/vuUAAA=';
   });
 });


### PR DESCRIPTION
After checking into some stuff for #1064, I found I could shrink the test by a couple bytes.

``` bash
  convert -size 1x1 canvas:white white.jpg
  cwebp -noalpha /private/tmp/white.jpg -o losslessNoAlpha.webp
```
