### PR TITLE
testProps  + createElement fixes for IE7

### DIFF
--- a/src/createElement.js
+++ b/src/createElement.js
@@ -1,12 +1,12 @@
 define(function() {
   var createElement = function() {
     if (typeof document.createElement !== 'function') {
-      var oldCreateElement = document.createElement;
-      document.createElement = function (tagName) {
-        return oldCreateElement(tagName);
-      };
+      // This is the case in IE7, where the type of createElement is "object".
+      // For this reason, we cannot call apply() as Object is not a Function.
+      return document.createElement(arguments[0]);
+    } else {
+      return document.createElement.apply(document, arguments);
     }
-    return document.createElement.apply(document, arguments);
   };
   return createElement;
 });

--- a/src/testProps.js
+++ b/src/testProps.js
@@ -24,7 +24,7 @@ define(['contains', 'mStyle', 'createElement', 'nativeTestProps', 'is', 'cssToDO
     }
 
     // Otherwise do it properly
-    var afterInit, i, prop, before;
+    var afterInit, i, propsLength, prop, before;
 
     // If we don't have a style element, that means
     // we're running async or after the core tests,
@@ -44,7 +44,8 @@ define(['contains', 'mStyle', 'createElement', 'nativeTestProps', 'is', 'cssToDO
       }
     }
 
-    for ( i = 0; i < props.length; i++ ) {
+    propsLength = props.length;
+    for ( i = 0; i < propsLength; i++ ) {
       prop = props[i];
       before = mStyle.style[prop];
 


### PR DESCRIPTION
When iterating over array in IE7 using for ( i in array ) construction, 'i' variable not only takes indices values, but also functions belonging to Array object. For this reason, Modernizr simply fails on a certain tests on IE7.
Also there is an issue with document.createElement invocation on IE7. Its type is for some odd reason an "object", therefore it doesn't have apply() function on it. I hit this issue when using browsernizr2 NPM package, which is a thin wrapper over Modernizr to make it working with browserify.
