### PR TITLE
Add support for dot properties in addTest - for #1088

### DIFF
--- a/src/addTest.js
+++ b/src/addTest.js
@@ -64,8 +64,15 @@ define(['ModernizrProto', 'Modernizr', 'hasOwnProp', 'setClasses'], function( Mo
     } else {
 
       feature = feature.toLowerCase();
+      var featureSplit = feature.split('.');
+      var last = Modernizr[featureSplit[0]];
 
-      if ( Modernizr[feature] !== undefined ) {
+      // Again, we don't check for parent test existence. Get that right, though.
+      if (featureSplit.length == 2) {
+        last = last[featureSplit[1]];
+      }
+
+      if ( typeof last != 'undefined' ) {
         // we're going to quit if you're trying to overwrite an existing test
         // if we were to allow it, we'd do this:
         //   var re = new RegExp("\\b(no-)?" + feature + "\\b");
@@ -77,10 +84,15 @@ define(['ModernizrProto', 'Modernizr', 'hasOwnProp', 'setClasses'], function( Mo
       test = typeof test == 'function' ? test() : test;
 
       // Set the value (this is the magic, right here).
-      Modernizr[feature] = test;
+      if (featureSplit.length == 1) {
+        Modernizr[featureSplit[0]] = test;
+      }
+      else if (featureSplit.length == 2) {
+        Modernizr[featureSplit[0]][featureSplit[1]] = test;
+      }
 
       // Set a single class (either `feature` or `no-feature`)
-      setClasses([(test ? '' : 'no-') + feature]);
+      setClasses([(test ? '' : 'no-') + featureSplit.join('-')]);
 
       // Trigger the event
       Modernizr._trigger(feature, test);

--- a/src/testRunner.js
+++ b/src/testRunner.js
@@ -6,6 +6,11 @@ define(['tests', 'Modernizr', 'classes', 'is'], function( tests, Modernizr, clas
     var aliasIdx;
     var result;
     var nameIdx;
+    var featureName;
+    var featureNameSplit;
+    var modernizrProp;
+    var mPropCount;
+
     for ( var featureIdx in tests ) {
       featureNames = [];
       feature = tests[featureIdx];
@@ -30,10 +35,26 @@ define(['tests', 'Modernizr', 'classes', 'is'], function( tests, Modernizr, clas
       // Run the test, or use the raw value if it's not a function
       result = is(feature.fn, 'function') ? feature.fn() : feature.fn;
 
+
       // Set each of the names on the Modernizr object
       for (nameIdx = 0; nameIdx < featureNames.length; nameIdx++) {
-        Modernizr[featureNames[nameIdx]] = result;
-        classes.push((Modernizr[featureNames[nameIdx]] ? '' : 'no-') + featureNames[nameIdx]);
+        featureName = featureNames[nameIdx];
+        // Support dot properties as sub tests. We don't do checking to make sure
+        // that the implied parent tests have been added. You must call them in
+        // order (either in the test, or make the parent test a dependency).
+        //
+        // Cap it to TWO to make the logic simple and because who needs that kind of subtesting
+        // hashtag famous last words
+        featureNameSplit = featureName.split('.');
+
+        if (featureNameSplit.length === 1) {
+          Modernizr[featureNameSplit[0]] = result;
+        }
+        else if (featureNameSplit.length === 2) {
+          Modernizr[featureNameSplit[0]][featureNameSplit[1]] = result;
+        }
+
+        classes.push((result ? '' : 'no-') + featureNameSplit.join('-'));
       }
     }
   }


### PR DESCRIPTION
I considered putting something in the `options` for sub tests, but this was pretty simple and everyone gets it I think. Didn't run tests, so lets wait on that.

/cc @darcyclarke
