### PR TITLE
feature-detect: URL parser

### DIFF
--- a/feature-detects/url/parser.js
+++ b/feature-detects/url/parser.js
@@ -1,0 +1,28 @@
+/*!
+{
+  "name": "URL parser",
+  "property": "urlparser",
+  "notes": [{
+    "name": "URL",
+    "href": "https://dvcs.w3.org/hg/url/raw-file/tip/Overview.html"
+  }],
+  "polyfills": ["urlparser"],
+  "authors": ["Ron Waldon (@jokeyrhyme)"],
+  "tags": ["url"]
+}
+!*/
+/* DOC
+Check if browser implements the URL constructor for parsing URLs.
+*/
+define(['Modernizr'], function (Modernizr) {
+  Modernizr.addTest('urlparser', function () {
+    var url;
+    try {
+      // have to actually try use it, because Safari defines a dud constructor
+      url = new URL('http://modernizr.com/');
+      return url.href === 'http://modernizr.com/';
+    } catch (e) {
+      return false;
+    }
+  });
+});

--- a/lib/config-all.json
+++ b/lib/config-all.json
@@ -215,6 +215,7 @@
     "test/unicode-range",
     "test/url/bloburls",
     "test/url/data-uri",
+    "test/url/parser",
     "test/userdata",
     "test/vibration",
     "test/video/autoplay",

--- a/lib/polyfills.json
+++ b/lib/polyfills.json
@@ -724,6 +724,12 @@
     "href": "https://github.com/jakearchibald/ES6-Promises",
     "licenses": ["MIT"]
   },
+  "urlparser": {
+    "authors": ["Google Inc."],
+    "href": "https://github.com/Polymer/URL",
+    "licenses": ["BSD"],
+    "name": "Polymer URL parser polyfill"
+  },
   "css-selector-engine": {
     "name": "CSS Selector Engine",
     "authors": ["Егор Халимоненко"],


### PR DESCRIPTION
This is a feature detect for the built-in URL parser that Polymer relies on:
- http://www.polymer-project.org/docs/start/platform.html
- https://dvcs.w3.org/hg/url/raw-file/tip/Overview.html

It's implemented in Chrome and Firefox, Safari does have the constructor but it doesn't return the expected object / prototype / etc.
