### PR TITLE
Let .hasEvent work with array iteration methods.

### DIFF
--- a/src/isEventSupported.js
+++ b/src/isEventSupported.js
@@ -13,17 +13,17 @@ define(['ModernizrProto', 'createElement'], function( ModernizrProto, createElem
     var needsFallback = !('onblur' in document.documentElement);
 
     /**
-     * @param  {string|*}           eventName  is the name of an event to test for (e.g. "resize")
-     * @param  {(Object|string|*)=} element    is the element|document|window|tagName to test on
+     * @this {*} is used as `element` for array-style iterations
+     * @param {!string} eventName is the name of an event to test for (e.g. "resize")
+     * @param {(Node|Window|string|number)=} element is a tagname or object to test on
      * @return {boolean}
      */
     function isEventSupportedInner( eventName, element ) {
 
       var isSupported;
       if ( !eventName ) { return false; }
-      if ( !element || typeof element === 'string' ) {
-        element = createElement(element || 'div');
-      }
+      element = typeof element === 'number' ? this && this.valueOf() : element;
+      element = typeof element !== 'string' && element || createElement(element || 'div');
 
       // Testing via the `in` operator is sufficient for modern browsers and IE.
       // When using `setAttribute`, IE skips "unload", WebKit skips "unload" and


### PR DESCRIPTION
This simple change lets `.hasEvent(event, element?)` work with methods like `array.every` or `array.filter`. It checks if `element` is a number and if so it uses `this` as the `element`.

``` js
['drag', 'dragend'].every(Modernizr.hasEvent) // uses 'div' in strict mode, `window` in non-strict
['drag', 'dragend'].every(Modernizr.hasEvent, 'img') // creates element on each iteration
['drag', 'dragend'].every(Modernizr.hasEvent, document.createElement('img')) // reuses element
```

Explicitly supplying the <var>thisArg</var> avoids the strict mode difference.
