### PR TITLE
Added a test for animated WebP images

### DIFF
--- a/feature-detects/img/webp-animation.js
+++ b/feature-detects/img/webp-animation.js
@@ -1,0 +1,37 @@
+/*!
+{
+  "name": "Webp Animation",
+  "async": true,
+  "property": "webpanimation",
+  "aliases": ["webp-animation"],
+  "tags": ["image"],
+  "authors": ["Krister Kari", "Rich Bradshaw", "Ryan Seddon", "Paul Irish"],
+  "notes": [{
+    "name": "WebP Info",
+    "href": "http://code.google.com/speed/webp/"
+  },{
+    "name": "Chormium blog - Chrome 32 Beta: Animated WebP images and faster Chrome for Android touch input",
+    "href": "http://blog.chromium.org/2013/11/chrome-32-beta-animated-webp-images-and.html"
+  }]
+}
+!*/
+/* DOC
+
+Tests for animated webp support.
+
+*/
+define(['Modernizr', 'addTest'], function( Modernizr, addTest ) {
+  Modernizr.addAsyncTest(function(){
+    var image = new Image();
+
+    image.onerror = function() {
+      addTest('webpanimation', false, { aliases: ['webp-animation'] });
+    };
+
+    image.onload = function() {
+      addTest('webpanimation', image.width == 1, { aliases: ['webp-animation'] });
+    };
+
+    image.src = 'data:image/webp;base64,UklGRlIAAABXRUJQVlA4WAoAAAASAAAAAAAAAAAAQU5JTQYAAAD/////AABBTk1GJgAAAAAAAAAAAAAAAAAAAGQAAABWUDhMDQAAAC8AAAAQBxAREYiI/gcA';
+  });
+});

--- a/lib/config-all.json
+++ b/lib/config-all.json
@@ -143,6 +143,7 @@
     "test/img/srcset",
     "test/img/webp-lossless",
     "test/img/webp-alpha",
+    "test/img/webp-animation",
     "test/img/webp",
     "test/indexedDB",
     "test/input",


### PR DESCRIPTION
This tests for animated WebP using the data URI from https://developers.google.com/speed/webp/faq.

Did some quick testing:
- Firefox 26 beta: returns false for support
- Chrome 31: returns false for support, does not render animated webp on this page: http://blog.chromium.org/2013/11/chrome-32-beta-animated-webp-images-and.html
- Chrome 32 beta: returns true for support, renders that animated webp
