### PR TITLE
added test for custom search event for input with type of search

### DIFF
--- a/feature-detects/inputsearchevent.js
+++ b/feature-detects/inputsearchevent.js
@@ -1,0 +1,23 @@
+/*!
+{
+  "name": "input[search] search event",
+  "property": "search",
+  "tags": ["input","search"],
+  "authors": ["Calvin Webster"],
+  "notes": [{
+    "name": "Wufoo demo",
+    "href": "http://www.wufoo.com/html5/types/5-search.html?"
+  }, {
+    "name": "CSS Tricks",
+    "href": "http://css-tricks.com/webkit-html5-search-inputs/"
+  }]
+}
+!*/
+/* DOC
+
+ There is a custom `search` event implemented in webkit browsers when using an `input[search]` element.
+
+ */
+define(['Modernizr', 'hasEvent'], function( Modernizr, hasEvent ) {
+    Modernizr.addTest('inputsearchevent',  hasEvent('search'));
+});

--- a/lib/config-all.json
+++ b/lib/config-all.json
@@ -128,6 +128,7 @@
     "test/indexedDB",
     "test/input",
     "test/inputtypes",
+    "test/inputsearchevent",
     "test/json",
     "test/lists-reversed",
     "test/mathml",


### PR DESCRIPTION
created test for the custom event `search` that webkit browsers fire when entering anything on an `input[type=search]`

I tested it on 

Safari
Chrome and Chrome Canary
Opera 12.16 and Opera 15 to see the test change since the webkit change
Firefox
Ie7 and ie9

This is definitely just a proposal to add this test, and am not sure of any browsers' (other than webkit) future implementation of the `search` event.
