### PR TITLE
mathml: fix missing AMD dependency on testStyles

### DIFF
--- a/feature-detects/mathml.js
+++ b/feature-detects/mathml.js
@@ -14,14 +14,14 @@
 /* DOC
 Detects support for MathML, for mathematic equations in web pages.
 */
-define(['Modernizr'], function( Modernizr ) {
+define(['Modernizr', 'testStyles'], function( Modernizr, testStyles ) {
   // Based on work by Davide (@dpvc) and David (@davidcarlisle)
   // in https://github.com/mathjax/MathJax/issues/182
 
   Modernizr.addTest('mathml', function() {
     var ret;
 
-    Modernizr.testStyles('#modernizr{position:absolute}', function(node){
+    testStyles('#modernizr{position:absolute}', function(node){
       node.innerHTML = '<math><mfrac><mi>xx</mi><mi>yy</mi></mfrac></math>';
 
       ret = node.offsetHeight > node.offsetWidth;


### PR DESCRIPTION
If the MathML detect is the only enabled detect, then the produced build of Modernizr will break at runtime.

In this PR, I ensure that the `testStyles` function is declared as a dependency.
