### PR TITLE
Add console.group method test

### DIFF
--- a/feature-detects/consolegroup.js
+++ b/feature-detects/consolegroup.js
@@ -1,0 +1,23 @@
+/*!
+{
+  "name": "Console Group Methods",
+  "property": "console.group",
+  "caniuse" : "console.group",
+  "notes": [{
+    "name": "MDN documentation",
+    "href": "https://developer.mozilla.org/en/docs/Web/API/console.group"
+  }, {
+    "name": "IEDC documentation",
+    "href": "http://msdn.microsoft.com/en-us/library/ie/dn265068(v=vs.85).aspx"
+  }]
+}
+!*/
+/* DOC
+Detects support for the console.group method and by extension support for console.groupEnd and console.groupCollapsed.
+*/
+define(['Modernizr'], function( Modernizr ) {
+  Modernizr.addTest(
+    'consolegroup',
+    (typeof console.group == 'function')
+  );
+});

--- a/lib/config-all.json
+++ b/lib/config-all.json
@@ -22,6 +22,7 @@
     "test/canvas/todataurl",
     "test/canvas",
     "test/canvastext",
+    "test/consolegroup",
     "test/contenteditable",
     "test/contentsecuritypolicy",
     "test/contextmenu",


### PR DESCRIPTION
Learned today that console.group/groupCollapsed/groupEnd is not universally known, specifically in [IE10 and below](http://msdn.microsoft.com/en-us/library/ie/dn265068%28v=vs.85%29.aspx), so needed to write my own test anyway.
