### PR TITLE
Removing stray +

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,4 +10,4 @@ trim_trailing_whitespace = true
 insert_final_newline = true
 
 [*.md]
- +trim_trailing_whitespace = false
+trim_trailing_whitespace = false


### PR DESCRIPTION
Removing a stray `+` from in front of `trim_trailing_whitespace = false`
