### PR TITLE
small fix for svg filter test

### DIFF
--- a/feature-detects/svg/filters.js
+++ b/feature-detects/svg/filters.js
@@ -16,7 +16,7 @@ define(['Modernizr'], function( Modernizr ) {
   Modernizr.addTest('svgfilters', function() {
     var result = false;
     try {
-      result = typeof SVGFEColorMatrixElement !== undefined &&
+      result = 'SVGFEColorMatrixElement' in window &&
         SVGFEColorMatrixElement.SVG_FECOLORMATRIX_TYPE_SATURATE == 2;
     }
     catch(e) {}


### PR DESCRIPTION
Originally found by @jbt in #723, his pull got outdated. 

This is an update both to the file location, and to the new `in` style.
