### PR TITLE
Add test to detect the support of the Intl API

### DIFF
--- a/feature-detects/intl.js
+++ b/feature-detects/intl.js
@@ -1,0 +1,22 @@
+/*!
+ {
+ "name": "Internationalization API",
+ "property": "Intl",
+ "notes": [{
+ "name": "MDN documentation",
+ "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"
+ },{
+ "name": "ECMAScript spec",
+ "href": "http://www.ecma-international.org/ecma-402/1.0/"
+ }]
+ }
+ !*/
+/* DOC
+
+ Detects support for the Internationalization API which allow easy formatting of number and dates and sorting string
+ based on a locale
+
+ */
+define(['Modernizr', 'prefixed'], function( Modernizr, prefixed ) {
+  Modernizr.addTest('intl', !!prefixed('Intl', window));
+});

--- a/lib/config-all.json
+++ b/lib/config-all.json
@@ -147,6 +147,7 @@
     "test/input",
     "test/inputsearchevent",
     "test/inputtypes",
+    "test/intl",
     "test/json",
     "test/lists-reversed",
     "test/mathml",


### PR DESCRIPTION
Tested in 
Chrome, ( true )
Chrome Canary (true)
Firefox (false)
Firefox Nightly (true)
Safari (false)
Opera (true)

I could not test in IE
