### PR TITLE
add bug notes about dragndrop on mobile

### DIFF
--- a/feature-detects/draganddrop.js
+++ b/feature-detects/draganddrop.js
@@ -3,6 +3,7 @@
   "name": "Drag & Drop",
   "property": "draganddrop",
   "caniuse": "dragndrop",
+  "knownBugs": ["Mobile browsers like Android, iOS < 6, and Firefox OS technically support the APIs, but don't expose it to the end user, resulting in a false positive."],
   "notes": [{
     "name": "W3C spec",
     "href": "http://www.w3.org/TR/2010/WD-html5-20101019/dnd.html"


### PR DESCRIPTION
"fixes" #637

DnD has worked in iOS since v 6 ([demo](http://harlancampbelljr.com/test4art/story_html5.html))

Blink has [this bug](http://crbug.com/156390), and I [filed one for FFOS](https://bugzilla.mozilla.org/show_bug.cgi?id=945073). No idea how to submit a bug on IE Mobile, but I reached out to @reybango to find out
