### PR TITLE
add fileinputdirectory to config-all.json

### DIFF
--- a/lib/config-all.json
+++ b/lib/config-all.json
@@ -108,6 +108,7 @@
     "test/file/api",
     "test/file/filesystem",
     "test/forms/fileinput",
+    "test/forms/fileinputdirectory",
     "test/forms/formattribute",
     "test/forms/inputnumber-l10n",
     "test/forms/placeholder",


### PR DESCRIPTION
Sorry, meant to try this again.  the fileinputdirectory test wasn't included in the config-all.json.  If this was intentional, you can disregard.

ref #965 
