### PR TITLE
Add querySelector test, addresses #1194

### DIFF
--- a/feature-detects/queryselector.js
+++ b/feature-detects/queryselector.js
@@ -8,7 +8,8 @@
   "notes": [{
     "name" : "W3C Selectors reference",
     "href": "http://www.w3.org/TR/selectors-api/#queryselectorall"
-  }]
+  }],
+  "polyfills": ["css-selector-engine"]
 }
 !*/
 /* DOC

--- a/lib/polyfills.json
+++ b/lib/polyfills.json
@@ -706,5 +706,11 @@
     "authors": ["Jake Archibald"],
     "href": "https://github.com/jakearchibald/ES6-Promises",
     "licenses": ["MIT"]
+  },
+  "css-selector-engine": {
+    "name": "CSS Selector Engine",
+    "authors": ["Егор Халимоненко"],
+    "href": "https://github.com/termi/CSS_selector_engine",
+    "licenses": ["MIT"]
   }
 }


### PR DESCRIPTION
Wasn't sure whether document should be an injected dependency, but the convention seems to be to assume it's a global, so have followed that.
