### PR TITLE
Clean up dev dependencies

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -213,7 +213,7 @@ module.exports = function( grunt ) {
   });
 
   // Load required contrib packages
-  require('matchdep').filterAll(['grunt-*', '!grunt-cli']).forEach(grunt.loadNpmTasks);
+  require('matchdep').filter(['grunt-*', '!grunt-cli']).forEach(grunt.loadNpmTasks);
 
   // devDependencies may or may not be installed
   require('matchdep').filterDev('grunt-*').forEach(function (contrib) {
@@ -258,5 +258,5 @@ module.exports = function( grunt ) {
 
   // Build
   grunt.registerTask('build', ['clean', 'generateinit', 'requirejs', 'copy', 'clean:postbuild', 'stripdefine', 'uglify']);
-  grunt.registerTask('default', ['build', 'jshint', 'qunit']);
+  grunt.registerTask('default', ['build', 'jshint']);
 };

--- a/package.json
+++ b/package.json
@@ -20,11 +20,11 @@
     "grunt-contrib-clean": "~0.4.0",
     "grunt-contrib-copy": "~0.4.0",
     "grunt-contrib-requirejs": "~0.4.0",
-    "grunt-contrib-connect": "~0.5.0",
-    "grunt-saucelabs": "~4.0.4",
     "grunt-cli": "~0.1.11"
   },
   "devDependencies": {
+    "grunt-contrib-connect": "~0.5.0",
+    "grunt-saucelabs": "~4.0.4",
     "grunt-contrib-qunit": "~0.2.0",
     "grunt-contrib-nodeunit": "~0.2.0"
   },


### PR DESCRIPTION
A clean up of some recent activity regarding dependencies:
1. The matchdep filter in Gruntfile.js was set up to avoid [missing dependency warnings](https://github.com/Modernizr/Modernizr/issues/1154#issuecomment-30296449). If dev dependencies are found, they are allowed to conditionally load [here](https://github.com/Modernizr/Modernizr/blob/master/Gruntfile.js#L218-L225).
2. I moved `grunt-contrib-connect` and `grunt-saucelabs` to devDependencies. They are only used for testing purposes, and have a big impact in install time reduction via npm.
3. Since `grunt-contrib-qunit` is a dev dependency, I've moved it out of the default task. It can be run using the existing `grunt test` command.
