### PR TITLE
Remove "cast" from Promise test

### DIFF
--- a/feature-detects/es6/promises.js
+++ b/feature-detects/es6/promises.js
@@ -26,7 +26,6 @@ define(['Modernizr'], function( Modernizr ) {
     return 'Promise' in window &&
     // Some of these methods are missing from
     // Firefox/Chrome experimental implementations
-    'cast' in window.Promise &&
     'resolve' in window.Promise &&
     'reject' in window.Promise &&
     'all' in window.Promise &&


### PR DESCRIPTION
[It looks like Promise.cast was killed a while ago](https://github.com/domenic/promises-unwrapping/issues/98), so no need to test for it.

[Jake did the same change in his Polyfill](https://github.com/jakearchibald/es6-promise/commit/baa0195a4453d87031e276ac35e5a1aa24a7bb18), so I think that this change should be safe.
