### PR TITLE
Fix JS error on Firefox hidden iframes: verify that getComputedStyle is not returning null before using it

### DIFF
--- a/feature-detects/css/pseudoanimations.js
+++ b/feature-detects/css/pseudoanimations.js
@@ -8,6 +8,7 @@
 define(['Modernizr', 'testStyles', 'test/css/animations'], function (Modernizr) {
   Modernizr.addTest('csspseudoanimations', function () {
     var result = false;
+    var style;
 
     if (!Modernizr.cssanimations || !window.getComputedStyle) {
       return result;
@@ -21,7 +22,10 @@ define(['Modernizr', 'testStyles', 'test/css/animations'], function (Modernizr) 
     ].join('');
 
     Modernizr.testStyles(styles, function (elem) {
-      result = window.getComputedStyle(elem, ':before').getPropertyValue('font-size') === '10px';
+      style = window.getComputedStyle(elem, ':before');
+      if(style !== null) {
+        result = style.getPropertyValue('font-size') === '10px';
+      }
     });
 
     return result;

--- a/feature-detects/css/pseudotransitions.js
+++ b/feature-detects/css/pseudotransitions.js
@@ -8,6 +8,7 @@
 define(['Modernizr', 'testStyles', 'test/css/transitions'], function (Modernizr) {
   Modernizr.addTest('csspseudotransitions', function () {
     var result = false;
+    var style;
 
     if (!Modernizr.csstransitions || !window.getComputedStyle) {
       return result;
@@ -19,9 +20,11 @@ define(['Modernizr', 'testStyles', 'test/css/transitions'], function (Modernizr)
 
     Modernizr.testStyles(styles, function (elem) {
       // Force rendering of the element's styles so that the transition will trigger
-      window.getComputedStyle(elem, ':before').getPropertyValue('font-size');
-      elem.className += 'trigger';
-      result = window.getComputedStyle(elem, ':before').getPropertyValue('font-size') === '5px';
+      style = window.getComputedStyle(elem, ':before');
+      if(style !== null) {
+        elem.className += 'trigger';
+        result = window.getComputedStyle(elem, ':before').getPropertyValue('font-size') === '5px';
+      }
     });
 
     return result;

--- a/feature-detects/css/subpixelfont.js
+++ b/feature-detects/css/subpixelfont.js
@@ -26,8 +26,15 @@ define(['Modernizr', 'testStyles'], function( Modernizr, testStyles ) {
   function( elem ) {
     var subpixel = elem.firstChild;
     subpixel.innerHTML = 'This is a text written in Arial';
-    Modernizr.addTest('subpixelfont', window.getComputedStyle ?
-      window.getComputedStyle(subpixel, null).getPropertyValue('width') !== '44px'
-    : false);
+    Modernizr.addTest('subpixelfont', function() {
+      var style;
+      var result = false;
+
+      if(window.getComputedStyle && (style = window.getComputedStyle(subpixel, null)) !== null) {
+        result = style.getPropertyValue('width') !== '44px';
+      }
+
+      return result;
+    });
   }, 1, ['subpixel']);
 });

--- a/feature-detects/elem/ruby.js
+++ b/feature-detects/elem/ruby.js
@@ -42,9 +42,12 @@ define(['Modernizr', 'createElement', 'docElement'], function( Modernizr, create
 
     function getStyle( element, styleProperty ) {
       var result;
+      var style;
 
       if ( window.getComputedStyle ) {     // for non-IE browsers
-        result = document.defaultView.getComputedStyle(element,null).getPropertyValue(styleProperty);
+        if ( (style = document.defaultView.getComputedStyle(element,null)) !== null ) {
+          result = style.getPropertyValue(styleProperty);
+        }
       } else if ( element.currentStyle ) { // for IE
         result = element.currentStyle[styleProperty];
       }

--- a/feature-detects/inputtypes.js
+++ b/feature-detects/inputtypes.js
@@ -53,6 +53,7 @@ define(['Modernizr', 'inputElem', 'docElement', 'inputtypes', 'inputs', 'smile']
     var inputElemType;
     var defaultView;
     var len = props.length;
+    var style;
 
     for ( var i = 0; i < len; i++ ) {
 
@@ -74,7 +75,8 @@ define(['Modernizr', 'inputElem', 'docElement', 'inputtypes', 'inputs', 'smile']
 
           // Safari 2-4 allows the smiley as a value, despite making a slider
           bool =  defaultView.getComputedStyle &&
-            defaultView.getComputedStyle(inputElem, null).WebkitAppearance !== 'textfield' &&
+            (style = defaultView.getComputedStyle(inputElem, null)) !== null &&
+            style.WebkitAppearance !== 'textfield' &&
             // Mobile android web browser has false positive, so must
             // check the height to see if the widget is actually there.
             (inputElem.offsetHeight !== 0);


### PR DESCRIPTION
On Firefox, `getComputedStyle` returns `null` if it's called inside a hidden iframe. You can see an example here:
https://www.groupon.com/deals/butter

Open that URL on Firefox. You'll see several JS errors in the console, the first being `TypeError: window.getComputedStyle(...) is null`. This is happening not on that page, but on a hidden iframe on that page (that iframe is loaded on page load but it's only shown when a user takes certain action, so it's a completely valid use case).

So, basically, this code will break:
```javascript
var result = false;
if(window.getComputedStyle) {
  result = window.getComputedStyle(element, null).getPropertyValue('font-size') === '10px';
}
return result;
```

The solution is to first check for the returned value, like this:
```javascript
var result;
var style;
if(window.getComputedStyle && (style = window.getComputedStyle(element, null)) !== null) {
  result = style.getPropertyValue('font-size') === '10px';
}
return result;
```

Different files have different coding styles, so I tried to preserve the coding style for each file.