### PR TITLE
More IE7 fixes: atRule and unit test

### DIFF
--- a/src/atRule.js
+++ b/src/atRule.js
@@ -11,6 +11,10 @@ define(['ModernizrProto', 'prefixes'], function( ModernizrProto, prefixes ) {
     var cssrule = window.CSSRule;
     var rule;
 
+    if (typeof cssrule === 'undefined') {
+      return false;
+    }
+
     // remove literal @ from begining of provided property
     prop = prop.replace(/^@/,'');
 

--- a/test/js/unit-caniuse.js
+++ b/test/js/unit-caniuse.js
@@ -126,7 +126,8 @@ window.caniusecb = function(scriptdata) {
 
   // translate 'y' 'n' or 'a' into a boolean that Modernizr uses
   function bool(ciuresult){
-    if (ciuresult == 'y' || ciuresult == 'a') return true;
+    // To handle correctly things like 'y #1' or 'a #2'
+    if (ciuresult.indexOf('y') === 0 || ciuresult.indexOf('a') === 0) return true;
     // 'p' is for polyfill
     if (ciuresult == 'n' || ciuresult == 'p') return false;
     throw 'unknown return value from can i use';
@@ -141,7 +142,7 @@ window.caniusecb = function(scriptdata) {
       o.result = !!o.result;
 
     // if caniuse gave us a 'partial', lets let it pass with a note.
-    if (o.ciuresult == 'a'){
+    if (o.ciuresult.indexOf('a') === 0){
       return ok(true,
                 o.browser + o.version + ': Caniuse reported partial support for ' + o.ciufeature +
                   '. So.. Modernizr\'s ' + o.result + ' is good enough...'


### PR DESCRIPTION
Hi,

In IE7, the `Modernizr.prefixed("@import")` test was throwing an exception in following lines:

``` javascript
if (rule in cssrule)
...
if (thisRule in cssrule)
```

This is because cssrule is undefined. I added a check to handle that [corner] case.

Also, _caniuse_ test suite was dying because of failure to parse certain results in JSONP. Specifically, those which have form 'a #_i_' or 'y #_i_', where _i_ is numeric. I would think this refers to some notes regarding support of particular property.   I've added more relaxed comparison with 'a' and 'y' to allow test suite to at least complete execution normally in IE7.

Would be happy if you guys could consider merging this.

Thanks,
Vlad.
