### PR TITLE
Added ability to extend the default html5shiv list of elements

### DIFF
--- a/src/html5shiv.js
+++ b/src/html5shiv.js
@@ -247,7 +247,18 @@ define(function() {
        * @memberOf html5
        * @type Array|String
        */
-      'elements': options.elements || 'abbr article aside audio bdi canvas data datalist details figcaption figure footer header hgroup main mark meter nav output progress section summary time video',
+      'elements': (function () {
+        var elements = 'abbr article aside audio bdi canvas data datalist details figcaption figure footer header hgroup main mark meter nav output progress section summary time video';
+        if (options.elements) {
+          if (options.extendElementsList) {
+            elements = elements + ' ' + options.elements;
+          } else {
+            elements = options.elements;
+          } 
+        }
+        
+        return elements;
+      })(),
 
       /**
        * current version of html5shiv


### PR DESCRIPTION
In order to e.g. run html5shiv over svg elements as well as the standard html5 ones without having to know anything about the default list's contents
