### PR TITLE
Detect emoji support on Windows 7+

### DIFF
--- a/feature-detects/emoji.js
+++ b/feature-detects/emoji.js
@@ -12,9 +12,10 @@ define(['Modernizr', 'createElement', 'test/canvastext'], function( Modernizr, c
     if (!Modernizr.canvastext) return false;
     var node = createElement('canvas'),
     ctx = node.getContext('2d');
+    ctx.fillStyle = '#f00';
     ctx.textBaseline = 'top';
     ctx.font = '32px Arial';
-    ctx.fillText('\ud83d\ude03', 0, 0); // "smiling face with open mouth" emoji
+    ctx.fillText('\ud83d\udc28', 0, 0); // U+1F428 KOALA
     return ctx.getImageData(16, 16, 1, 1).data[0] !== 0;
   });
 });


### PR DESCRIPTION
U+1F603 SMILING FACE WITH OPEN MOUTH is just an outline on Windows, so we weren't detecting that anything was drawn at all. Now we use U+1F428 KOALA instead, which is filled in by the Windows emoji font (Segoe UI Symbol). Since these emoji are monochrome on Windows 7/8, we set the fill color to red to ensure we get a non-zero red value from the pixel we sample.
