### PR TITLE
Add test for the `Beacon API`

### DIFF
--- a/feature-detects/network/beacon.js
+++ b/feature-detects/network/beacon.js
@@ -1,0 +1,21 @@
+/*!
+{
+  "name": "Beacon API",
+  "notes": [{
+    "name": "MDN documentation",
+    "href": "https://developer.mozilla.org/en-US/docs/Web/API/navigator.sendBeacon"
+  },{
+    "name": "W3C specification",
+    "href": "https://dvcs.w3.org/hg/webperf/raw-file/tip/specs/Beacon/Overview.html"
+  }],
+  "property": "beacon",
+  "tags": ["beacon", "network"],
+  "authors": ["Cătălin Mariș"]
+}
+!*/
+/* DOC
+Detects support for an API that allows for asynchronous transfer of small HTTP data from the client to a server.
+*/
+define(['Modernizr'], function( Modernizr ) {
+  Modernizr.addTest('beacon', 'sendBeacon' in navigator);
+});

--- a/lib/config-all.json
+++ b/lib/config-all.json
@@ -174,6 +174,7 @@
     "test/json",
     "test/lists-reversed",
     "test/mathml",
+    "test/network/beacon",
     "test/network/connection",
     "test/network/eventsource",
     "test/network/xhr-responsetype-arraybuffer",

--- a/test/modular.html
+++ b/test/modular.html
@@ -107,6 +107,7 @@
     "test/img/apng",
     "test/img/webp-lossless",
     "test/img/webp",
+    "test/network/beacon",
     "test/network/connection",
     "test/network/eventsource",
     "test/network/xhr2",


### PR DESCRIPTION
- W3C Specification: https://dvcs.w3.org/hg/webperf/raw-file/tip/specs/Beacon/Overview.html
- Support for this API has [recently landed in `Blink`](https://codereview.chromium.org/232053005/), and it's already present in the [`Firefox Nightly Builds`](https://bugzilla.mozilla.org/show_bug.cgi?id=936340):
  
  ![](https://cloud.githubusercontent.com/assets/1223565/2928473/d26b9344-d77d-11e3-9ce7-c973ac70a74d.png)
