### PR TITLE
fixes for ie 11

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -70,7 +70,9 @@ module.exports = function( grunt ) {
         files: {
           src: [
             '<%= env.nodeTests%>',
-            '<%= env.browserTests %>'
+            '<%= env.browserTests %>',
+            'test/browser/setup.js',
+            'test/browser/integration/*.js'
           ]
         }
       }

--- a/feature-detects/crypto/getrandomvalues.js
+++ b/feature-detects/crypto/getrandomvalues.js
@@ -17,8 +17,9 @@
 /* DOC
 Detects support for the window.crypto.getRandomValues for generate cryptographically secure random numbers
 */
-define(['Modernizr'], function( Modernizr ) {
+define(['Modernizr', 'prefixed'], function( Modernizr, prefixed ) {
   // In Safari <=5.0 `window.crypto` exists (for some reason) but is `undefined`, so we have to check
   // it’s truthy before checking for existence of `getRandomValues`
-  Modernizr.addTest('getrandomvalues', 'crypto' in window && !!window.crypto && 'getRandomValues' in window.crypto);
+  var crypto = prefixed('crypto', window);
+  Modernizr.addTest('getrandomvalues', !!crypto && 'getRandomValues' in crypto);
 });

--- a/test/browser/integration/caniuse.js
+++ b/test/browser/integration/caniuse.js
@@ -200,7 +200,7 @@ window.caniusecb = function(caniuse) {
         return it('Caniuse result for ' + o.ciufeature + ' matches Modernizr\'s result for ' + o.feature, function() {
           return expect([
             Modernizr.meter,
-            Modernizr.progressmeter
+            Modernizr.progressbar
           ]).to.contain(ciubool);
         });
       }

--- a/test/browser/setup.js
+++ b/test/browser/setup.js
@@ -1,3 +1,4 @@
+/* globals mocha, __coverage__ */
 $(document).ready(function() {
   var runner = mocha.run();
 

--- a/test/js/lib/uaparser.js
+++ b/test/js/lib/uaparser.js
@@ -180,6 +180,9 @@
       {"pattern":"(Teleca Q7)",
        "v1_replacement":null,
        "family_replacement":null},
+      {"pattern":"Trident(.*)rv.(\\d+)\.(\\d+)",
+       "v1_replacement":null,
+       "family_replacement":"IE"},
       {"pattern":"(MSIE) (\\d+)\\.(\\d+)",
        "v1_replacement":null,
        "family_replacement":"IE"}


### PR DESCRIPTION
* added some files to jshint, that were previously missing and caused temporarily cause a broken master
* update getRandomValues to support `window.msCrypto` as well
* fix typo in caniuse mapping
* add IE 11 to ua-parser mapping