### PR TITLE
Docs cleanup in mq.js

### DIFF
--- a/src/mq.js
+++ b/src/mq.js
@@ -1,13 +1,13 @@
 define(['ModernizrProto', 'testMediaQuery'], function( ModernizrProto, testMediaQuery ) {
-  /** Modernizr.mq tests a given media query, live against the current state of the window
-   * A few important notes:
-       * If a browser does not support media queries at all (eg. oldIE) the mq() will always return false
-       * A max-width or orientation query will be evaluated against the current state, which may change later.
-       * You must specify values. Eg. If you are testing support for the min-width media query use:
-           Modernizr.mq('(min-width:0)')
-    * usage:
-    * Modernizr.mq('only screen and (max-width:768)')
-    */ 
+/** Modernizr.mq tests a given media query, live against the current state of the window
+  * A few important notes:
+      * If a browser does not support media queries at all (eg. oldIE) the mq() will always return false
+      * A max-width or orientation query will be evaluated against the current state, which may change later.
+      * You must specify values. Eg. If you are testing support for the min-width media query use:
+          Modernizr.mq('(min-width:0)')
+  * usage:
+  * Modernizr.mq('only screen and (max-width:768)')
+*/ 
   var mq = ModernizrProto.mq = testMediaQuery;
   return mq;
 });

--- a/src/mq.js
+++ b/src/mq.js
@@ -7,7 +7,7 @@ define(['ModernizrProto', 'testMediaQuery'], function( ModernizrProto, testMedia
           Modernizr.mq('(min-width:0)')
   * usage:
   * Modernizr.mq('only screen and (max-width:768)')
-*/ 
+*/
   var mq = ModernizrProto.mq = testMediaQuery;
   return mq;
 });

--- a/src/mq.js
+++ b/src/mq.js
@@ -1,12 +1,13 @@
 define(['ModernizrProto', 'testMediaQuery'], function( ModernizrProto, testMediaQuery ) {
-  // Modernizr.mq tests a given media query, live against the current state of the window
-  // A few important notes:
-  //   * If a browser does not support media queries at all (eg. oldIE) the mq() will always return false
-  //   * A max-width or orientation query will be evaluated against the current state, which may change later.
-  //   * You must specify values. Eg. If you are testing support for the min-width media query use:
-  //       Modernizr.mq('(min-width:0)')
-  // usage:
-  // Modernizr.mq('only screen and (max-width:768)')
+  /** Modernizr.mq tests a given media query, live against the current state of the window
+   * A few important notes:
+       * If a browser does not support media queries at all (eg. oldIE) the mq() will always return false
+       * A max-width or orientation query will be evaluated against the current state, which may change later.
+       * You must specify values. Eg. If you are testing support for the min-width media query use:
+           Modernizr.mq('(min-width:0)')
+    * usage:
+    * Modernizr.mq('only screen and (max-width:768)')
+    */ 
   var mq = ModernizrProto.mq = testMediaQuery;
   return mq;
 });


### PR DESCRIPTION
I think for better organization, it should be switched to a full doc block.