### PR TITLE
Add test for ES6 Promises

### DIFF
--- a/feature-detects/es6/promises.js
+++ b/feature-detects/es6/promises.js
@@ -1,0 +1,44 @@
+/*!
+{
+  "name": "ES6 Promises",
+  "property": "promises",
+  "caniuse": "promises",
+  "polyfills": ["es6promises"],
+  "authors": ["Krister Kari", "Jake Archibald"],
+  "tags": ["es6"],
+  "notes": [{
+    "name": "The ES6 promises spec",
+    "href": "https://github.com/domenic/promises-unwrapping"
+  },{
+    "name": "Chromium dashboard - ES6 Promises",
+    "href": "http://www.chromestatus.com/features/5681726336532480"
+  },{
+    "name": "JavaScript Promises: There and back again - HTML5 Rocks",
+    "href": "http://www.html5rocks.com/en/tutorials/es6/promises/"
+  }]
+}
+!*/
+/* DOC
+
+Check if browser implements ECMAScript 6 Promises per specification.
+
+*/
+define(['Modernizr'], function( Modernizr ) {
+  Modernizr.addTest('promises', function() {
+    return 'Promise' in window &&
+    // Some of these methods are missing from
+    // Firefox/Chrome experimental implementations
+    'cast' in window.Promise &&
+    'resolve' in window.Promise &&
+    'reject' in window.Promise &&
+    'all' in window.Promise &&
+    'race' in window.Promise &&
+    // Older version of the spec had a resolver object
+    // as the arg rather than a function
+    (function() {
+      var resolve;
+      new window.Promise(function(r) { resolve = r; });
+      return typeof resolve === 'function';
+    }());
+  });
+});

--- a/lib/config-all.json
+++ b/lib/config-all.json
@@ -114,6 +114,7 @@
     "test/es5/strictmode",
     "test/es5/string",
     "test/es6/contains",
+    "test/es6/promises",
     "test/event/deviceorientation-motion",
     "test/event/oninput",
     "test/exif-orientation",

--- a/lib/polyfills.json
+++ b/lib/polyfills.json
@@ -693,5 +693,11 @@
     "authors": ["Remy Sharp"],
     "href": "http://remysharp.com/2008/06/30/maxlength-plugin/",
     "licenses": ["CC SA"]
+  },
+  "es6promises": {
+    "name": "ES6-Promises",
+    "authors": ["Jake Archibald"],
+    "href": "https://github.com/jakearchibald/ES6-Promises",
+    "licenses": ["MIT"]
   }
 }


### PR DESCRIPTION
[This feature test is from Jake Archibald's ES6 Promises polyfill](https://github.com/jakearchibald/ES6-Promises/blob/master/lib/promise/polyfill.js).

Quick browser test:
Firefox 26 returns `false`
Chrome 31.0.1650.63 returns `false`
Chrome 34.0.1766.0 canary returns `true`
