### PR TITLE
Added test for postMessage structured clones

### DIFF
--- a/feature-detects/postmessage.js
+++ b/feature-detects/postmessage.js
@@ -5,14 +5,24 @@
   "caniuse": "x-doc-messaging",
   "notes": [{
     "name": "W3C Spec",
-    "href": "https://www.w3.org/TR/html5/comms.html#posting-messages"
+    "href": "https://www.w3.org/TR/webmessaging/#crossDocumentMessages"
   }],
-  "polyfills": ["easyxdm", "postmessage-jquery"]
+  "polyfills": ["easyxdm", "postmessage-jquery"],
+  "knownBugs": ["structuredclones - Android 2&3 can not send a structured clone of dates, filelists or regexps"],
+  "warnings": ["Some old WebKit versions have bugs. Stick with object, array, number and pixeldata to be safe."]
 }
 !*/
 /* DOC
 Detects support for the `window.postMessage` protocol for cross-document messaging.
+`Modernizr.postmessage.structuredclones` reports if `postMessage` can send objects.
 */
-define(['Modernizr'], function(Modernizr) {
-  Modernizr.addTest('postmessage', 'postMessage' in window);
+define(['Modernizr'], function( Modernizr ) {
+  var support = new Boolean('postMessage' in window);
+  support.structuredclones = true;
+
+  try {
+    window.postMessage({ toString: function () { support.structuredclones = false; } }, '*');
+  } catch (e) {}
+
+  Modernizr.addTest('postmessage', support);
 });


### PR DESCRIPTION
Implemented the test discussed in Issue #388.

The name `postmessagestructuredclones` is terribly long. Other name suggestions?

Noticed the can-i-use test forces partial support to boolean true. So to test this with can-i-use I have to modify the `testify` function to handle partial support => false for only this test. But then I noticed the caniuse have some errors in their browser-support, so probably should contact Alexis to fix that first anyways...
