### PR TITLE
Method to provide hyphenated versions of prefixed CSS properties

### DIFF
--- a/lib/config-all.json
+++ b/lib/config-all.json
@@ -6,7 +6,8 @@
     "html5printshiv",
     "load",
     "testProp",
-    "fnBind"
+    "fnBind",
+    "prefixedCSS"
   ],
   "feature-detects": [
     "test/a/download",

--- a/src/cssToDOM.js
+++ b/src/cssToDOM.js
@@ -1,0 +1,10 @@
+define(function() {
+  // Helper function for converting kebab-case to camelCase,
+  // e.g. box-sizing -> boxSizing
+  function cssToDOM( name ) {
+    return name.replace(/([a-z])-([a-z])/g, function(str, m1, m2) {
+      return m1 + m2.toUpperCase();
+    }).replace(/^-/, '');
+  }
+  return cssToDOM;
+});

--- a/src/domToCSS.js
+++ b/src/domToCSS.js
@@ -1,9 +1,10 @@
 define(function() {
-  // Helper function for e.g. boxSizing -> box-sizing
-  function domToHyphenated( name ) {
+  // Helper function for converting camelCase to kebab-case,
+  // e.g. boxSizing -> box-sizing
+  function domToCSS( name ) {
     return name.replace(/([A-Z])/g, function(str, m1) {
       return '-' + m1.toLowerCase();
     }).replace(/^ms-/, '-ms-');
   }
-  return domToHyphenated;
+  return domToCSS;
 });

--- a/src/nativeTestProps.js
+++ b/src/nativeTestProps.js
@@ -1,4 +1,4 @@
-define(['injectElementWithStyles', 'domToHyphenated'], function ( injectElementWithStyles, domToHyphenated ) {
+define(['injectElementWithStyles', 'domToCSS'], function ( injectElementWithStyles, domToCSS ) {
   // Function to allow us to use native feature detection functionality if available.
   // Accepts a list of property names and a single value
   // Returns `undefined` if native detection not available
@@ -8,7 +8,7 @@ define(['injectElementWithStyles', 'domToHyphenated'], function ( injectElementW
     if ('CSS' in window && 'supports' in window.CSS) {
       // Try every prefixed variant of the property
       while (i--) {
-        if (window.CSS.supports(domToHyphenated(props[i]), value)) {
+        if (window.CSS.supports(domToCSS(props[i]), value)) {
           return true;
         }
       }
@@ -19,7 +19,7 @@ define(['injectElementWithStyles', 'domToHyphenated'], function ( injectElementW
       // Build a condition string for every prefixed variant
       var conditionText = [];
       while (i--) {
-        conditionText.push('(' + domToHyphenated(props[i]) + ':' + value + ')');
+        conditionText.push('(' + domToCSS(props[i]) + ':' + value + ')');
       }
       conditionText = conditionText.join(' or ');
       return injectElementWithStyles('@supports (' + conditionText + ') { #modernizr { position: absolute; } }', function( node ) {

--- a/src/prefixed.js
+++ b/src/prefixed.js
@@ -1,11 +1,9 @@
-define(['ModernizrProto', 'testPropsAll'], function( ModernizrProto, testPropsAll ) {
+define(['ModernizrProto', 'testPropsAll', 'cssToDOM'], function( ModernizrProto, testPropsAll, cssToDOM ) {
   // Modernizr.prefixed() returns the prefixed or nonprefixed property name variant of your input
   // Modernizr.prefixed('boxSizing') // 'MozBoxSizing'
 
-  // Properties must be passed as dom-style camelcase, rather than `box-sizing` hypentated style.
-  // Return values will also be the camelCase variant, if you need to translate that to hypenated style use:
-  //
-  //     str.replace(/([A-Z])/g, function(str,m1){ return '-' + m1.toLowerCase(); }).replace(/^ms-/,'-ms-');
+  // Properties can be passed as DOM-style camelCase or CSS-style kebab-case.
+  // Return values will always be in camelCase; if you want kebab-case, use Modernizr.prefixedCSS().
 
   // If you're trying to ascertain which transition end event to bind to, you might do something like...
   //
@@ -17,6 +15,10 @@ define(['ModernizrProto', 'testPropsAll'], function( ModernizrProto, testPropsAl
   //     transEndEventName = transEndEventNames[ Modernizr.prefixed('transition') ];
 
   var prefixed = ModernizrProto.prefixed = function( prop, obj, elem ) {
+    // Convert kebab-case to camelCase
+    if (prop.indexOf('-') != -1) {
+      prop = cssToDOM(prop);
+    }
     if (!obj) {
       return testPropsAll(prop, 'pfx');
     } else {

--- a/src/prefixedCSS.js
+++ b/src/prefixedCSS.js
@@ -1,0 +1,15 @@
+define(['ModernizrProto', 'prefixed', 'domToCSS'], function( ModernizrProto, prefixed, domToCSS ) {
+  // Modernizr.prefixedCSS() is like Modernizr.prefixed(), but returns the result in
+  // hyphenated form, e.g.:
+  // Modernizr.prefixedCSS('transition') // '-moz-transition'
+
+  // It’s only suitable for style properties.
+
+  // Properties can be passed as DOM-style camelCase or CSS-style kebab-case.
+  // Return values will always be the hyphenated variant, or `false` if not supported
+  var prefixedCSS = ModernizrProto.prefixedCSS = function(prop) {
+    var prefixedProp = prefixed(prop);
+    return prefixedProp && domToCSS(prefixedProp);
+  };
+  return prefixedCSS;
+});


### PR DESCRIPTION
_This issue was originally called “Vendor prefix constant”, but conversation has diverged. #1223 will result in a `Modernizr._prefix` property being added, fulfilling the OP’s original request, so we’ll track that request over there. – Stu Cox_

---

Sometimes, to just get the vendor prefix for unsupported cases…

``` js
$('head').append([
'<style>',
'.carousel {',
prefix('transition') + ': all ' + duration + 's ease-in-out;',
prefix('transform') + ': translate3d(0, 0, 0);',
prefix('backface-visibility') + ':hidden;',  // Exception
'}',
'</style>'
].join("\n"));

function prefix (n) {
    return Modernizr.prefixed(n).replace(/([A-Z])/g, function(str,m1){ return '-' + m1.toLowerCase(); }).replace(/^ms-/,'-ms-');
}
```
