### PR TITLE
add appveyor config for ci on windows

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,17 @@
+environment:
+  matrix:
+    - nodejs_version: 0.10
+
+# Get the latest stable version of Node 0.STABLE.latest
+install:
+  - ps: Update-NodeJsInstallation (Get-NodeJsLatestBuild $env:nodejs_version)
+  - npm install
+
+build: off
+
+before_test:
+  - npm install grunt-cli -g
+  - grunt build
+
+test_script:
+  - npm test


### PR DESCRIPTION
Currently have it set to [point to my own fork](https://ci.appveyor.com/project/PatrickKettner/modernizr/build/1.0.1),
but I will update to point to modernizr's assuming we like using it.