### PR TITLE
Add test for HTML Imports

### DIFF
--- a/feature-detects/htmlimports.js
+++ b/feature-detects/htmlimports.js
@@ -1,0 +1,22 @@
+/*!
+{
+  "name": "HTML Imports",
+  "notes": [
+    {
+      "name": "W3C HTML Imports Specification",
+      "href": "http://w3c.github.io/webcomponents/spec/imports/"
+    },
+    {
+      "name": "HTML Imports - #include for the web",
+      "href": "http://www.html5rocks.com/en/tutorials/webcomponents/imports/"
+    }
+  ],
+  "polyfills": ["polymer-htmlimports"],
+  "property": "htmlimports",
+  "tags": ["html", "import"]
+}
+!*/
+
+define(['Modernizr'], function ( Modernizr ) {
+  Modernizr.addTest('htmlimports', 'import' in document.createElement('link'));
+});

--- a/lib/config-all.json
+++ b/lib/config-all.json
@@ -140,6 +140,7 @@
     "test/hashchange",
     "test/hiddenscroll",
     "test/history",
+    "test/htmlimports",
     "test/ie8compat",
     "test/iframe/sandbox",
     "test/iframe/seamless",

--- a/lib/polyfills.json
+++ b/lib/polyfills.json
@@ -712,5 +712,11 @@
     "authors": ["Егор Халимоненко"],
     "href": "https://github.com/termi/CSS_selector_engine",
     "licenses": ["MIT"]
+  },
+  "polymer-htmlimports": {
+    "authors": ["Google Inc."],
+    "href": "https://github.com/polymer/HTMLImports",
+    "licenses": ["BSD"],
+    "name": "Polymer HTMLImports polyfill"
   }
 }

--- a/test/modular.html
+++ b/test/modular.html
@@ -101,6 +101,7 @@
     "test/forms/placeholder",
     "test/forms/speechinput",
     "test/forms/validation",
+    "test/htmlimports",
     "test/iframe/sandbox",
     "test/iframe/seamless",
     "test/iframe/srcdoc",


### PR DESCRIPTION
- Test page: http://jsbin.com/lineheco/1
  
  AFAIK, this feature is only available in Chrome with the appropriate flag enabled:
  
  ![](https://f.cloud.github.com/assets/1223565/2241141/7575772c-9cc2-11e3-95bd-dcf28616d446.png)
- Useful links:
  - [W3C HTML Imports Specification](http://w3c.github.io/webcomponents/spec/imports/)
  - [HTML5Rocks: HTML Imports](http://www.html5rocks.com/en/tutorials/webcomponents/imports/)
## 

Let me know if I need to make any other changes.
