### PR TITLE
Add preserve-3d feature-detect

### DIFF
--- a/feature-detects/css/preverse3d.js
+++ b/feature-detects/css/preverse3d.js
@@ -1,0 +1,22 @@
+/*!
+{
+  "name": "CSS Transform Style preserve-3d",
+  "property": "preserve3d",
+  "tags": ["css"]
+}
+!*/
+define(['Modernizr', 'testStyles', 'prefixed'], function (Modernizr, testStyles, prefixed) {
+    Modernizr.addTest('preserve3d', function () {
+        var prefixedProperty = prefixed('transformStyle');
+
+        if (!prefixedProperty)
+            return false;
+
+        var transformStyleProperty = prefixedProperty.replace(/([A-Z])/g, function (str, m1) { return '-' + m1.toLowerCase(); }).replace(/^ms-/, '-ms-');
+
+        return testStyles('#modernizr { ' + transformStyleProperty + ': preserve-3d; }', function (elem, rule) {
+            // Check against computed value
+            return window.getComputedStyle ? getComputedStyle(elem, null).getPropertyValue(transformStyleProperty) === 'preserve-3d' : false;
+        });
+    });
+});

--- a/lib/config-all.json
+++ b/lib/config-all.json
@@ -61,6 +61,7 @@
     "test/css/overflow-scrolling",
     "test/css/pointerevents",
     "test/css/positionsticky",
+    "test/css/preverse3d",
     "test/css/pseudoanimations",
     "test/css/pseudotransitions",
     "test/css/reflections",


### PR DESCRIPTION
Fixes [#762](https://github.com/Modernizr/Modernizr/issues/762)

IE10 supports `3D transforms` but unfortunately not `transform-style: preserve-3d`.

Code work's properly on all browsers (including IE10 ofc).
