### PR TITLE
Add bang so minification is easier

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,1 +1,1 @@
-/* Modernizr 3.0.0pre (Custom Build) | MIT  */
+/*! Modernizr 3.0.0pre (Custom Build) | MIT  */


### PR DESCRIPTION
Depending on the minification that's used having the `/*! ... comment ..*/` is helpful.  I suggest adding the bang here so the custom builds do not have to modify the source that's generated and add a `!` to ensure they maintain the MIT copyright when minifying. 

I think it's the custom build that reads from this file to add the license.  I could be wrong, in which case, I hope the thing that does the custom build adds the `!` to the start of the copyright/license comment.