### PR TITLE
adds "noPrefixes" option, to opt-out vendor prefix check, fixes #1082

### DIFF
--- a/src/ModernizrProto.js
+++ b/src/ModernizrProto.js
@@ -7,7 +7,8 @@ define(['tests'], function ( tests ) {
     // can go in here as configuration.
     _config: {
       classPrefix : '',
-      enableClasses : true
+      enableClasses : true,
+      usePrefixes : true
     },
 
     // Queue of tests

--- a/src/cssomPrefixes.js
+++ b/src/cssomPrefixes.js
@@ -1,5 +1,5 @@
 define(['ModernizrProto', 'omPrefixes'], function( ModernizrProto, omPrefixes ) {
-  var cssomPrefixes = omPrefixes.split(' ');
+  var cssomPrefixes = (ModernizrProto._config.usePrefixes ? omPrefixes.split(' ') : []);
   ModernizrProto._cssomPrefixes = cssomPrefixes;
   return cssomPrefixes;
 });

--- a/src/domPrefixes.js
+++ b/src/domPrefixes.js
@@ -1,5 +1,5 @@
 define(['ModernizrProto', 'omPrefixes'], function( ModernizrProto, omPrefixes ) {
-  var domPrefixes = omPrefixes.toLowerCase().split(' ');
+  var domPrefixes = (ModernizrProto._config.usePrefixes ? omPrefixes.toLowerCase().split(' ') : []);
   ModernizrProto._domPrefixes = domPrefixes;
   return domPrefixes;
 });

--- a/src/noPrefixes.js
+++ b/src/noPrefixes.js
@@ -1,0 +1,5 @@
+define(['ModernizrProto'], function( ModernizrProto ) {
+  var usePrefixes = false;
+  ModernizrProto._config.usePrefixes = usePrefixes;
+  return usePrefixes;
+});

--- a/src/prefixes.js
+++ b/src/prefixes.js
@@ -1,6 +1,6 @@
 define(['ModernizrProto'], function( ModernizrProto ) {
   // List of property values to set for css tests. See ticket #21
-  var prefixes = ' -webkit- -moz- -o- -ms- '.split(' ');
+  var prefixes = (ModernizrProto._config.usePrefixes ? ' -webkit- -moz- -o- -ms- '.split(' ') : []);
 
   // expose these for the plugin API. Look in the source for how to join() them against your input
   ModernizrProto._prefixes = prefixes;


### PR DESCRIPTION
Based upon https://github.com/Modernizr/Modernizr/issues/1082. By adding `noPrefixes` to the config options, a flag is set to empty the vendor prefixes array used by testAllProps.

Checkout https://github.com/Modernizr/Modernizr/issues/1082#issuecomment-32118659 for details.
