### PR TITLE
Fixes typo in background blend mode test.

### DIFF
--- a/feature-detects/css/backgroundblendmode.js
+++ b/feature-detects/css/backgroundblendmode.js
@@ -20,5 +20,5 @@ Detects the ability for the browser to composite backgrounds using blending mode
 similar to ones found in Photoshop or Illustrator
 */
 define(['Modernizr', 'prefixed'], function( Modernizr, prefixed ) {
-  Modernizr.addTest('backgroundblendmode', prefixed('backgroundBlendModes', 'text'));
+  Modernizr.addTest('backgroundblendmode', prefixed('backgroundBlendMode', 'text'));
 });


### PR DESCRIPTION
`backgroundBlendModes` doesn't work, while `backgroundBlendMode` does.
