### PR TITLE
Metadata generation

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -26,7 +26,7 @@ module.exports = function( grunt ) {
         ' * information allows you to progressively enhance your pages with a granular level\n' +
         ' * of control over the experience.\n' +
         ' *\n' +
-        ' */'
+        ' */\n'
     },
     meta: {
     },
@@ -36,12 +36,15 @@ module.exports = function( grunt ) {
     nodeunit: {
       files: ['test/api/*.js']
     },
-    stripdefine: {
+    classprefix: {
       build: ['dist/modernizr-build.js']
     },
-    generateinit: {
-      build: {
-        src: ['tmp/modernizr-init.js']
+    'modernizr-build': {
+      options: {
+        banner: '<%= banner.full %>'
+      },
+      dist: {
+        dest: 'dist/modernizr-build.js'
       }
     },
     uglify: {
@@ -107,63 +110,7 @@ module.exports = function( grunt ) {
       }
     },
     clean: {
-      dist: ['dist'],
-      postbuild: [
-        'build',
-        'tmp'
-      ]
-    },
-    copy: {
-      build: {
-        files: {
-          'dist/modernizr-build.js': 'build/src/modernizr-build.js'
-        }
-      }
-    },
-    requirejs: {
-      compile: {
-        options: {
-          dir: 'build',
-          appDir: '.',
-          baseUrl: 'src',
-          optimize: 'none',
-          optimizeCss: 'none',
-          useStrict: true,
-          paths: {
-            'test': '../feature-detects',
-            'modernizr-init': '../tmp/modernizr-init'
-          },
-          modules: [{
-            'name': 'modernizr-build',
-            'include': ['modernizr-init'],
-            'create': true
-          }],
-          fileExclusionRegExp: /^(.git|node_modules|modulizr|media|test)$/,
-          wrap: {
-            start: '<%= banner.full %>' + '\n;(function(window, document, undefined){',
-            end: '})(this, document);'
-          },
-          onBuildWrite: function (id, path, contents) {
-            if ((/define\(.*?\{/).test(contents)) {
-              //Remove AMD ceremony for use without require.js or almond.js
-              contents = contents.replace(/define\(.*?\{/, '');
-
-              contents = contents.replace(/\}\);\s*?$/,'');
-
-              if ( !contents.match(/Modernizr\.addTest\(/) && !contents.match(/Modernizr\.addAsyncTest\(/) ) {
-                //remove last return statement and trailing })
-                contents = contents.replace(/return.*[^return]*$/,'');
-              }
-            }
-            else if ((/require\([^\{]*?\{/).test(contents)) {
-              contents = contents.replace(/require[^\{]+\{/, '');
-              contents = contents.replace(/\}\);\s*$/,'');
-            }
-
-            return contents;
-          }
-        }
-      }
+      dist: ['dist']
     },
     connect: {
       server: {
@@ -192,10 +139,10 @@ module.exports = function( grunt ) {
   });
 
   // Strip define fn
-  grunt.registerMultiTask('stripdefine', 'Strip define call from dist file', function() {
+  grunt.registerMultiTask('classprefix', 'Hack the class prefix into place.', function() {
     this.filesSrc.forEach(function(filepath) {
-      // Remove `define('modernizr-init' ...)` and `define('modernizr-build' ...)`
-      var mod = grunt.file.read(filepath).replace(/define\("modernizr-(init|build)", function\(\)\{\}\);/g, '');
+
+      var mod = grunt.file.read(filepath);
 
       // Hack the prefix into place. Anything is way too big for something so small.
       if ( modConfig && modConfig.classPrefix ) {
@@ -205,14 +152,23 @@ module.exports = function( grunt ) {
     });
   });
 
-  grunt.registerMultiTask('generateinit', 'Generate Init file', function() {
-    var requirejs = require('requirejs');
-    requirejs.config({
-      appDir: __dirname + '/src/',
-      baseUrl: __dirname + '/src/'
+  grunt.registerMultiTask('modernizr-build', 'Generate Modernizr Build', function() {
+    var done = this.async();
+    var dest = this.files[0].dest;
+    var options = this.options({
+      banner: ''
     });
-    var generateInit = requirejs('generate');
-    grunt.file.write('tmp/modernizr-init.js', generateInit(modConfig));
+    var banner = grunt.template.process(options.banner);
+
+    var build = require('./lib/build');
+
+    build(modConfig, function(content) {
+      grunt.file.write(dest, banner + content);
+      done();
+    }, function(err) {
+      grunt.fail.warn(err);
+    });
+
   });
 
   // Testing tasks
@@ -227,11 +183,8 @@ module.exports = function( grunt ) {
   // Build
   grunt.registerTask('build', [
     'clean',
-    'generateinit',
-    'requirejs',
-    'copy',
-    'clean:postbuild',
-    'stripdefine',
+    'modernizr-build',
+    'classprefix',
     'uglify'
   ]);
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -36,9 +36,6 @@ module.exports = function( grunt ) {
     nodeunit: {
       files: ['test/api/*.js']
     },
-    classprefix: {
-      build: ['dist/modernizr-build.js']
-    },
     'modernizr-build': {
       options: {
         banner: '<%= banner.full %>'
@@ -138,20 +135,6 @@ module.exports = function( grunt ) {
     }
   });
 
-  // Strip define fn
-  grunt.registerMultiTask('classprefix', 'Hack the class prefix into place.', function() {
-    this.filesSrc.forEach(function(filepath) {
-
-      var mod = grunt.file.read(filepath);
-
-      // Hack the prefix into place. Anything is way too big for something so small.
-      if ( modConfig && modConfig.classPrefix ) {
-        mod = mod.replace('classPrefix : \'\',', 'classPrefix : \'' + modConfig.classPrefix.replace(/"/g, '\\"') + '\',');
-      }
-      grunt.file.write(filepath, mod);
-    });
-  });
-
   grunt.registerMultiTask('modernizr-build', 'Generate Modernizr Build', function() {
     var done = this.async();
     var dest = this.files[0].dest;
@@ -184,7 +167,6 @@ module.exports = function( grunt ) {
   grunt.registerTask('build', [
     'clean',
     'modernizr-build',
-    'classprefix',
     'uglify'
   ]);
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -28,7 +28,10 @@ module.exports = function( grunt ) {
         ' *\n' +
         ' */\n'
     },
-    meta: {
+    'modernizr-metadata': {
+      dist: {
+        dest: 'dist/metadata.json'
+      }
     },
     qunit: {
       files: ['test/index.html']
@@ -143,7 +146,7 @@ module.exports = function( grunt ) {
     });
     var banner = grunt.template.process(options.banner);
 
-    var build = require('./lib/build');
+    var build = require('./lib/').build;
 
     build(modConfig, function(content) {
       grunt.file.write(dest, banner + content);
@@ -152,6 +155,12 @@ module.exports = function( grunt ) {
       grunt.fail.warn(err);
     });
 
+  });
+
+  grunt.registerMultiTask('modernizr-metadata', 'Generate Modernizr metadata', function() {
+    var dest = this.files[0].dest;
+    var metadata = require('./lib/').metadata;
+    grunt.file.write(dest, JSON.stringify(metadata, null, '  '));
   });
 
   // Testing tasks
@@ -168,6 +177,10 @@ module.exports = function( grunt ) {
     'clean',
     'modernizr-build',
     'uglify'
+  ]);
+
+  grunt.registerTask('meta', [
+    'modernizr-metadata'
   ]);
 
   grunt.registerTask('default', [

--- a/lib/build.js
+++ b/lib/build.js
@@ -1,86 +1,71 @@
-/* jshint node: true */
+// Defines a module that works in Node and AMD.
+// https://github.com/umdjs/umd/blob/master/nodeAdapter.js
 
-module.exports = function (opts, callback) {
-  'use strict';
+if (typeof module === 'object' && typeof define !== 'function') {
+  var define = function (factory) {
+    module.exports = factory(require, exports, module);
+  };
+}
+
+define(function(require) {
+
+  var generateInit = require('./generate-init');
+  var requirejs = require('requirejs');
 
   // Usage:
-  // require('modernizr').build(config, callback);
+  // require('modernizr').build(config, callback, errback);
   //
   // Where:
   // config - A JSON object of config options (see ./lib/config-all.json)
   // callback - A callback function once build completes
+  // errback - A callback function on error occurs
 
-  opts = opts || {};
+  return function build(opts, callback, errback) {
+    'use strict';
 
-  var cwd = process.cwd();
-  var path = require('path');
-  var spawn = require('win-spawn');
-  var fs = require('fs');
+    opts = opts || {};
+    var init = generateInit(opts);
 
-  var localRoot = path.join(__dirname, '..');
+    var config = {
+      rawText: {
+        'modernizr-init': init
+      },
+      name: 'modernizr-init',
+      baseUrl: 'src/',
+      optimize: 'none',
+      optimizeCss: 'none',
+      paths: {
+        test: '../feature-detects'
+      },
+      out: callback,
+      // So we do not need to remove `define('modernizr-init' ...)` and `define('modernizr-build' ...)`
+      skipModuleInsertion: true,
+      useStrict: true,
+      wrap: {
+        start: ';(function(window, document, undefined){',
+        end: '})(this, document);'
+      },
+      onBuildWrite: function (id, path, contents) {
+        if ((/define\(.*?\{/).test(contents)) {
+          //Remove AMD ceremony for use without require.js or almond.js
+          contents = contents.replace(/define\(.*?\{/, '');
 
-  // Temporarily change working dir to Modernizr root
-  process.chdir(localRoot);
+          contents = contents.replace(/\}\);\s*?$/,'');
 
-  // Context-sensitive requires
-  var grunt = require('grunt');
+          if ( !contents.match(/Modernizr\.addTest\(/) && !contents.match(/Modernizr\.addAsyncTest\(/) ) {
+            //remove last return statement and trailing })
+            contents = contents.replace(/return.*[^return]*$/,'');
+          }
+        }
+        else if ((/require\([^\{]*?\{/).test(contents)) {
+          contents = contents.replace(/require[^\{]+\{/, '');
+          contents = contents.replace(/\}\);\s*$/,'');
+        }
 
-  // So we don't make path assumptions, we load the current Gruntfile
-  require(path.join(localRoot, 'Gruntfile'))(grunt);
-
-  // and store our config options for later use.
-  var settings = grunt.config();
-
-  // White noise suppression
-  var verbose = (opts.verbose !== false);
-  delete opts.verbose;
-
-  if (typeof opts !== 'undefined') {
-    var configPath = path.join(__dirname, 'config-all.json');
-
-    if (fs.existsSync(configPath)) {
-      var modernizrConfig = grunt.file.readJSON(configPath);
-
-      for (var key in opts) {
-        modernizrConfig[key] = opts[key];
+        return contents;
       }
+    };
 
-      grunt.file.write(configPath, JSON.stringify(modernizrConfig, null, 2));
-    }
-  }
-
-  var build = spawn(__dirname + '/../node_modules/.bin/' + 'grunt', ['build'], {
-    stdio: verbose ? 'inherit' : [0, 'pipe', 2],
-    cwd: localRoot
-  });
-
-  build.on('exit', function (code) {
-
-    // Ensure uglify is defined
-    var uglify = (settings.uglify || {}).dist || {};
-
-    // Read concat / minified source
-    var source, dest;
-
-    if (uglify.src && fs.existsSync(uglify.src[0])) {
-      source = grunt.file.read(uglify.src[0]);
-    }
-
-    if (uglify.dest && fs.existsSync(uglify.dest)) {
-      dest = grunt.file.read(uglify.dest);
-    }
-
-    // Switch working directory back to original
-    process.chdir(cwd);
-
-    // If callback is defined, invoke it
-    if (typeof callback === 'function') {
-      callback({
-        code: source,
-        min: dest
-      });
-    } else {
-      return process.exit(code);
-    }
-  });
-};
+    requirejs.optimize(config, null, errback);
+  };
+});

--- a/lib/build.js
+++ b/lib/build.js
@@ -16,15 +16,15 @@ define(function(require) {
   // require('modernizr').build(config, callback, errback);
   //
   // Where:
-  // config - A JSON object of config options (see ./lib/config-all.json)
-  // callback - A callback function once build completes
-  // errback - A callback function on error occurs
+  // options - A object of config options (see ./lib/config-all.json)
+  // callback - A callback function once build completes, code is passed as the first argument
+  // errback - A callback function on error occurs, error is passed as the first argument
 
-  return function build(opts, callback, errback) {
+  return function build(options, callback, errback) {
     'use strict';
 
-    opts = opts || {};
-    var init = generateInit(opts);
+    options = options || {};
+    var init = generateInit(options);
 
     var config = {
       rawText: {

--- a/lib/generate-init.js
+++ b/lib/generate-init.js
@@ -1,4 +1,16 @@
-define(['underscore'], function( _ ) {
+// Defines a module that works in Node and AMD.
+// https://github.com/umdjs/umd/blob/master/nodeAdapter.js
+
+if (typeof module === 'object' && typeof define !== 'function') {
+  var define = function (factory) {
+    module.exports = factory(require, exports, module);
+  };
+}
+
+define(function(require) {
+  'use strict';
+  var _ = require('underscore');
+
   return function( config ) {
     // Set some defaults
     if (!config) {

--- a/lib/generate-init.js
+++ b/lib/generate-init.js
@@ -49,7 +49,13 @@ define(function(require) {
       output += ', setClasses, classes';
     }
 
-    output += ') {\n' +
+    output += ') {\n';
+
+    if (config.classPrefix !== '') {
+      output += '  ModernizrProto._config.classPrefix = \'' + config.classPrefix + '\';\n\n';
+    }
+
+    output +=
     '  // Run each test\n' +
     '  testRunner();\n' +
     '\n';

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,9 +1,7 @@
 /* jshint node: true */
 'use strict';
 
-require('grunt');
-
 module.exports = {
   build: require('./build'),
-  metadata: require('./generate-meta')
+  metadata: require('./metadata')
 };

--- a/lib/metadata.js
+++ b/lib/metadata.js
@@ -3,8 +3,6 @@ var file = require('file');
 var path = require('path');
 var marked = require('marked');
 var polyfills = require('./polyfills.json');
-var outputDir = path.resolve(__dirname + '/../dist');
-var outputPath = outputDir + '/metadata.json';
 
 var viewRoot = path.resolve(__dirname + '/../feature-detects');
 var tests = [];
@@ -137,9 +135,4 @@ file.walkSync(viewRoot, function (start, dirs, files) {
   });
 });
 
-
-if (!fs.existsSync(outputDir)) {
-  fs.mkdirSync(outputDir);
-}
-fs.writeFileSync(outputPath, JSON.stringify(tests, null, '  '));
 module.exports = tests;

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "scripts": {
     "test": "./node_modules/.bin/grunt test"
   },
-  "main": "./lib/cli",
+  "main": "./lib/",
   "repository": {
     "type": "git",
     "url": "git://github.com/Modernizr/Modernizr.git"

--- a/package.json
+++ b/package.json
@@ -7,8 +7,6 @@
   },
   "dependencies": {
     "file": "0.2.1",
-    "mkdirp": "~0.3.4",
-    "optimist": "~0.3.5",
     "requirejs": "~2.1.4",
     "underscore": "~1.4.4",
     "marked": "~0.2.8",
@@ -17,11 +15,9 @@
     "grunt-contrib-watch": "~0.3.1",
     "grunt-contrib-clean": "~0.4.0",
     "grunt-contrib-copy": "~0.4.0",
-    "grunt-contrib-requirejs": "~0.4.0",
     "grunt-cli": "~0.1.11",
     "load-grunt-tasks": "~0.2.1",
-    "grunt-contrib-jshint": "~0.8.0",
-    "win-spawn": "^2.0.0"
+    "grunt-contrib-jshint": "~0.8.0"
   },
   "devDependencies": {
     "grunt-contrib-connect": "~0.5.0",

--- a/test/api/build.js
+++ b/test/api/build.js
@@ -41,14 +41,13 @@ exports.buildCustom = function (test) {
       "test/dom/classlist"
     ],
     "verbose": false
-  }, function () {
+  }, function (content) {
     test.ok(true, "should finish build without errors");
-    var file = fs.readFileSync(path.join(cwd, "dist", "modernizr-build.js"), "utf8");
 
-    test.notEqual(file.indexOf("boxsizing"), -1, "Should find test for boxsizing");
-    test.notEqual(file.indexOf("classlist"), -1, "Should find test for classlist");
+    test.notEqual(content.indexOf("boxsizing"), -1, "Should find test for boxsizing");
+    test.notEqual(content.indexOf("classlist"), -1, "Should find test for classlist");
 
-    test.equal(file.indexOf("cssanimations"), -1, "Should not find test for cssanimations");
+    test.equal(content.indexOf("cssanimations"), -1, "Should not find test for cssanimations");
 
     test.done();
   });

--- a/test/api/build.js
+++ b/test/api/build.js
@@ -15,7 +15,7 @@ exports.setUp = function (callback) {
 
 exports.build = function (test) {
   test.expect(3);
-  var modernizr = require(path.join(cwd, "lib", "cli"));
+  var modernizr = require(path.join(cwd, "lib"));
 
   test.ok(modernizr.build, "should export build function");
   test.equal(typeof modernizr.build, "function", "modernizr.build should be a function");
@@ -30,7 +30,7 @@ exports.build = function (test) {
 
 exports.buildCustom = function (test) {
   test.expect(6);
-  var modernizr = require(path.join(cwd, "lib", "cli"));
+  var modernizr = require(path.join(cwd, "lib"));
 
   test.ok(modernizr.build, "should export build function");
   test.equal(typeof modernizr.build, "function", "modernizr.build should be a function");

--- a/test/api/index.js
+++ b/test/api/index.js
@@ -4,7 +4,7 @@
 exports.core = function (test) {
   test.expect(2);
 
-  var modernizr = require("../../lib/cli");
+  var modernizr = require("../../lib/");
   test.ok(modernizr, "modernizr should be truthy");
 
   var keys = Object.keys(modernizr);


### PR DESCRIPTION
This PR disables automatic metadata generation.

Additional changes:

1. Renamed file from `generate-meta` to `metadata`.
2. Renamed file from `cli.js` to `index.js`. This allows to use of such cases `require('./lib/').metadata;`.
3. Added grunt task `meta` to generate `dist/metadata.json` file.