### PR TITLE
Fixed saucelab issues fixes #1133

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ node_js:
 before_script: 
   - npm install grunt-cli -g
   - grunt build
-script: grunt travis --verbose
+script: grunt travis
 env: 
   global: 
   - secure: noRIQS5Wv/9SFs4bK+0NZNQ7nnL+WfP6PhkPQR5QxNmXR1S4wjdiHy4/yv4aO/j1URgFw1YiFf+80k7YIn/9vIT+lMzE0wiw5FXTQM9PIB2mPHC2wzc0Y1Xj5kfuFXZemWTt73y1IkT53PjxezslVSduPKTxjXJuPmUk2FG3yaw=

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -200,10 +200,10 @@ module.exports = function( grunt ) {
     'saucelabs-qunit': {
       all: {
         options: {
-          urls: ['http://127.0.0.1:9999/test/basic.html'],
+          urls: ['http://localhost:9999/test/basic.html'],
           tunnelTimeout: 5,
           build: process.env.TRAVIS_JOB_ID,
-          concurrency: 2,
+          concurrency: 3,
           browsers: browsers,
           testname: 'qunit tests',
           tags: ['master', '<%= pkg.version %>']
@@ -254,7 +254,7 @@ module.exports = function( grunt ) {
   grunt.registerTask('sauce', ['connect', 'saucelabs-qunit']);
 
   // Travis CI task.
-  grunt.registerTask('travis', ['test']);
+  grunt.registerTask('travis', ['jshint', 'sauce']);
 
   // Build
   grunt.registerTask('build', ['clean', 'generateinit', 'requirejs', 'copy', 'clean:postbuild', 'stripdefine', 'uglify']);

--- a/feature-detects/crypto/getrandomvalues.js
+++ b/feature-detects/crypto/getrandomvalues.js
@@ -20,5 +20,5 @@ Detects support for the window.crypto.getRandomValues for generate cryptographic
 
 */
 define(['Modernizr'], function( Modernizr ) {
-  Modernizr.addTest('getrandomvalues', 'crypto' in window && 'getRandomValues' in window.crypto);
+  Modernizr.addTest('getrandomvalues', !!(window.crypto && 'crypto' in window && 'getRandomValues' in window.crypto));
 });

--- a/feature-detects/event/oninput.js
+++ b/feature-detects/event/oninput.js
@@ -52,6 +52,8 @@ define(['Modernizr', 'docElement', 'createElement', 'testStyles', 'hasEvent'], f
       input.removeEventListener('input', handler, false);
       docElement.removeChild(input);
       return supportsOnInput;
-    } catch (e) {}
+    } catch (e) {
+      return false;
+    }
   });
 });

--- a/feature-detects/video/autoplay.js
+++ b/feature-detects/video/autoplay.js
@@ -23,7 +23,11 @@ define(['Modernizr', 'addTest', 'docElement', 'createElement', 'test/video'], fu
       clearTimeout(timeout);
       elem.removeEventListener('playing', testAutoplay);
       addTest('videoautoplay', called || elem.currentTime !== 0);
-      elem.parentNode.removeChild(elem);
+      // Safar 5 & 6 can sometimes get in a weird state where
+      // this will run twice and on the second run elem is already removed.
+      if (elem && elem.parentNode) {
+        elem.parentNode.removeChild(elem);
+      }
     };
 
     //skip the test if video itself, or the autoplay

