### PR TITLE
add note about the silk browser having a false positive on box-shadow

### DIFF
--- a/feature-detects/css/boxshadow.js
+++ b/feature-detects/css/boxshadow.js
@@ -4,7 +4,10 @@
   "property": "boxshadow",
   "caniuse": "css-boxshadow",
   "tags": ["css"],
-  "knownBugs": ["WebOS false positives on this test."]
+  "knownBugs": [
+    "WebOS false positives on this test.",
+    "The Kindle Silk browser false positives"
+  ]
 }
 !*/
 define(['Modernizr', 'testAllProps'], function( Modernizr, testAllProps ) {


### PR DESCRIPTION
fixes #790

@ryanseddon says

> [I say we document that it fails and ref this issue in the code.](https://github.com/Modernizr/Modernizr/issues/790#issuecomment-12679344)

I agree.
