### PR TITLE
csstransform3d detect should prefer css conditionals - fixes #1512

### DIFF
--- a/feature-detects/css/transforms3d.js
+++ b/feature-detects/css/transforms3d.js
@@ -9,7 +9,7 @@
   ]
 }
 !*/
-define(['Modernizr', 'testAllProps', 'testStyles', 'docElement'], function( Modernizr, testAllProps, testStyles, docElement ) {
+define(['Modernizr', 'testAllProps', 'testStyles', 'docElement', 'test/css/supports'], function( Modernizr, testAllProps, testStyles, docElement ) {
   Modernizr.addTest('csstransforms3d', function() {
     var ret = !!testAllProps('perspective', '1px', true);
     var usePrefix = Modernizr._config.usePrefixes;
@@ -19,12 +19,17 @@ define(['Modernizr', 'testAllProps', 'testStyles', 'docElement'], function( Mode
     //   some conditions. As a result, Webkit typically recognizes the syntax but
     //   will sometimes throw a false positive, thus we must do a more thorough check:
     if ( ret && (!usePrefix || 'webkitPerspective' in docElement.style )) {
-
-      // Webkit allows this media query to succeed only if the feature is enabled.
-      // `@media (transform-3d),(-webkit-transform-3d){ ... }`
+      var mq;
+      // Use CSS Conditional Rules if available
+      if (Modernizr.supports) {
+        mq = '@supports (perspective: 1px)';
+      } else {
+        // Otherwise, Webkit allows this media query to succeed only if the feature is enabled.
+        // `@media (transform-3d),(-webkit-transform-3d){ ... }`
+        mq = '@media (transform-3d)';
+        if (usePrefix ) mq += ',(-webkit-transform-3d)';
+      }
       // If loaded inside the body tag and the test element inherits any padding, margin or borders it will fail #740
-      var mq = '@media (transform-3d)';
-      if (usePrefix ) mq += ',(-webkit-transform-3d)';
       mq += '{#modernizr{left:9px;position:absolute;height:5px;margin:0;padding:0;border:0}}';
 
       testStyles(mq, function( elem ) {


### PR DESCRIPTION
This fixes https://github.com/Modernizr/Modernizr/issues/1512
There's several ways this could be done.  This looked cleanest to me.

The root cause is that EdgeHTML looks a lot like webkit now.  So it falls through the existing double-check for a old webkit bug (referenced in the code comments, also see  https://github.com/Modernizr/Modernizr/issues/15) where css 3d transforms were sometimes not correctly detected due to GPU acceleration.

However, that double-check relies on the non-standard [at]media(transform-3d) media query.  We've been discussing this with the W3C and consensus is that this media query should go away from browsers, but that's contingent on updating content relying on it (including Modernizr).

Context: http://lists.w3.org/Archives/Public/www-style/2014Oct/0390.html and https://code.google.com/p/chromium/issues/detail?id=426644 

So my proposed fix here is to prefer the standardized CSS supports detection mechanism and only fall back to the [at]media rule when CSS at supports isn't available.

I've tested and validated this on IE (6-11 doc modes), Spartan, Chrome, Firefox, Opera (blink-based), and Safari (Mac and iOS).

Note that this fix won't work in the latest public EdgeHTML preview builds quite yet still because it doesn't have [at]supports. But I have special builds. :-) Coming soon to public preview builds.