### PR TITLE
Add test for `Proximity API`

### DIFF
--- a/feature-detects/proximity.js
+++ b/feature-detects/proximity.js
@@ -1,0 +1,61 @@
+/*!
+{
+  "authors": ["Cătălin Mariș"],
+  "caniuse": "proximity",
+  "name": "Proximity API",
+  "notes": [{
+    "name": "MDN documentation",
+    "href": "https://developer.mozilla.org/en-US/docs/Web/API/Proximity_Events"
+  },{
+    "name": "W3C specification",
+    "href": "http://www.w3.org/TR/proximity/"
+  }],
+  "property": "proximity",
+  "tags": ["events", "proximity"]
+}
+!*/
+/* DOC
+Detects support for an API that allows users to get proximity related information from the device's proximity sensor.
+*/
+define(['Modernizr', 'addTest'], function( Modernizr, addTest ) {
+
+  Modernizr.addAsyncTest(function () {
+
+    var timeout;
+    var timeoutTime = 300;
+
+    function advertiseSupport() {
+
+      // Clean up after ourselves
+      clearTimeout(timeout);
+      window.removeEventListener('deviceproximity', advertiseSupport);
+
+      // Advertise support as the browser supports
+      // the API and the device has a proximity sensor
+      addTest('proximity', true);
+
+    }
+
+    // Check if the browser has support for the API
+    if ( 'ondeviceproximity' in window && 'onuserproximity' in window ) {
+
+      // Check if the device has a proximity sensor
+      // ( devices without such a sensor support the events but
+      //   will never fire them resulting in a false positive )
+      window.addEventListener('deviceproximity', advertiseSupport);
+
+      // If the event doesn't fire in a reasonable amount of time,
+      // it means that the device doesn't have a proximity sensor,
+      // thus, we can advertise the "lack" of support
+      timeout = setTimeout(function() {
+        window.removeEventListener('deviceproximity', advertiseSupport);
+        addTest('proximity', false);
+      }, timeoutTime);
+
+    } else {
+      addTest('proximity', false);
+    }
+
+  });
+
+});

--- a/lib/config-all.json
+++ b/lib/config-all.json
@@ -192,6 +192,7 @@
     "test/pointerevents",
     "test/pointerlock-api",
     "test/postmessage",
+    "test/proximity",
     "test/quota-management-api",
     "test/requestanimationframe",
     "test/script/async",

--- a/test/modular.html
+++ b/test/modular.html
@@ -166,6 +166,7 @@
     "test/pointerevents",
     "test/pointerlock-api",
     "test/postmessage",
+    "test/proximity",
     "test/quota-management-api",
     "test/requestanimationframe",
     "test/svg",


### PR DESCRIPTION
- W3C Specification: http://www.w3.org/TR/proximity/
- Test page: [click me!](http://jsbin.com/rimiwove/2/)
- Test page in action (using the latest [Firefox Beta for Android](https://play.google.com/store/apps/details?id=org.mozilla.firefox_beta)): 
  
  <img src="https://cloud.githubusercontent.com/assets/1223565/3279751/f1a5e71a-f414-11e3-84c3-64bcb8445c33.gif" width=230 height=400>
## 

<del>There is one detail that is currently included in the [MDN link](https://developer.mozilla.org/en-US/docs/Web/API/Proximity_Events), namely:</del>
 

>   <del>"Obviously, the API requires the device to have a proximity sensor, which are mostly available only on mobile devices. Devices without such a sensor may support those events but will never fire them."</del>

<del>that I think is important, and which I don't know if should be included somewhere inline or not. (Cc: @patrickkettner)
</del>
