### PR TITLE
[REGRESSION] fix IE8 exception caused by CSS @supports detect

### DIFF
--- a/feature-detects/css/supports.js
+++ b/feature-detects/css/supports.js
@@ -19,5 +19,5 @@
 define(['Modernizr'], function( Modernizr ) {
   // Relies on the fact that a browser vendor should expose the CSSSupportsRule interface
 
-  Modernizr.addTest('supports', 'SUPPORTS_RULE' in window.CSSRule);
+  Modernizr.addTest('supports', 'CSSRule' in window && 'SUPPORTS_RULE' in window.CSSRule);
 });


### PR DESCRIPTION
This detect was originally discussed in the following issues:
- https://github.com/Modernizr/Modernizr/issues/648
- https://github.com/Modernizr/Modernizr/issues/1226

This following commit introduced an exception when run in IE8:
- https://github.com/Modernizr/Modernizr/commit/31371a95cf170e2e8214a1d179ad8bf8b0d4b755

This pull request adds an additional check so that the existence of the global `CSSRule` object is not assumed. This is not currently reproducible using the Modernizr.com production / stable version (e.g. 2.7.x), but is demonstrable with the current master branch.

I propose that this block the v3 milestone.

Also, as I'm not 100% sure of the intent for this detect, it might be a good idea for @ryanseddon and @patrickkettner to double-check my work.
