### PR TITLE
Update documentation on the rationale for ignoring cookiesEnabled

### DIFF
--- a/feature-detects/cookies.js
+++ b/feature-detects/cookies.js
@@ -13,7 +13,11 @@ define(['Modernizr'], function( Modernizr ) {
   // https://github.com/Modernizr/Modernizr/issues/191
 
   Modernizr.addTest('cookies', function () {
-    // navigator.cookieEnabled is in IE9 but always true. Don't rely on it.
+    // navigator.cookieEnabled cannot detect custom or nuanced cookie blocking
+    // configurations. For example, when blocking cookies via the Advanced
+    // Privacy Settings in IE9, it always returns true. And there have been
+    // issues in the past with site-specific exceptions.
+    // Don't rely on it.
 
     // try..catch because some in situations `document.cookie` is exposed but throws a
     // SecurityError if you try to access it; e.g. documents created from data URIs


### PR DESCRIPTION
In [this issue](https://github.com/Modernizr/Modernizr/issues/666) it was reported that navigator.cookiesEnabled always returns `true` in IE9 but I did not find that to be the case

![screen shot 2014-05-22 at 12 04 37 pm](https://cloud.githubusercontent.com/assets/589564/3056643/f6c939f4-e1cc-11e3-8b5b-96386aefb9de.png)

To get it to return `false` I updated the cookie settings like so:
![screen shot 2014-05-22 at 12 05 02 pm](https://cloud.githubusercontent.com/assets/589564/3056654/1667bc0e-e1cd-11e3-94ba-285d9cd0e5aa.png)

However, I still think cookiesEnabled is unreliable since it does not do a good job of detecting nuanced cookie settings (first party vs third party, [site-specific exceptions](https://bugzilla.mozilla.org/show_bug.cgi?id=578534#c16)) reliably. For example, this setting in IE9, which for all intents and purposes is blocking cookies, returns `true` for cookiesEnabled

![screen shot 2014-05-22 at 12 06 37 pm](https://cloud.githubusercontent.com/assets/589564/3056710/c0173270-e1cd-11e3-8bb5-33d00ee0b147.png)

Just wanted to clarify the rationale in the comment so it's more accurate as to why we ignore this property. If anyone wants to re-word this, feel free.

Full Disclosure: These tests were done in one of the Windows 7 IE9 VMs that Microsoft distributes
