### PR TITLE
Remove deprecated WebKit gradient syntax

### DIFF
--- a/feature-detects/css/gradients.js
+++ b/feature-detects/css/gradients.js
@@ -6,34 +6,16 @@
   "tags": ["css"],
   "knownBugs": ["False-positives on webOS (https://github.com/Modernizr/Modernizr/issues/202)"],
   "notes": [{
-    "name": "Webkit Gradient Syntax",
-    "href": "http://webkit.org/blog/175/introducing-css-gradients/"
-  },{
-    "name": "Mozilla Linear Gradient Syntax",
-    "href": "http://developer.mozilla.org/en/CSS/-moz-linear-gradient"
-  },{
-    "name": "Mozilla Radial Gradient Syntax",
-    "href": "http://developer.mozilla.org/en/CSS/-moz-radial-gradient"
-  },{
     "name": "W3C Gradient Spec",
-    "href": "dev.w3.org/csswg/css3-images/#gradients-"
+    "href": "dev.w3.org/csswg/css3-images/#gradients"
   }]
 }
 !*/
 define(['Modernizr', 'prefixes', 'createElement'], function( Modernizr, prefixes, createElement ) {
-
   Modernizr.addTest('cssgradients', function() {
-
-    var str1 = 'background-image:';
-    var str2 = 'gradient(linear,left top,right bottom,from(#9f9),to(white));';
-    var str3 = 'linear-gradient(left top,#9f9, white);';
-
-    var css =
-      // legacy webkit syntax (FIXME: remove when syntax not in use anymore)
-      (str1 + '-webkit- '.split(' ').join(str2 + str1) +
-       // standard syntax             // trailing 'background-image:'
-       prefixes.join(str3 + str1)).slice(0, -str1.length);
-
+    var property = 'background-image:';
+    var value = 'linear-gradient(left top,#9f9, white);';
+    var css = (property + prefixes.join(value + property)).slice(0, -property.length);
     var elem = createElement('div');
     var style = elem.style;
     style.cssText = css;


### PR DESCRIPTION
Safari 6.0 (OSX) is reporting cssgradients support despite not supporting the standard syntax (http://dev.w3.org/csswg/css-images-3/#gradients).

As of January 2011, the WebKit team moved to support the new syntax (see: https://www.webkit.org/blog/1424/css3-gradients/ ). The old syntax should be considered deprecated and browsers which lack support for the newer syntax should fail the "cssgradients" test.
