### PR TITLE
Don't strip valid whitespace from md files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,3 +8,6 @@ end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
+
+[*.md]
+ +trim_trailing_whitespace = false


### PR DESCRIPTION
Little improvement, nothing major. Two trailing spaces adds a linebreak.
