### PR TITLE
make xhr2 test more accurate with FF3.6

### DIFF
--- a/feature-detects/network/xhr2.js
+++ b/feature-detects/network/xhr2.js
@@ -19,7 +19,6 @@ Tests for XHR2.
 define(['Modernizr'], function( Modernizr ) {
   // all three of these details report consistently across all target browsers:
   //   !!(window.ProgressEvent);
-  //   !!(window.FormData);
-  //   window.XMLHttpRequest && "withCredentials" in new XMLHttpRequest;
-  Modernizr.addTest('xhr2', 'FormData' in window);
+  //   'XMLHttpRequest' in window && 'withCredentials' in new XMLHttpRequest
+  Modernizr.addTest('xhr2', 'XMLHttpRequest' in window && 'withCredentials' in new XMLHttpRequest());
 });


### PR DESCRIPTION
fixes #1020
even though "We don't actually support FF3.6", no reason not to have a test that is more accurate there.

cc @ryanseddon
