### PR TITLE
Fixing issue with relying on global installation of grunt

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -49,7 +49,7 @@ module.exports = function (opts, callback) {
     }
   }
 
-  var build = cp.spawn("grunt", ["build"], {
+  var build = cp.spawn(__dirname + "/../node_modules/.bin/" + "grunt", ["build"], {
     stdio: verbose ? "inherit" : [0, "pipe", 2],
     cwd: localRoot
   });

--- a/package.json
+++ b/package.json
@@ -21,14 +21,15 @@
     "grunt-contrib-copy": "~0.4.0",
     "grunt-contrib-requirejs": "~0.4.0",
     "grunt-contrib-connect": "~0.5.0",
-    "grunt-saucelabs": "~4.0.4"
+    "grunt-saucelabs": "~4.0.4",
+    "grunt-cli": "~0.1.11"
   },
   "devDependencies": {
     "grunt-contrib-qunit": "~0.2.0",
     "grunt-contrib-nodeunit": "~0.2.0"
   },
   "scripts": {
-    "test": "grunt test"
+    "test": "./node_modules/.bin/grunt test"
   },
   "main": "./lib/cli",
   "repository": {


### PR DESCRIPTION
Modernizr currently relies on a global installation of grunt to use modernizr to build or run its tests. This pull request fixes this problem and locks down the `grunt-cli` version to a specific version.
