### PR TITLE
fix vmin and vmax tests for windows browsers

### DIFF
--- a/feature-detects/css/vmaxunit.js
+++ b/feature-detects/css/vmaxunit.js
@@ -14,7 +14,7 @@
   }]
 }
 !*/
-define(['Modernizr', 'docElement', 'testStyles'], function( Modernizr, docElement, testStyles ) {
+define(['Modernizr', 'docElement', 'testStyles', 'roundedEquals'], function( Modernizr, docElement, testStyles, roundedEquals ) {
   testStyles('#modernizr1{width: 50vmax}#modernizr2{width:50px;height:50px;overflow:scroll}', function() {
     var elem = document.getElementById('modernizr1');
     var scroller = document.getElementById('modernizr2');
@@ -27,6 +27,6 @@ define(['Modernizr', 'docElement', 'testStyles'], function( Modernizr, docElemen
                           getComputedStyle(elem, null) :
                           elem.currentStyle)['width'],10);
 
-    Modernizr.addTest('cssvmaxunit', expectedWidth === compWidth || expectedWidth === compWidth - scrollbarWidth);
+    Modernizr.addTest('cssvmaxunit', roundedEquals(expectedWidth, compWidth) || roundedEquals(expectedWidth, compWidth - scrollbarWidth));
   }, 2);
 });

--- a/feature-detects/css/vmaxunit.js
+++ b/feature-detects/css/vmaxunit.js
@@ -15,12 +15,18 @@
 }
 !*/
 define(['Modernizr', 'docElement', 'testStyles'], function( Modernizr, docElement, testStyles ) {
-  testStyles('#modernizr { width: 50vmax; }', function( elem ) {
+  testStyles('#modernizr1{width: 50vmax}#modernizr2{width:50px;height:50px;overflow:scroll}', function() {
+    var elem = document.getElementById('modernizr1');
+    var scroller = document.getElementById('modernizr2');
+    var scrollbarWidth = parseInt((scroller.offsetWidth - scroller.clientWidth) / 2, 10);
+
     var one_vw = docElement.clientWidth/100;
     var one_vh = docElement.clientHeight/100;
+    var expectedWidth = parseInt(Math.max(one_vw, one_vh) * 50, 10);
     var compWidth = parseInt((window.getComputedStyle ?
                           getComputedStyle(elem, null) :
                           elem.currentStyle)['width'],10);
-    Modernizr.addTest('cssvmaxunit', parseInt(Math.max(one_vw, one_vh)*50,10) == compWidth );
-  });
+
+    Modernizr.addTest('cssvmaxunit', expectedWidth === compWidth || expectedWidth === compWidth - scrollbarWidth);
+  }, 2);
 });

--- a/feature-detects/css/vminunit.js
+++ b/feature-detects/css/vminunit.js
@@ -15,12 +15,18 @@
 }
 !*/
 define(['Modernizr', 'docElement', 'testStyles'], function( Modernizr, docElement, testStyles ) {
-  testStyles('#modernizr { width: 50vmin; }', function( elem ) {
+  testStyles('#modernizr1{width: 50vmin}#modernizr2{width:50px;height:50px;overflow:scroll}', function() {
+    var elem = document.getElementById('modernizr1');
+    var scroller = document.getElementById('modernizr2');
+    var scrollbarWidth = parseInt((scroller.offsetWidth - scroller.clientWidth) / 2, 10);
+
     var one_vw = docElement.clientWidth/100;
     var one_vh = docElement.clientHeight/100;
+    var expectedWidth = parseInt(Math.min(one_vw, one_vh) * 50, 10);
     var compWidth = parseInt((window.getComputedStyle ?
                           getComputedStyle(elem, null) :
                           elem.currentStyle)['width'],10);
-    Modernizr.addTest('cssvminunit', parseInt(Math.min(one_vw, one_vh)*50,10) == compWidth );
-  });
+
+    Modernizr.addTest('cssvminunit', expectedWidth === compWidth || expectedWidth === compWidth - scrollbarWidth);
+  }, 2);
 });

--- a/feature-detects/css/vminunit.js
+++ b/feature-detects/css/vminunit.js
@@ -15,7 +15,7 @@
 }
 !*/
 define(['Modernizr', 'docElement', 'testStyles', 'roundedEquals'], function( Modernizr, docElement, testStyles, roundedEquals ) {
-  testStyles('#modernizr1{width: 50vmin}#modernizr2{width:50px;height:50px;overflow:scroll}', function() {
+  testStyles('#modernizr1{width: 50vm;width:50vmin}#modernizr2{width:50px;height:50px;overflow:scroll}', function() {
     var elem = document.getElementById('modernizr1');
     var scroller = document.getElementById('modernizr2');
     var scrollbarWidth = parseInt((scroller.offsetWidth - scroller.clientWidth) / 2, 10);

--- a/feature-detects/css/vminunit.js
+++ b/feature-detects/css/vminunit.js
@@ -14,7 +14,7 @@
   }]
 }
 !*/
-define(['Modernizr', 'docElement', 'testStyles'], function( Modernizr, docElement, testStyles ) {
+define(['Modernizr', 'docElement', 'testStyles', 'roundedEquals'], function( Modernizr, docElement, testStyles, roundedEquals ) {
   testStyles('#modernizr1{width: 50vmin}#modernizr2{width:50px;height:50px;overflow:scroll}', function() {
     var elem = document.getElementById('modernizr1');
     var scroller = document.getElementById('modernizr2');
@@ -27,6 +27,6 @@ define(['Modernizr', 'docElement', 'testStyles'], function( Modernizr, docElemen
                           getComputedStyle(elem, null) :
                           elem.currentStyle)['width'],10);
 
-    Modernizr.addTest('cssvminunit', expectedWidth === compWidth || expectedWidth === compWidth - scrollbarWidth);
+    Modernizr.addTest('cssvminunit', roundedEquals(expectedWidth, compWidth) || roundedEquals(expectedWidth, compWidth - scrollbarWidth));
   }, 2);
 });

--- a/src/roundedEquals.js
+++ b/src/roundedEquals.js
@@ -1,0 +1,8 @@
+define(function() {
+  // Change the function's scope.
+  function roundedEquals(a, b) {
+    return a - 1 === b || a === b || a + 1 === b;
+  }
+
+  return roundedEquals;
+});

--- a/test/browser/src/roundedEquals.js
+++ b/test/browser/src/roundedEquals.js
@@ -1,0 +1,28 @@
+describe('roundedEquals', function() {
+  var roundedEquals;
+  var cleanup;
+
+  before(function(done) {
+
+    requirejs.config({
+      baseUrl: '../src',
+      paths: { cleanup: '../test/cleanup' }
+    });
+
+    requirejs(['roundedEquals', 'cleanup'], function(_roundedEquals, _cleanup) {
+      roundedEquals = _roundedEquals;
+      cleanup = _cleanup;
+      done();
+    });
+  });
+
+  it('works', function() {
+    expect(roundedEquals(1, 2)).to.be(true);
+    expect(roundedEquals(2, 2)).to.be(true);
+    expect(roundedEquals(3, 2)).to.be(true);
+  });
+
+  after(function() {
+    cleanup();
+  });
+});


### PR DESCRIPTION
firefox was failing on the test page because of the scrollbars on the page.

these detects are virtually identical - should we combine them?