### PR TITLE
use exec rather than spawn when using windows

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -14,7 +14,7 @@ module.exports = function (opts, callback) {
 
   var cwd = process.cwd();
   var path = require('path');
-  var cp = require('child_process');
+  var spawn = require('win-spawn');
   var fs = require('fs');
 
   var localRoot = path.join(__dirname, '..');
@@ -49,7 +49,7 @@ module.exports = function (opts, callback) {
     }
   }
 
-  var build = cp.spawn(__dirname + '/../node_modules/.bin/' + 'grunt', ['build'], {
+  var build = spawn(__dirname + '/../node_modules/.bin/' + 'grunt', ['build'], {
     stdio: verbose ? 'inherit' : [0, 'pipe', 2],
     cwd: localRoot
   });

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "grunt-contrib-requirejs": "~0.4.0",
     "grunt-cli": "~0.1.11",
     "load-grunt-tasks": "~0.2.1",
-    "grunt-contrib-jshint": "~0.8.0"
+    "grunt-contrib-jshint": "~0.8.0",
+    "win-spawn": "^2.0.0"
   },
   "devDependencies": {
     "grunt-contrib-connect": "~0.5.0",


### PR DESCRIPTION
fixes #1290

~~this gives us the least terrible of both worlds, using spawn unless
windows, where we use exec. That way everyone can build~~

uses [win-spawn](https://github.com/ForbesLindesay/win-spawn), rather than child_process.spawn, for cross platform goodness
