### PR TITLE
Update build.js

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -49,7 +49,7 @@ module.exports = function (opts, callback) {
     }
   }
 
-  var build = cp.spawn(__dirname + '/../node_modules/.bin/' + 'grunt', ['build'], {
+  var build = cp.exec(__dirname + '/../node_modules/.bin/' + 'grunt', ['build'], {
     stdio: verbose ? 'inherit' : [0, 'pipe', 2],
     cwd: localRoot
   });


### PR DESCRIPTION
Is it necessary the `cp.spawn` calling in /lib/build.js? Seems it can be simplified to `cp.exec` to be compatible in windows environment.
