### PR TITLE
The this scope isn't always the expected window.

### DIFF
--- a/lib/processbuild.js
+++ b/lib/processbuild.js
@@ -7,7 +7,7 @@ var mod = fs.readFileSync(__dirname + '/dist/modernizr-build.js', 'utf8');
 var license = fs.readFileSync(__dirname + '/LICENSE', 'utf8');
 
 mod = mod.replace('define("modernizr-init",[], function(){});', '');
-mod = license + '\n;(function(window, document, undefined){\n' + mod + '\n})(this, document);';
+mod = license + '\n;(function(window, document, undefined){\n' + mod + '\n})(window, document);';
 
 fs.writeFileSync(__dirname + '/dist/modernizr-build.js', mod, 'utf8');
 


### PR DESCRIPTION
When Modernizr is loaded within a scope, it breaks. So make sure it get's exported to the window scope.
