### PR TITLE
Fix: cssToDOM for IE <= 7

### DIFF
--- a/src/cssToDOM.js
+++ b/src/cssToDOM.js
@@ -2,6 +2,9 @@ define(function() {
   // Helper function for converting kebab-case to camelCase,
   // e.g. box-sizing -> boxSizing
   function cssToDOM( name ) {
+    //old ie hack
+    if (typeof name !== "string")
+        return "";
     return name.replace(/([a-z])-([a-z])/g, function(str, m1, m2) {
       return m1 + m2.toUpperCase();
     }).replace(/^-/, '');


### PR DESCRIPTION
if name is not a string return empty string
