### PR TITLE
Test for `sizes` attribute support on `img`.

### DIFF
--- a/feature-detects/img/sizes.js
+++ b/feature-detects/img/sizes.js
@@ -1,0 +1,21 @@
+/*!
+{
+  "name": "sizes attribute",
+  "property": "sizes",
+  "tags": ["image"],
+  "authors": ["Mat Marquis"],
+  "notes": [{
+    "name": "Spec",
+    "href": "http://picture.responsiveimages.org/#parse-sizes-attr"
+    },{
+    "name": "Usage Details",
+    "href": "http://ericportis.com/posts/2014/srcset-sizes/"
+    }]
+}
+!*/
+/* DOC
+Test for the `sizes` attribute on images
+*/
+define(['Modernizr', 'createElement'], function( Modernizr, createElement ) {
+  Modernizr.addTest('sizes', 'sizes' in createElement('img'));
+});


### PR DESCRIPTION
I like these easy ones.

Presumably this will be landing everywhere at the same time as `picture`, so support for `sizes`/`srcset` on `source` can likely be assumed based on the overarching `picture` test that landed yesterday ( abc570790ec92321b488991eb42363883471dbf1 ). I’ll be keeping an eye on this whether I like it or not, though, so I can revisit with a separate test on `picture > source` if `sizes` rolls out to `img` and `source` separately in any UA.
