### PR TITLE
update webgl test to use probablySupportsContext

### DIFF
--- a/feature-detects/webgl.js
+++ b/feature-detects/webgl.js
@@ -10,9 +10,10 @@
 define(['Modernizr', 'createElement'], function( Modernizr, createElement ) {
   Modernizr.addTest('webgl', function() {
     var canvas = createElement('canvas');
-    if ('supportsContext' in canvas) {
-      return canvas.supportsContext('webgl') || canvas.supportsContext('experimental-webgl');
+    var supports = 'probablySupportsContext' in canvas ? 'probablySupportsContext' :  'supportsContext';
+    if (supports in canvas) {
+      return canvas[supports]('webgl') || canvas[supports]('experimental-webgl');
     }
-    return !!window.WebGLRenderingContext;
+    return 'WebGLRenderingContext' in window;
   });
 });


### PR DESCRIPTION
fixes #1499 

spec was updated to use `probablySupportsContext` instead of `supportsContext`: https://developers.whatwg.org/the-canvas-element.html#dom-canvas-probablysupportscontext

WHATWG thread: https://lists.w3.org/Archives/Public/public-whatwg-archive/2013Sep/0013.html

updated in WebKit here: https://bugs.webkit.org/show_bug.cgi?id=120716

AFAICT `supportsContext` was only ever implemented in WebKit and `supportsContext` was replaced with `probablySupportsContext` in WebKit three months later, so it seems sufficient to just replace `supportsContext`. I've only tested in Safari 7 and iOS 7, however.