### PR TITLE
Improves error handling in bind, per es5-shim implementation

### DIFF
--- a/modernizr.js
+++ b/modernizr.js
@@ -246,8 +246,11 @@ window.Modernizr = (function( window, document, undefined ) {
 
         var target = this;
 
-        if (typeof target != "function") {
-            throw new TypeError();
+        try {
+          Object.prototype.toString.call(target) === '[object Function]';
+        }
+        catch(err) {
+          throw new TypeError(err);
         }
 
         var args = slice.call(arguments, 1),


### PR DESCRIPTION
The Function.prototype.bind, borrowed from es5-shim, is using typeof to determine whether arguments passed through bind are functions or not. This has the unintended side effect of inadvertently halting js processing in older browsers, where a try/catch would be more appropriate.

A few others have experienced this problem but no solution is proposed:
http://stackoverflow.com/questions/12569030/modernizr-causing-errors-in-ie8-exception-handling
https://github.com/pimterry/loglevel/issues/21
http://w3facility.org/question/modernizr-causing-errors-in-ie8-exception-handling/
https://www.bountysource.com/issues/1569186-stack-overflow-error-when-running-a-simple-app-in-ie8-started-on-meteor-0-8-0

The es5-shim library from which this functionality originates appropriately uses an isFunction helper to check whether the object is a function instead. The following commit introduces this check to the modernizr adaptation.

https://github.com/es-shims/es5-shim/blob/master/es5-shim.js#L56