### PR TITLE
add novalidate test

### DIFF
--- a/feature-detects/forms/novalidate.js
+++ b/feature-detects/forms/novalidate.js
@@ -1,0 +1,25 @@
+/*!
+{
+  "name": "form novalidate attribute",
+  "property": "formnovalidate",
+  "aliases": ["form-novalidate"],
+  "notes": [{
+    "name": "html5 doctor article",
+    "href": "http://html5doctor.com/html5-forms-introduction-and-new-attributes/#novalidate"
+  }, {
+    "name": "Wufoo demo",
+    "href": "http://www.wufoo.com/html5/attributes/11-novalidate.html"
+  }],
+  "polyfills": [
+    "webshims"
+  ]
+}
+!*/
+/* DOC
+
+Detect support for the form novalidate attribute
+
+*/
+define(['Modernizr', 'createElement'], function( Modernizr, createElement ) {
+  Modernizr.addTest('formnovalidate', !!('noValidate' in createElement('form')), { aliases: ['form-novalidate'] });
+});

--- a/lib/config-all.json
+++ b/lib/config-all.json
@@ -109,6 +109,7 @@
     "test/forms/fileinput",
     "test/forms/formattribute",
     "test/forms/inputnumber-l10n",
+    "test/forms/novalidate",
     "test/forms/placeholder",
     "test/forms/speechinput",
     "test/forms/validation",


### PR DESCRIPTION
fixes #1070

If this lands, this could possibly simplify the [validate](https://github.com/Modernizr/Modernizr/blob/029cefe/feature-detects/forms/validation.js) detect a decent amount (`novalidate` shouldn't exist where the validation API doesn't). 
