### PR TITLE
Use `window` instead of `this` to set scoped global object reference

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -141,7 +141,7 @@ module.exports = function( grunt ) {
           fileExclusionRegExp: /^(.git|node_modules|modulizr|media|test)$/,
           wrap: {
             start: '<%= banner.full %>' + '\n;(function(window, document, undefined){',
-            end: '})(this, document);'
+            end: '})(window, document);'
           },
           onBuildWrite: function (id, path, contents) {
             if ((/define\(.*?\{/).test(contents)) {


### PR DESCRIPTION
This pull request resolves #1431. Per my comment on that issue:

> Modernizr's assumption that `this === window` is causing it to break for an increasing number of us who use Browserify and similar tools. Wherever Modernizr's code is executed with a non-global function context, it will break. We can work around it by adding some extra steps to our build tools, but it could be avoided entirely by replacing the offending line with something like `})(window, document);`
>
> `this` was once used to shorten walks up the scope, [but `window` seems to work just as well for that](http://jsperf.com/this-vs-window-for-global-object-access).
