### PR TITLE
Fix broken link in comment

### DIFF
--- a/feature-detects/css/animations.js
+++ b/feature-detects/css/animations.js
@@ -8,7 +8,7 @@
   "warnings": ["Android < 4 will pass this test, but can only animate a single property at a time"],
   "notes": [{
     "name" : "Article: 'Dispelling the Android CSS animation myths'",
-    "href": "http://goo.gl/CHVJm"
+    "href": "http://goo.gl/OGw5Gm"
   }]
 }
 !*/


### PR DESCRIPTION
The original link is http://daneden.me/2011/12/14/putting-up-with-androids-bullshit/ but as per 3e2b1ea42f62a58c5262a3e39d3d844c92d64510 a short URL is provided.
