### PR TITLE
blacklist Android 2.x on Modernizr.csstransforms

### DIFF
--- a/feature-detects/css/transforms.js
+++ b/feature-detects/css/transforms.js
@@ -7,5 +7,10 @@
 }
 !*/
 define(['Modernizr', 'testAllProps'], function( Modernizr, testAllProps ) {
-  Modernizr.addTest('csstransforms', testAllProps('transform', 'scale(1)', true));
+  Modernizr.addTest('csstransforms', function() {
+    // Android < 3.0 is buggy, so we sniff and blacklist
+    // http://git.io/hHzL7w
+    return navigator.userAgent.indexOf('Android 2.') !== -1 &&
+           testAllProps('transform', 'scale(1)', true);
+  });
 });


### PR DESCRIPTION
closes #903