--- a/lib/sauce-browsers.json
+++ b/lib/sauce-browsers.json
@@ -1,56 +1,46 @@
 [
 	{
-        "browserName": "firefox",
-        "platform": "WIN7"
-    },{
-        "browserName": "chrome",
-        "platform": "linux"
-    }, {
-        "browserName": "internet explorer",
-        "platform": "WIN8",
-        "version": "10"
-    }, {
-        "browserName": "internet explorer",
-        "platform": "VISTA",
-        "version": "9"
-    }, {
-        "browserName": "internet explorer",
-        "platform": "XP",
-        "version": "8"
-    }, {
-        "browserName": "internet explorer",
-        "platform": "XP",
-        "version": "7"
-    }, {
-        "browserName": "internet explorer",
-        "platform": "XP",
-        "version": "6"
-    }, {
-        "browserName": "opera",
-        "platform": "WIN7",
-        "version": "12"
-    }, {
-	    "browserName": "safari",
-	    "platform": "OS X 10.6",
-	    "version": "5"
+    "browserName": "chrome",
+    "platform": "linux"
+  }, {
+    "browserName": "internet explorer",
+    "platform": "WIN8",
+    "version": "10"
+  }, {
+    "browserName": "internet explorer",
+    "platform": "VISTA",
+    "version": "9"
+  }, {
+    "browserName": "internet explorer",
+    "platform": "XP",
+    "version": "8"
+  }, {
+    "browserName": "internet explorer",
+    "platform": "XP",
+    "version": "7"
+  }, {
+    "browserName": "internet explorer",
+    "platform": "XP",
+    "version": "6"
+  }, {
+    "browserName": "opera",
+    "platform": "WIN7",
+    "version": "12"
+  }, {
+    "browserName": "safari",
+    "platform": "OS X 10.6",
+    "version": "5"
 	}, {
-	    "browserName": "safari",
-	    "platform": "OS X 10.8",
-	    "version": "6"
-	}, {
-	    "browserName": "iphone",
-	    "platform": "OS X 10.8",
-	    "version": "5.1"
+    "browserName": "safari",
+    "platform": "OS X 10.8",
+    "version": "6" 
 	}, {
 		"browserName": "iphone",
-	    "platform": "OS X 10.8",
-	    "version": "6.0"
+    "platform": "OS X 10.8",
+    "version": "6.0"
 	}, {
-	    "browserName": "iphone",
-	    "platform": "OS X 10.8"
-	}, {
-	    "browserName": "android",
-	    "platform": "Linux",
-	    "version": "4.0"
+    "browserName": "android",
+    "platform": "Linux",
+    "version": "4.0"
 	}
 ]

--- a/test/js/setup.js
+++ b/test/js/setup.js
@@ -1,5 +1,5 @@
 // Avoid `console` errors in browsers that lack a console
-if (!(window.console && console.log)) {
+if (!(window.console && console.log && console.dir)) {
     (function() {
         var noop = function() {};
         var methods = ['assert', 'clear', 'count', 'debug', 'dir', 'dirxml', 'error', 'exception', 'group', 'groupCollapsed', 'groupEnd', 'info', 'log', 'markTimeline', 'profile', 'profileEnd', 'markTimeline', 'table', 'time', 'timeEnd', 'timeStamp', 'trace', 'warn'];
@@ -16,6 +16,7 @@ window.TEST = {
   // note some unique members of the Modernizr object
   inputs    : ['input','inputtypes', 'textarea'],
   audvid    : ['video','audio', 'webglextensions'],
+  flash     : ['flash'],
   columns   : ['csscolumns'],
   API       : ['addTest', 'mq', 'hasEvent', 'testProp', 'testAllProps', 'testStyles', '_prefixes', '_domPrefixes', '_cssomPrefixes', 'prefixed'],
   extraclass: ['js'],

--- a/test/js/unit.js
+++ b/test/js/unit.js
@@ -140,10 +140,9 @@ test('html classes are looking good',function(){
       getObject = function(aclass) {
         var classSplit = aclass.split('-');
         if(typeof Modernizr[aclass] != 'undefined') {
-          return Modernizr[aclass];
-        }
-        else if (classSplit.length == 2) {
-          return Modernizr[classSplit[0]][classSplit[1]];
+          return !!Modernizr[aclass];
+        } else if (classSplit.length == 2) {
+          return !!Modernizr[classSplit[0]][classSplit[1]];
         }
       };
 
@@ -213,6 +212,7 @@ test('Modernizr properties are looking good',function(){
 
   var nobool = TEST.API.concat(TEST.inputs)
                        .concat(TEST.audvid)
+                       .concat(TEST.flash)
                        .concat(TEST.privates)
                        .concat(TEST.columns)
                        .concat(['textarea', 'testtruthy', 'testfalsy']) // due to forms-placeholder.js test


### PR DESCRIPTION
- Change test address to localhost to fix saucelabs IE6 issue
- Make sure oninput test returns false when not supported
- Coerce undefined values so oldIE doesn't fail on csscolumns tests
- Add flash to removed tests
- Safari 5 throws when doing an in check on window.crypto
- Cast to boolean as Safari 6 complains
- Safari 5 & 6 fail randomly on autoplay test
