### PR TITLE
Made the Regions detect work properly even when the page is zoomed out

### DIFF
--- a/feature-detects/css/regions.js
+++ b/feature-detects/css/regions.js
@@ -61,6 +61,8 @@ define(['Modernizr', 'createElement', 'docElement'], function( Modernizr, create
     docElement.removeChild(container);
     content = region = container = undefined;
 
-    return (delta == 42);
+    /* Since getBoundingClientRect() behaves oddly when the page is zoomed out in Chrome,
+       we're OK with a couple of pixels difference. For now... */
+    return (delta >= 41) && (delta <= 43);
   });
 });


### PR DESCRIPTION
Chrome does some off floating point operations that results in `getBoundingClientRect()` returning a value that's one pixel off when zoomed out.
