### PR TITLE
change vw/vh tests to clientWidth rather than innerWidth in case of

### DIFF
--- a/feature-detects/css/vmaxunit.js
+++ b/feature-detects/css/vmaxunit.js
@@ -13,10 +13,10 @@
   }]
 }
 !*/
-define(['Modernizr', 'testStyles'], function( Modernizr, testStyles ) {
+define(['Modernizr', 'docElement', 'testStyles'], function( Modernizr, docElement, testStyles ) {
   testStyles('#modernizr { width: 50vmax; }', function( elem, rule ) {
-    var one_vw = window.innerWidth/100;
-    var one_vh = window.innerHeight/100;
+    var one_vw = docElement.clientWidth/100;
+    var one_vh = docElement.clientHeight/100;
     var compWidth = parseInt((window.getComputedStyle ?
                           getComputedStyle(elem, null) :
                           elem.currentStyle)['width'],10);

--- a/feature-detects/css/vminunit.js
+++ b/feature-detects/css/vminunit.js
@@ -13,10 +13,10 @@
   }]
 }
 !*/
-define(['Modernizr', 'testStyles'], function( Modernizr, testStyles ) {
+define(['Modernizr', 'docElement', 'testStyles'], function( Modernizr, docElement, testStyles ) {
   testStyles('#modernizr { width: 50vmin; }', function( elem, rule ) {
-    var one_vw = window.innerWidth/100;
-    var one_vh = window.innerHeight/100;
+    var one_vw = docElement.clientWidth/100;
+    var one_vh = docElement.clientHeight/100;
     var compWidth = parseInt((window.getComputedStyle ?
                           getComputedStyle(elem, null) :
                           elem.currentStyle)['width'],10);

--- a/feature-detects/css/vwunit.js
+++ b/feature-detects/css/vwunit.js
@@ -13,9 +13,9 @@
   }]
 }
 !*/
-define(['Modernizr', 'testStyles'], function( Modernizr, testStyles ) {
+define(['Modernizr', 'docElement', 'testStyles'], function( Modernizr, docElement, testStyles ) {
   testStyles('#modernizr { width: 50vw; }', function( elem, rule ) {
-    var width = parseInt(window.innerWidth/2,10);
+    var width = parseInt(docElement.innerWidth/2,10);
     var compStyle = parseInt((window.getComputedStyle ?
                               getComputedStyle(elem, null) :
                               elem.currentStyle)['width'],10);


### PR DESCRIPTION
fixes #1045

as pointed out @rjgotten, firefox ([correctly](http://dev.w3.org/csswg/css-values/)) accounts for scrollbars when calculating vw/vh units. Using clientWidth rather than innerWidth makes the tests work correctly.
