### PR TITLE
Create atRule API to check for atRules (@keyframes, @import, etc.)

### DIFF
--- a/lib/config-all.json
+++ b/lib/config-all.json
@@ -1,13 +1,14 @@
 {
   "classPrefix": "",
   "options": [
-    "setClasses",
     "addTest",
+    "atRule",
+    "fnBind",
     "html5printshiv",
     "load",
-    "testProp",
-    "fnBind",
-    "prefixedCSS"
+    "prefixedCSS",
+    "setClasses",
+    "testProp"
   ],
   "feature-detects": [
     "test/a/download",

--- a/src/atRule.js
+++ b/src/atRule.js
@@ -1,0 +1,38 @@
+define(['ModernizrProto', 'prefixes'], function( ModernizrProto, prefixes ) {
+  /**
+   * atRule returns a given CSS property at-rule (eg @keyframes), possibly in
+   * some prefixed form, or false, in the case of an unsupported rule
+   *
+   * @param prop - String naming the property to test
+   */
+
+  var atRule = function(prop) {
+    var length = prefixes.length;
+    var cssrule = window.CSSRule;
+    var rule;
+
+    // remove literal @ from begining of provided property
+    prop = prop.replace(/^@/,'');
+
+    // CSSRules use underscores instead of dashes
+    rule = prop.replace(/-/g,'_').toUpperCase() + '_RULE';
+
+    if (rule in cssrule) {
+      return '@' + prop;
+    }
+
+    for ( var i = 0; i < length; i++ ) {
+      // prefixes gives us something like -o-, and we want O_
+      var prefix = prefixes[i];
+      var thisRule = prefix.toUpperCase() + '_' + rule;
+
+      if (thisRule in cssrule) {
+        return '@-' + prefix.toLowerCase() + '-' + prop;
+      }
+    }
+
+    return false;
+  };
+
+  return atRule;
+});

--- a/src/prefixed.js
+++ b/src/prefixed.js
@@ -1,4 +1,4 @@
-define(['ModernizrProto', 'testPropsAll', 'cssToDOM'], function( ModernizrProto, testPropsAll, cssToDOM ) {
+define(['ModernizrProto', 'testPropsAll', 'cssToDOM', 'atRule'], function( ModernizrProto, testPropsAll, cssToDOM, atRule ) {
   // Modernizr.prefixed() returns the prefixed or nonprefixed property name variant of your input
   // Modernizr.prefixed('boxSizing') // 'MozBoxSizing'
 
@@ -15,8 +15,12 @@ define(['ModernizrProto', 'testPropsAll', 'cssToDOM'], function( ModernizrProto,
   //     transEndEventName = transEndEventNames[ Modernizr.prefixed('transition') ];
 
   var prefixed = ModernizrProto.prefixed = function( prop, obj, elem ) {
-    // Convert kebab-case to camelCase
+    if (prop.indexOf('@') === 0) {
+      return atRule(prop);
+    }
+
     if (prop.indexOf('-') != -1) {
+      // Convert kebab-case to camelCase
       prop = cssToDOM(prop);
     }
     if (!obj) {

--- a/test/js/unit.js
+++ b/test/js/unit.js
@@ -592,6 +592,11 @@ test('Modernizr.prefixed() - css and DOM resolving', function(){
 
 });
 
+test('Modernizr.prefixed atRule', function() {
+  equal(Modernizr.prefixed('@import'), '@import', 'Everyone supports import');
+  equal(Modernizr.prefixed('@penguin'), false, 'Nobody supports @penguin');
+});
+
 
 // FIXME: so a few of these are whitelisting for webkit. i'd like to improve that.
 test('Modernizr.prefixed autobind', function(){


### PR DESCRIPTION
fixes #814

creates a new API to test if any kind of `@-`rule is supported.

eg
1. `Modernizr.atRule('charset', '"UTF-8"')`
2. `Modernizr.atRule('filter', 'foo {}')`
3. `Modernizr.atRule('font-face')`
4. `Modernizr.atRule('import', 'url()')`
5. `Modernizr.atRule('keyframes')`
6. `Modernizr.atRule('media')`
7. `Modernizr.atRule('page')`
8. `Modernizr.atRule('supports', '(){}')`
9. `Modernizr.atRule('viewport')`

Assuming we want to add a new API (I know @paulirish has bemoaned its increase in size), we could clean up some existing tests, and easily add future ones. This also allows for an easy API for other scripts to hook into (the reason behind #814)
