### PR TITLE
Attempt to use replaceState to validate we can use the History API.

### DIFF
--- a/feature-detects/history.js
+++ b/feature-detects/history.js
@@ -35,6 +35,15 @@ define(['Modernizr'], function( Modernizr ) {
       return false;
     }
 
+    try {
+      // TODO: better way to use replaceState that doesn't actually change the current url?
+      var path = window.location.pathname + window.location.search;
+      window.history.replaceState({path: path}, '', path);
+    }
+    catch (e) {
+      return false;
+    }
+
     // Return the regular check
     return (window.history && 'pushState' in window.history);
   });


### PR DESCRIPTION
Checking if history (pushState) is supported will pass for Firefox Addons with the current implementation but is actually not supported. You cannot tell though until you attempt to actually use the API.

For more info, I originally reported this here: https://github.com/rackt/react-router/issues/535

Also note the `TODO`. Looking for suggestions for that.
