### PR TITLE
Catch window.find exception in FF for Android, fixes #1438

### DIFF
--- a/feature-detects/css/hyphens.js
+++ b/feature-detects/css/hyphens.js
@@ -165,15 +165,15 @@ define(['Modernizr', 'prefixes', 'createElement', 'testAllProps', 'addTest'], fu
           }
 
           /* try to find the doubled testword, without the delimiter */
-          if (window.find) {
-            result = window.find(testword + testword);
-          } else {
-            try {
+          try {
+            if (window.find) {
+              result = window.find(testword + testword);
+            } else {
               textrange = window.self.document.body.createTextRange();
               result = textrange.findText(testword + testword);
-            } catch (e) {
-              result = false;
             }
+          } catch (e) {
+            result = false;
           }
 
           document.body.removeChild(div);


### PR DESCRIPTION
This prevents lebowskilebowski being left at the top of the page when using Firefox on Android.

Firefox on Android throws a NS_ERROR_NOT_AVAILABLE exception when calling window.find()

Happens on FF35.0 and Android 4.4.4

Screenshot: #1438