### PR TITLE
:target Feature Test

### DIFF
--- a/feature-detects/css/target.js
+++ b/feature-detects/css/target.js
@@ -1,0 +1,35 @@
+/*!
+{
+  "name": "CSS :target pseudo-class",
+  "caniuse": "css-sel3",
+  "property": "target",
+  "tags": ["css"],
+  "notes": [{
+    "name": "MDN documentation",
+    "href": "https://developer.mozilla.org/en-US/docs/Web/CSS/:target"
+  }],
+  "authors": ["@zachleat"],
+  "warnings": ["Opera Mini supports :target but doesn't update the hash for anchor links."]
+}
+!*/
+/* DOC
+
+Detects support for the ':target' CSS pseudo-class.
+
+*/
+define(['Modernizr'], function( Modernizr ) {
+  // querySelector
+  Modernizr.addTest('target', function() {
+    var doc = window.document;
+    if(!('querySelectorAll' in doc) ) {
+      return false;
+    }
+
+    try {
+      doc.querySelectorAll(':target');
+      return true;
+    } catch(e) {
+      return false;
+    }
+  });
+});

--- a/lib/config-all.json
+++ b/lib/config-all.json
@@ -73,6 +73,7 @@
     "test/css/siblinggeneral",
     "test/css/subpixelfont",
     "test/css/supports",
+    "test/css/target",
     "test/css/textshadow",
     "test/css/transforms",
     "test/css/transformstylepreserve3d",


### PR DESCRIPTION
I created two different approaches to feature testing `:target`. I think this is the better one, even though it uses try/catch. The other involves changing the hash, which isn’t ideal. http://www.zachleat.com/web/moving-target/

Tested on:
- Chrome 31: Passes
- Firefox 25: Passes
- IE7, IE8: Fails Correctly (Not supported)
- IE9, IE10: Passes
- Safari 7: Passes
- Android 2.3: Passes
- Windows Phone 7.5: Passes
- BB6.1, BB7: Passes
- BB5: Passes Correctly and does not require an opt-out like the other method.
- Kindle 3.4: Passes and does not add a history entry like the other method.
- Opera Mini: Would pass incorrectly (unlike the other method) but we use window.operamini to opt-out and return false.
- Opera 9.10: Fails Correctly (Not supported)
- Opera 12: Passes

Opera Mini is the only non-ideal result.

Related to #440.
