### PR TITLE
Add docs badge to README

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,14 @@
   "bugs": {
     "url": "https://github.com/Modernizr/Modernizr/issues"
   },
+  "inch": {
+    "files": {
+        "included": [
+          "feature-detects/",
+          "src/"
+        ]
+      }
+  },
   "keywords": [
     "html5",
     "css3",

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-# Modernizr [![Build Status](http://img.shields.io/travis/Modernizr/Modernizr/master.svg)](http://travis-ci.org/Modernizr/Modernizr)
+# Modernizr [![Build Status](http://img.shields.io/travis/Modernizr/Modernizr/master.svg)](http://travis-ci.org/Modernizr/Modernizr) [![Inline docs](http://inch-ci.org/github/Modernizr/Modernizr.svg?branch=master)](http://inch-ci.org/github/Modernizr/Modernizr)
 
 ##### Modernizr is a JavaScript library that detects HTML5 and CSS3 features in the user’s browser.
 


### PR DESCRIPTION
Hi there,

I want to propose to add this badge to the README to show off inline-documentation: [![Inline docs](http://inch-ci.org/github/Modernizr/Modernizr.svg)](http://inch-ci.org/github/Modernizr/Modernizr)

The badge links to [Inch CI](http://inch-ci.org) and shows an evaluation by [InchJS](http://trivelop.de/inchjs), a project that tries to raise the visibility of inline-docs. Besides testing and other coverage, documenting your code is often neglected although it is a very engaging part of Open Source that encourages aspiring developers to jump into the source and see how it all ties together.

So far over 600 **Ruby** projects are sporting these badges to raise awareness for the importance of inline-docs and to show potential contributors that they can expect a certain level of code documentation when they dive into your project's code and motivate them to eventually document their own. I would really like to do the same for the **JavaScript** community and roll out support for JS over the coming weeks (early adopters are [forever](https://github.com/foreverjs/forever), [node-sass](https://github.com/sass/node-sass) and [when](https://github.com/cujojs/when)).

Although this is "only" a passion project, I really would like to hear your thoughts, critique and suggestions. Your status page is http://inch-ci.org/github/Modernizr/Modernizr

What do you think?