### PR TITLE
Fix paths in generated metadata.json on Windows

### DIFF
--- a/lib/generate-meta.js
+++ b/lib/generate-meta.js
@@ -64,7 +64,8 @@ file.walkSync(viewRoot, function (start, dirs, files) {
     metadata.deps = deps;
 
     var baseDir = __dirname.replace(/lib$/, '');
-    metadata.path = './' + (start + '/' + file).replace(baseDir, '');
+    var pathSeparatorRE = new RegExp('\\' + path.sep, 'g');
+    metadata.path = './' + (start + '/' + file).replace(baseDir, '').replace(pathSeparatorRE, '/');
     metadata.amdPath = metadata.path.replace(/^\.\/feature\-detects/, 'test').replace(/\.js$/i, '');
 
     if (!metadata.name) {


### PR DESCRIPTION
When using gulp-modernizr, feature detects in subdirectories throw an error on my Windows 7 VM. I've narrowed it down to `lib/generate-meta.json` creating weird paths:

![image](https://cloud.githubusercontent.com/assets/654171/3363220/b68e2788-fb11-11e3-82a3-d271bf8ac08e.png)

Example: `./feature-detects\css/all.js`

/cc @patrickkettner @doctyper
