### PR TITLE
fix: `this` refers to the global object

### DIFF
--- a/src/ModernizrProto.js
+++ b/src/ModernizrProto.js
@@ -23,8 +23,9 @@ define(['tests'], function ( tests ) {
       // synchronous tests. I would leave it out, but the code
       // to *disallow* sync tests in the real version of this
       // function is actually larger than this.
+      var self = this;
       setTimeout(function() {
-        cb(this[test]);
+        cb(self[test]);
       }, 0);
     },
 


### PR DESCRIPTION
hence the callback doesn't receive the test argument
