### PR TITLE
False-positive for csstransforms test

### DIFF
--- a/feature-detects/css/transforms.js
+++ b/feature-detects/css/transforms.js
@@ -10,7 +10,7 @@ define(['Modernizr', 'testAllProps'], function( Modernizr, testAllProps ) {
   Modernizr.addTest('csstransforms', function() {
     // Android < 3.0 is buggy, so we sniff and blacklist
     // http://git.io/hHzL7w
-    return navigator.userAgent.indexOf('Android 2.') !== -1 &&
+    return navigator.userAgent.indexOf('Android 2.') === -1 &&
            testAllProps('transform', 'scale(1)', true);
   });
 });


### PR DESCRIPTION
Check for Android 2.x was wrong. Introduced by f62f1630a08acbdc3a3a74e3f77dbfb5899d7a71.
