### PR TITLE
new detect: "bloblurls" for URL.createObjectURL, etc

### DIFF
--- a/feature-detects/url/bloburls.js
+++ b/feature-detects/url/bloburls.js
@@ -1,0 +1,19 @@
+/*!
+{
+  "name": "Blob URLs",
+  "property": "bloburls",
+  "caniuse": "bloburls",
+  "notes": [{
+    "name": "W3C Working Draft",
+    "href": "http://www.w3.org/TR/FileAPI/#creating-revoking"
+  }],
+  "tags": ["file", "url"],
+  "authors": ["Ron Waldon (@jokeyrhyme)"]
+}
+!*/
+/* DOC
+Detects support for creating Blob URLs
+*/
+define(['Modernizr'], function( Modernizr ) {
+  Modernizr.addTest('bloburls', 'URL' in window && 'revokeObjectURL' in URL && 'createObjectURL' in URL);
+});

--- a/lib/config-all.json
+++ b/lib/config-all.json
@@ -212,6 +212,7 @@
     "test/typed-arrays",
     "test/unicode",
     "test/unicode-range",
+    "test/url/bloburls",
     "test/url/data-uri",
     "test/userdata",
     "test/vibration",


### PR DESCRIPTION
This PR adds the feature detect discussed in #189, for `URL.createObjectURL`.

`Modernizr.bloburls` is `true` in Chrome, and `false` in Internet Explorer 8.
