### PR TITLE
Add SVG foreignObject tag support detection.

### DIFF
--- a/feature-detects/svg/foreignobject.js
+++ b/feature-detects/svg/foreignobject.js
@@ -1,0 +1,20 @@
+/*!
+{
+  "name": "SVG foreignObject",
+  "property": "svgforeignobject",
+  "tags": ["svg"],
+  "notes": [{
+    "name": "W3C Spec",
+    "href": "http://www.w3.org/TR/SVG11/extend.html"
+  }]
+}
+!*/
+/* DOC
+Detects support for foreignObject tag in SVG.
+*/
+define(['Modernizr', 'toStringFn'], function( Modernizr, toStringFn  ) {
+  Modernizr.addTest('svgforeignobject', function() {
+    return !!document.createElementNS &&
+      /SVGForeignObject/.test(toStringFn.call(document.createElementNS('http://www.w3.org/2000/svg', 'foreignObject')));
+  });
+});

--- a/lib/config-all.json
+++ b/lib/config-all.json
@@ -205,6 +205,7 @@
     "test/svg/clippaths",
     "test/svg/filters",
     "test/svg/inline",
+    "test/svg/foreignobject",
     "test/svg/smil",
     "test/svg",
     "test/textarea/maxlength",


### PR DESCRIPTION
Added to detect support which IE lacks.
Documentation: http://www.w3.org/TR/SVG11/extend.html
