### PR TITLE
add literal period to history's blacklist, ensuring that its android 2 and not android 22

### DIFF
--- a/feature-detects/history.js
+++ b/feature-detects/history.js
@@ -30,9 +30,9 @@ define(['Modernizr'], function( Modernizr ) {
 
     // We only want Android 2, stock browser, and not Chrome which identifies
     // itself as 'Mobile Safari' as well
-    if (ua.indexOf('Android 2') !== -1 &&
+    if (ua.indexOf('Android 2.') !== -1 &&
         ua.indexOf('Mobile Safari') !== -1 &&
-          ua.indexOf('Chrome') === -1) {
+        ua.indexOf('Chrome') === -1) {
       return false;
     }
 


### PR DESCRIPTION
fixes #765
