### PR TITLE
Add CSS appearance detection

### DIFF
--- a/feature-detects/css/appearance.js
+++ b/feature-detects/css/appearance.js
@@ -1,0 +1,23 @@
+/*!
+{
+  "name": "Appearance",
+  "property": "appearance",
+  "caniuse": "css-appearance",
+  "tags": ["css"],
+  "notes": [{
+    "name": "MDN documentation",
+    "href": "https://developer.mozilla.org/en-US/docs/Web/CSS/-moz-appearance"
+  },{
+    "name": "CSS-Tricks CSS Almanac: appearance",
+    "href": "http://css-tricks.com/almanac/properties/a/appearance/"
+  }]
+}
+!*/
+/* DOC
+Detects support for the `appearance` css property, which is used to make an
+element inherit the style of a standard user interface element. It can also be
+used to remove the default styles of an element, such as input and buttons.
+*/
+define(['Modernizr', 'testAllProps'], function( Modernizr, testAllProps ) {
+  Modernizr.addTest('appearance', testAllProps('appearance'));
+});

--- a/lib/config-all.json
+++ b/lib/config-all.json
@@ -30,6 +30,7 @@
     "test/crypto/getrandomvalues",
     "test/css/all",
     "test/css/animations",
+    "test/css/appearance",
     "test/css/backgroundblendmode",
     "test/css/backgroundcliptext",
     "test/css/backgroundposition-shorthand",

--- a/test/modular.html
+++ b/test/modular.html
@@ -28,6 +28,7 @@
     "test/battery/lowbattery",
     "test/canvas/todataurl",
     "test/css/animations",
+    "test/css/appearance",
     "test/css/backgroundcliptext",
     "test/css/backgroundposition-shorthand",
     "test/css/backgroundposition-xy",


### PR DESCRIPTION
This PR adds detection for CSS appearance support.

The appearance property does not appear in any CSS specification yet, but property is really useful and has [quite good browser support](http://caniuse.com/#feat=css-appearance). I think it's time to add this feature detection to Modernizr.