### PR TITLE
Add test for `picture` element support, per the proposed spec/impl. currently underway.

### DIFF
--- a/feature-detects/elem/picture.js
+++ b/feature-detects/elem/picture.js
@@ -1,0 +1,18 @@
+/*!
+{
+  "name": "picture Element",
+  "property": "picture",
+  "tags": ["elem"],
+  "authors": ["Scott Jehl", "Mat Marquis"],
+  "notes": [{
+    "name": "Specification",
+    "href": "http://picture.responsiveimages.org"
+  },{
+    "name": "Relevant spec issue",
+    "href": "https://github.com/ResponsiveImagesCG/picture-element/issues/87"
+  }]
+}
+!*/
+define(['Modernizr', 'createElement'], function( Modernizr ) {
+  Modernizr.addTest('picture', 'HTMLPictureElement' in window );
+});


### PR DESCRIPTION
I understand if you guys want to hold off on merging this one until we see some real-world implementations, but wanted to sneak this over to you in advance—we made sure to add `window.HTMLPictureElement` to the spec for the sake of easy testing. Happy to own any feature testing issues that should pop up when this thing starts landing in stable browsers, as well.
