### PR TITLE
False positive result for IndexedDB test in firefox private browsing window

### DIFF
--- a/feature-detects/indexeddb.js
+++ b/feature-detects/indexeddb.js
@@ -4,22 +4,52 @@
   "property": "indexeddb",
   "caniuse": "indexeddb",
   "tags": ["storage"],
-  "polyfills": ["indexeddb"]
+  "polyfills": ["indexeddb"],
+  "async": true
 }
 !*/
 /* DOC
 Detects support for the IndexedDB client-side storage API (final spec).
 */
-define(['Modernizr', 'prefixed'], function( Modernizr, prefixed ) {
+define(['Modernizr', 'prefixed', 'addTest'], function( Modernizr, prefixed, addTest ) {
   // Vendors had inconsistent prefixing with the experimental Indexed DB:
   // - Webkit's implementation is accessible through webkitIndexedDB
   // - Firefox shipped moz_indexedDB before FF4b9, but since then has been mozIndexedDB
   // For speed, we don't test the legacy (and beta-only) indexedDB
 
-  var indexeddb = prefixed('indexedDB', window);
-  Modernizr.addTest('indexeddb', !!indexeddb);
+  Modernizr.addAsyncTest(function(){
+    var indexeddb = prefixed('indexedDB', window);
 
-  if (!!indexeddb) {
-    Modernizr.addTest('indexeddb.deletedatabase', 'deleteDatabase' in indexeddb);
+    if(!!indexeddb) {
+      var testDBName = 'modernizr-' + Math.random();
+      var req = indexeddb.open(testDBName);
+
+      req.onerror = function(){
+        if(req.error && req.error.name === 'InvalidStateError') {
+          addTest('indexeddb', false);
+        } else{
+          addTest('indexeddb', true);
+          detectDeleteDatabase(indexeddb, testDBName);
+        }
+      };
+
+      req.onsuccess = function(){
+        addTest('indexeddb', true);
+        detectDeleteDatabase(indexeddb, testDBName);
+      };
+    } else {
+      addTest('indexeddb', false);
+    }
+  });
+
+  function detectDeleteDatabase(indexeddb, testDBName){
+    var deleteReq = indexeddb.deleteDatabase(testDBName);
+    deleteReq.onsuccess = function(){
+      addTest('indexeddb.deletedatabase', true);
+    };
+    deleteReq.onerror = function(){
+      addTest('indexeddb.deletedatabase', false);
+    };
   }
+
 });


### PR DESCRIPTION
Firefox in private mode has indexedDB available, however it doesn't seem to be writable. `indexedDB.open` results in `InvalidStateError`. And when the `readyState` is `done`, the `IDBOpenDBRequest` object will have an error: `DOMError { name: "InvalidStateError", message: "A mutation operation was attempted on a database that did not allow mutations." }`.

I'm not sure what's a possible solution to this. If anyone can point me to the right direction, I'm willing to put together a PR to fix this.