### PR TITLE
add flash detect

### DIFF
--- a/feature-detects/flash.js
+++ b/feature-detects/flash.js
@@ -1,0 +1,82 @@
+/*!
+  {
+  "name": "Flash",
+  "property": "flash",
+  "tags": ["flash"],
+  "polyfills": ["shumway"]
+  }
+  !*/
+/* DOC
+
+   Detects support flash, as well as flash blocking plugins
+
+*/
+define(['Modernizr', 'createElement', 'docElement', 'addTest'], function( Modernizr, createElement, docElement, addTest ) {
+  Modernizr.addAsyncTest(function() {
+    /* jshint -W053 */
+    var runTest = function(result, embed) {
+      var bool = !!result;
+      if (bool) {
+        bool = new Boolean(bool);
+        bool.blocked = (result === 'blocked');
+      }
+      addTest('flash', function() { return bool; });
+        if (embed) {
+          docElement.removeChild(embed);
+        }
+    };
+    var easy_detect;
+    var activex;
+    // we wrap activex in a try/catch becuase when flash is disabled through
+    // ActiveX controls, it throws an error.
+    try {
+      // Pan is an API that exists for flash objects.
+      activex = "Pan" in new window.ActiveXObject("ShockwaveFlash.ShockwaveFlash");
+    } catch(e) {}
+
+    easy_detect = !( ( "plugins" in navigator && "Shockwave Flash" in navigator.plugins ) || activex );
+
+    if (easy_detect) {
+      runTest(false);
+    }
+    else {
+      // flash seems to be installed, but it might be blocked. We have to
+      // actually create an element to see what happens to it.
+      var embed = createElement('embed');
+      var inline_style;
+
+      embed.type = 'application/x-shockwave-flash';
+
+      docElement.appendChild(embed);
+
+      // Pan doesn't exist in the embed if its IE (its on the ActiveXObjeect)
+      // so this check is for all other browsers.
+      if (!("Pan" in embed) && !activex) {
+        runTest('blocked', embed);
+        return;
+      }
+
+      // If we have got this far, there is still a chance a userland plugin
+      // is blocking us (either changing the styles, or automatically removing
+      // the element). Both of these require us to take a step back for a moment
+      // to allow for them to get time of the thread, hence a setTimeout.
+      setTimeout(function() {
+        if (!docElement.contains(embed)) {
+          runTest('blocked');
+          return;
+        }
+
+        inline_style = embed.style.cssText;
+        if (inline_style !== '') {
+          // the style of the element has changed automatically. This is a
+          // really poor heuristic, but for lower end flash blocks, it the
+          // only change they can make.
+          runTest('blocked', embed);
+          return;
+        }
+
+        runTest(true, embed);
+      }, 10);
+    }
+  });
+});

--- a/lib/config-all.json
+++ b/lib/config-all.json
@@ -106,6 +106,7 @@
     "test/exif-orientation",
     "test/file/api",
     "test/file/filesystem",
+    "test/flash",
     "test/forms/fileinput",
     "test/forms/formattribute",
     "test/forms/inputnumber-l10n",

--- a/lib/polyfills.json
+++ b/lib/polyfills.json
@@ -675,5 +675,11 @@
     "authors": ["BBN Technologies"],
     "href": "http://polycrypt.net/",
     "licenses": ["BSD"]
+  },
+  "shumway": {
+    "name": "JavaScript Flash VM",
+    "authors": ["Mozilla Foundation"],
+    "href": "https://github.com/mozilla/shumway",
+    "licenses": ["Apache2"]
   }
 }


### PR DESCRIPTION
fixes #48

[Here is the list of plugins that this has been tested successfully](https://gist.github.com/patrickkettner/31e9f6678a124bf97f78). 

The only failure is [SafeBrowser](http://digitalplanet.is/safebrowser.html). It does server side removal of `embed` and `object` elements, but doesn't touch those added by javascript. Even if I could detect this someway, I am not sure if this counts as blocking, anyway.

I have done a large amount of testing across all modern browsers, and ie7-11. If there is any flash block technique that this does not cover that anyone is aware of, please let me know.
