### PR TITLE
added fileinputdirectory.js to config-all.json

### DIFF
--- a/lib/config-all.json
+++ b/lib/config-all.json
@@ -108,6 +108,7 @@
     "test/file/api",
     "test/file/filesystem",
     "test/forms/fileinput",
+    "test/forms/fileinputdirectory"
     "test/forms/formattribute",
     "test/forms/inputnumber-l10n",
     "test/forms/placeholder",


### PR DESCRIPTION
I just noticed this test wasn't included.  If this was intentionally left out, that's cool too.

referencing closed issue #965
