### PR TITLE
Change `fnBind` to a normal lib function instead of a polyfill

### DIFF
--- a/src/fnBind.js
+++ b/src/fnBind.js
@@ -1,48 +1,56 @@
 define(['slice'], function( slice ) {
-  // Adapted from ES5-shim https://github.com/kriskowal/es5-shim/blob/master/es5-shim.js
-  // es5.github.com/#x15.3.4.5
+  // Not implemented as a polyfill, as that would change the environment,
+  // which isn’t something Modernizr should do
 
-  if (!Function.prototype.bind) {
-    Function.prototype.bind = function bind(that) {
-
-      var target = this;
-
-      if (typeof target != 'function') {
-        throw new TypeError();
-      }
-
-      var args = slice.call(arguments, 1);
-      var bound = function() {
-
-        if (this instanceof bound) {
-
-          var F = function(){};
-          F.prototype = target.prototype;
-          var self = new F();
-
-          var result = target.apply(
-            self,
-            args.concat(slice.call(arguments))
-          );
-          if (Object(result) === result) {
-            return result;
-          }
-          return self;
-
-        } else {
-
-          return target.apply(
-            that,
-            args.concat(slice.call(arguments))
-          );
-
-        }
-
-      };
-
-      return bound;
+  // Defer to native .bind if available
+  if ('bind' in Function.prototype) {
+    return function fnBind (fn, that) {
+      return fn.bind(that);
     };
   }
 
-  return Function.prototype.bind;
+  // Adapted from ES5-shim https://github.com/kriskowal/es5-shim/blob/master/es5-shim.js
+  // es5.github.com/#x15.3.4.5
+  function fnBind (fn, that) {
+
+    var target = fn;
+
+    if (typeof target != 'function') {
+      throw new TypeError();
+    }
+
+    var args = slice.call(arguments, 2);
+    var bound = function() {
+
+      if (fn instanceof bound) {
+
+        var F = function(){};
+        F.prototype = target.prototype;
+        var self = new F();
+
+        var result = target.apply(
+          self,
+          args.concat(slice.call(arguments))
+        );
+        if (Object(result) === result) {
+          return result;
+        }
+        return self;
+
+      } else {
+
+        return target.apply(
+          that,
+          args.concat(slice.call(arguments))
+        );
+
+      }
+
+    };
+
+    return bound;
+
+  }
+
+  return fnBind;
 });

--- a/src/testDOMProps.js
+++ b/src/testDOMProps.js
@@ -1,4 +1,4 @@
-define(['is', 'fnBind'], function( is ) {
+define(['is', 'fnBind'], function( is, fnBind ) {
   /**
    * testDOMProps is a generic DOM property test; if a browser supports
    *   a certain property, it won't return undefined for it.
@@ -14,11 +14,10 @@ define(['is', 'fnBind'], function( is ) {
 
         item = obj[props[i]];
 
-        // let's bind a function (and it has a bind method -- certain native objects that report that they are a
-        // function don't [such as webkitAudioContext])
-        if (is(item, 'function') && 'bind' in item){
-          // default to autobind unless override
-          return item.bind(elem || obj);
+        // let's bind a function
+        if (is(item, 'function')) {
+          // bind to obj unless overriden
+          return fnBind(item, elem || obj);
         }
 
         // return the unbound function or obj or value

--- a/test/js/unit.js
+++ b/test/js/unit.js
@@ -1,4 +1,4 @@
-/*global module, ok, equal, test, expect, raises, animationStyle */
+/*global module, ok, equal, test, expect, animationStyle */
 // PhantomJS timesout so leave autostart on
 if(navigator.userAgent.indexOf('PhantomJS') === -1) {
   QUnit.config.autostart = false;
@@ -17,65 +17,6 @@ module('Basics', {
 test('globals set up', function() {
   ok(window.Modernizr, 'global modernizr object created');
 });
-
-test('bind is implemented', function() {
-
-  ok(Function.prototype.bind, 'bind is a member of Function.prototype');
-
-  var a = function(){
-    return this.modernizr;
-  };
-  a = a.bind({modernizr: 'just awsome'});
-
-  equal('just awsome', a(), 'bind works as expected');
-
-
-  // thank you webkit layoutTests
-
-
-  var result;
-
-  function F(x, y) {
-    result = this + ' -> x:' + x + ', y:' + y;
-  }
-
-  var G = F.bind('"a"', '"b"');
-  var H = G.bind('"Cannot rebind this!"', '"c"');
-
-  G(1,2);
-  equal(result, '"a" -> x:"b", y:1');
-  H(1,2);
-  equal(result, '"a" -> x:"b", y:"c"');
-
-  var f = new F(1,2);
-  equal(result, '[object Object] -> x:1, y:2');
-  var g = new G(1,2);
-  equal(result, '[object Object] -> x:"b", y:1');
-  var h = new H(1,2);
-  equal(result, '[object Object] -> x:"b", y:"c"');
-
-  ok(f instanceof F, 'f instanceof F');
-  ok(g instanceof F, 'g instanceof F');
-  ok(h instanceof F, 'h instanceof F');
-
-  // Bound functions don't have a 'prototype' property.
-  ok('prototype' in F, '"prototype" in F');
-
-  // The object passed to bind as 'this' must be callable.
-  raises(function(){
-    Function.bind.call(undefined);
-  });
-
-  // Objects that allow call but not construct can be bound, but should throw if used with new.
-  var abcAt = String.prototype.charAt.bind('abc');
-  equal(abcAt(1), 'b', 'Objects that allow call but not construct can be bound...');
-
-  equal(1, Function.bind.length, 'it exists');
-
-
-});
-
-
 
 test('document.documentElement is valid and correct',1, function() {
   equal(document.documentElement,document.getElementsByTagName('html')[0]);


### PR DESCRIPTION
I know [we document it](http://modernizr.com/docs/#prefixeddom), but it’s pretty hidden and [might surprise some people](https://twitter.com/SteveWilshaw/status/448147756755218433). Also it could cause the fn.bind detect to fail (haven’t checked this though) – and generally I don’t think Modernizr should be changing the environment that low down, certainly not without an explicit opt-in.

It was added way back in #478, but that ticket ended up just discussing the API for `prefixed()` and didn’t discuss whether to polyfill or implement as a library function.

Also relevant: [this chap](http://webreflection.blogspot.co.uk/2014/03/do-not-require-polyfills.html) reckons polyfills shouldn’t be AMD dependencies – and I think I agree. Maybe.
