### PR TITLE
feature-detect for ES6 Map, Set, WeakMap and WeakSet

### DIFF
--- a/feature-detects/es6/collections.js
+++ b/feature-detects/es6/collections.js
@@ -1,0 +1,22 @@
+/*!
+{
+  "name": "ES6 Collections",
+  "property": "es6collections",
+  "notes": [{
+    "name": "unofficial ECMAScript 6 draft specification",
+    "href": "http://people.mozilla.org/~jorendorff/es6-draft.html"
+  }],
+  "polyfills": ["es6shim", "weakmap"],
+  "authors": ["Ron Waldon (@jokeyrhyme)"],
+  "warnings": ["ECMAScript 6 is still a only a draft, so this detect may not match the final specification or implementations."],
+  "tags": ["es6"]
+}
+!*/
+/* DOC
+Check if browser implements ECMAScript 6 Map, Set, WeakMap and WeakSet
+*/
+define(['Modernizr'], function(Modernizr) {
+  Modernizr.addTest('es6collections', !!(
+    window.Map && window.Set && window.WeakMap && window.WeakSet
+  ));
+});

--- a/lib/config-all.json
+++ b/lib/config-all.json
@@ -145,6 +145,7 @@
     "es5/syntax",
     "es5/undefined",
     "es6/array",
+    "es6/collections",
     "es6/contains",
     "es6/generators",
     "es6/math",

--- a/lib/polyfills.json
+++ b/lib/polyfills.json
@@ -698,6 +698,12 @@
     "href": "http://remysharp.com/2008/06/30/maxlength-plugin/",
     "licenses": ["CC SA"]
   },
+  "weakmap": {
+    "name": "ES6 WeakMap",
+    "authors": ["Google Inc."],
+    "href": "https://github.com/Polymer/WeakMap",
+    "licenses": ["BSD"]
+  },
   "eventlistener": {
     "name": "EventListener",
     "authors": ["Jonathan Neal"],


### PR DESCRIPTION
This feature detect shows whether the new collections constructors for ES6 are supported: Map, Set, WeakMap and WeakSet.

Chrome implements all 4, but hides 2 behind a flag. Firefox implements 3.

[Polymer requires WeakMap](http://www.polymer-project.org/docs/start/platform.html), so detecting this may allow us to skip loading the poly-fill in upcoming browsers.

Part of #1170.