### PR TITLE
`flex-wrap` contention

### DIFF
--- a/feature-detects/css/flexbox.js
+++ b/feature-detects/css/flexbox.js
@@ -7,9 +7,17 @@
   "notes": [{
     "name": "The _new_ flexbox",
     "href": "http://dev.w3.org/csswg/css3-flexbox"
-  }]
+  }],
+  "warnings": [
+    "A `true` result for this detect does not imply that the `flex-wrap` property is supported; see the `flexwrap` detect."
+  ]
 }
 !*/
+/* DOC
+
+Detects support for the Flexible Box Layout model, a.k.a. Flexbox, which allows easy manipulation of layout order and sizing within a container.
+
+*/
 define(['Modernizr', 'testAllProps'], function( Modernizr, testAllProps ) {
   Modernizr.addTest('flexbox', testAllProps('flexBasis', '1px', true));
 });

--- a/feature-detects/css/flexwrap.js
+++ b/feature-detects/css/flexwrap.js
@@ -1,0 +1,33 @@
+/*!
+{
+  "name": "Flex Line Wrapping",
+  "property": "flexwrap",
+  "tags": ["css", "flexbox"],
+  "notes": [{
+    "name": "W3C Flexible Box Layout spec",
+    "href": "http://dev.w3.org/csswg/css3-flexbox"
+  }],
+  "warnings": [
+    "Does not imply a modern implementation – see documentation."
+  ]
+}
+!*/
+/* DOC
+
+Detects support for the `flex-wrap` CSS property, part of Flexbox, which isn’t present in all Flexbox implementations (notably Firefox).
+
+This featured in both the 'tweener' syntax (implemented by IE10) and the 'modern' syntax (implemented by others). This detect will return `true` for either of these implementations, as long as the `flex-wrap` property is supported. So to ensure the modern syntax is supported, use together with `Modernizr.flexbox`:
+
+```javascript
+if (Modernizr.flexbox && Modernizr.flexwrap) {
+  // Modern Flexbox with `flex-wrap` supported
+}
+else {
+  // Either old Flexbox syntax, or `flex-wrap` not supported
+}
+```
+
+*/
+define(['Modernizr', 'testAllProps'], function( Modernizr, testAllProps ) {
+  Modernizr.addTest('flexbox', testAllProps('flexWrap', 'wrap', true));
+});

--- a/lib/config-all.json
+++ b/lib/config-all.json
@@ -47,6 +47,7 @@
     "test/css/flexbox",
     "test/css/flexboxlegacy",
     "test/css/flexboxtweener",
+    "test/css/flexwrap",
     "test/css/fontface",
     "test/css/generatedcontent",
     "test/css/gradients",


### PR DESCRIPTION
In v2.6.2, `Modernizr.flexbox` uses the `flex-wrap` property to detect support, but a string of issues (#744, #757, #812, #934, #936, #982) resulted in us changing this in v3.0pre to use `flex-basis` instead.

This is because, among other things, Firefox 21+ supports the modern flexbox syntax, except `flex-wrap` and `flex-flow` – so it would "false positive" for flexbox support.

Recent discussions on Twitter have highlighted that some users rely on `Modernizr.flexbox == true` meaning `flex-wrap` is supported:

> Well, that's going to break at least three sites I've coded, maybe 4. :-/
> https://twitter.com/joshbroton/status/383590623434903553

and:

> I think Flexbox is basically worthless without flex-wrap support.
> https://twitter.com/joshbroton/status/383590623434903553

[Solved By Flexbox](http://philipwalton.github.io/solved-by-flexbox/) doesn't use `flex-wrap` in any of its examples… but it does use it in its own page styles.

There's clearly a use case for flexbox without `flex-wrap` support, and a use case for knowing if `flex-wrap` is supported.

So… maybe we need a separate `Modernizr.flexwrap` detect?

The `flex-wrap` property features in both the modern spec and the 'tweener' spec IE10 implemented, so either:
- `Modernizr.flexwrap` should depend on a true result for `Modernizr.flexbox`; or
- Users should use `Modernizr.flexbox && Modernizr.flexwrap` / `.flexbox.flexwrap` to target the modern version of the spec

Thoughts?

/cc @joshbroton
