### PR TITLE
Added test for whether window dimensions in js are preadjusted to be device independent pixels

### DIFF
--- a/feature-detects/screendip.js
+++ b/feature-detects/screendip.js
@@ -1,0 +1,26 @@
+/*!
+{
+  "name": "Screen device independent pixels",
+  "property": "screendip",
+  "tags": ["screen", "dimensions"]
+}
+!*/
+/* DOC
+
+On high resolution devices with a device pixel ratio greater than 1, detects if the screen's dimensions
+(availWidth etc.) are given in device independent pixels (`true`) or in physical pixels (`false`).
+Defaults to `true` for devices with normal resolution.
+
+Something like the following will give measurements in device independent pixels
+
+```javascript
+var trueScreenWidth = screen.availWidth / (Modernizr.screendip ? 1 : window.devicePixelRatio);
+```
+
+*/
+define(['Modernizr', 'mq'], function( Modernizr, mq ) {
+  Modernizr.addTest('screendip', function () {
+    var dpr = window.devicePixelRatio;
+    return (dpr && dpr > 1) ? !mq('only all and (max-width:'+ screen.availWidth +'px)') : true;
+  });
+});

--- a/feature-detects/windowdip.js
+++ b/feature-detects/windowdip.js
@@ -1,0 +1,26 @@
+/*!
+{
+  "name": "Window device independent pixels",
+  "property": "windowdip",
+  "tags": ["window", "dimensions"]
+}
+!*/
+/* DOC
+
+On high resolution devices with a device pixel ratio greater than 1, detects if the window's dimensions
+(outerWidth etc.) are given in device independent pixels (`true`) or in physical pixels (`false`).
+Defaults to `true` for devices with normal resolution.
+
+Something like the following will give measurements in device independent pixels
+
+```javascript
+var trueWindowWidth = window.outerWidth / (Modernizr.windowdip ? 1 : window.devicePixelRatio);
+```
+
+*/
+define(['Modernizr', 'mq'], function( Modernizr, mq ) {
+  Modernizr.addTest('windowdip', function () {
+    var dpr = window.devicePixelRatio;
+    return (dpr && dpr > 1) ? !mq('only all and (max-width:'+ window.outerWidth +'px)') : true;
+  });
+});


### PR DESCRIPTION
Relating to this issue https://github.com/Modernizr/Modernizr/issues/1138.

It's roughly a translation of http://jsbin.com/IzEYuCI/3/edit using Modernizr's API. I haven't tested it in any devices yet but will test in a few tomorrow... although I don't have access to many so I guess would need testing on a wider suite of devices at some point before being accepted
