### PR TITLE
Modify the Shapes test to use shape-outside rather than shape-inside

### DIFF
--- a/feature-detects/css/shapes.js
+++ b/feature-detects/css/shapes.js
@@ -15,20 +15,19 @@
   }]
 }
 !*/
-define(['Modernizr', 'createElement', 'docElement', 'prefixed', 'testStyles'], function( Modernizr, createElement, docElement, prefixed, testStyles ) {
-    // Separate test for CSS shapes as WebKit has just implemented this alone
+define(['Modernizr', 'createElement', 'docElement', 'prefixed', 'testStyles'], function(Modernizr, createElement, docElement, prefixed, testStyles ) {
     Modernizr.addTest('shapes', function () {
-        var prefixedProperty = prefixed('shapeInside');
+        var prefixedProperty = prefixed('shapeOutside');
 
         if (!prefixedProperty)
             return false;
 
-        var shapeInsideProperty = prefixedProperty.replace(/([A-Z])/g, function (str, m1) { return '-' + m1.toLowerCase(); }).replace(/^ms-/, '-ms-');
+        var shapeOutsideProperty = prefixedProperty.replace(/([A-Z])/g, function (str, m1) { return '-' + m1.toLowerCase(); }).replace(/^ms-/, '-ms-');
 
-        return testStyles('#modernizr { ' + shapeInsideProperty + ':rectangle(0,0,0,0,0,0) }', function (elem) {
+        return testStyles('#modernizr { float: left; ' + shapeOutsideProperty + ':rectangle(0,0,0,0,0,0) }', function (elem) {
             // Check against computed value
             var styleObj = window.getComputedStyle ? getComputedStyle(elem, null) : elem.currentStyle;
-            return styleObj[prefixed('shapeInside', docElement.style, false)] == 'rectangle(0px, 0px, 0px, 0px, 0px, 0px)';
+            return styleObj[prefixed('shapeOutside', docElement.style, false)] == 'rectangle(0px, 0px, 0px, 0px, 0px, 0px)';
         });
     });
 });


### PR DESCRIPTION
Shapes Level 1 specification contains only shape-outside. I modified the test to be aligned with the specification.
From now the Shape test of Modernizr uses the shape-outside property for testing the feature. The following versions of the Shapes specification will contain support for shape-inside property.
