### PR TITLE
add detect for background-blend-mode

### DIFF
--- a/feature-detects/css/backgroundblendmode.js
+++ b/feature-detects/css/backgroundblendmode.js
@@ -1,0 +1,24 @@
+/*!
+{
+  "name": "CSS Background Blend Mode",
+  "property": "backgroundblendmode",
+  "caniuse": "css-backgroundblendmode",
+  "tags": ["css"],
+  "notes": [
+    {
+      "name": "CSS Blend Modes could be the next big thing in Web Design",
+      "href": " https://medium.com/@bennettfeely/css-blend-modes-could-be-the-next-big-thing-in-web-design-6b51bf53743a"
+    }, {
+      "name": "Demo",
+      "href": "http://bennettfeely.com/gradients/"
+    }
+  ]
+}
+!*/
+/*
+Detects the ability for the browser to composite backgrounds using blending modes
+similar to ones found in Photoshop or Illustrator
+*/
+define(['Modernizr', 'prefixed'], function( Modernizr, prefixed ) {
+  Modernizr.addTest('backgroundblendmode', prefixed('backgroundBlendModes', 'text'));
+});

--- a/lib/config-all.json
+++ b/lib/config-all.json
@@ -31,6 +31,7 @@
     "test/crypto/getrandomvalues",
     "test/css/all",
     "test/css/animations",
+    "test/css/backgroundblendmode",
     "test/css/backgroundcliptext",
     "test/css/backgroundposition-shorthand",
     "test/css/backgroundposition-xy",


### PR DESCRIPTION
fixes #1388

Unfortunatly, "[...] in some browsers, mix-blend-mode is implemented; the property is valid, the automated tests pass, but no blending actually takes place" - http://blogs.adobe.com/webplatform/2013/09/12/browser-support-matrix-for-css-blending/

background-blend-mode doesn't seem to have that issue, however
