### PR TITLE
Simplify Shapes test

### DIFF
--- a/feature-detects/css/shapes.js
+++ b/feature-detects/css/shapes.js
@@ -15,19 +15,6 @@
   }]
 }
 !*/
-define(['Modernizr', 'createElement', 'docElement', 'prefixed', 'testStyles'], function(Modernizr, createElement, docElement, prefixed, testStyles ) {
-    Modernizr.addTest('shapes', function () {
-        var prefixedProperty = prefixed('shapeOutside');
-
-        if (!prefixedProperty)
-            return false;
-
-        var shapeOutsideProperty = prefixedProperty.replace(/([A-Z])/g, function (str, m1) { return '-' + m1.toLowerCase(); }).replace(/^ms-/, '-ms-');
-
-        return testStyles('#modernizr { float: left; ' + shapeOutsideProperty + ':rectangle(0,0,0,0,0,0) }', function (elem) {
-            // Check against computed value
-            var styleObj = window.getComputedStyle ? getComputedStyle(elem, null) : elem.currentStyle;
-            return styleObj[prefixed('shapeOutside', docElement.style, false)] == 'rectangle(0px, 0px, 0px, 0px, 0px, 0px)';
-        });
-    });
+define(['Modernizr', 'testAllProps'], function( Modernizr, testAllProps ) {
+    Modernizr.addTest('shapes', testAllProps('shapeOutside', 'content-box', true));
 });


### PR DESCRIPTION
Shapes specification changed to support <box> values and the specification is in last call, so we can simplify the shapes test.
