### PR TITLE
Test errors in some browsers

### DIFF
--- a/feature-detects/crypto/getrandomvalues.js
+++ b/feature-detects/crypto/getrandomvalues.js
@@ -18,5 +18,7 @@
 Detects support for the window.crypto.getRandomValues for generate cryptographically secure random numbers
 */
 define(['Modernizr'], function( Modernizr ) {
-  Modernizr.addTest('getrandomvalues', 'crypto' in window && 'getRandomValues' in window.crypto);
+  // In Safari <=5.0 `window.crypto` exists (for some reason) but is `undefined`, so we have to check
+  // it’s truthy before checking for existence of `getRandomValues`
+  Modernizr.addTest('getrandomvalues', 'crypto' in window && !!window.crypto && 'getRandomValues' in window.crypto);
 });

--- a/feature-detects/css/supports.js
+++ b/feature-detects/css/supports.js
@@ -18,6 +18,5 @@
 !*/
 define(['Modernizr'], function( Modernizr ) {
   // Relies on the fact that a browser vendor should expose the CSSSupportsRule interface
-
-  Modernizr.addTest('supports', 'SUPPORTS_RULE' in window.CSSRule);
+  Modernizr.addTest('supports', 'CSSRule' in window && 'SUPPORTS_RULE' in window.CSSRule);
 });


### PR DESCRIPTION
- On IE <=8, the `supports` detect throws:
  
  ```
  Object expected
  ```
- On IE <=8, the `flash` detect throws (with no useful line num unfortunately):
  
  ```
  HTML Parsing Error: Unable to modify the parent container element before the child
  ```
- On Safari <=5.0, the `getrandomvalues` detect throws:
  
  ```
  TypeError: Result of expression 'window.crypto' [undefined] is not a valid argument for 'in'.
  ```
