### PR TITLE
Detect emoji support with various device pixel ratio

### DIFF
--- a/feature-detects/emoji.js
+++ b/feature-detects/emoji.js
@@ -9,13 +9,16 @@ Detects support for emoji character sets.
 */
 define(['Modernizr', 'createElement', 'test/canvastext'], function( Modernizr, createElement ) {
   Modernizr.addTest('emoji', function() {
-    if (!Modernizr.canvastext) return false;
+    if (!Modernizr.canvastext || !window.devicePixelRatio) return false;
     var node = createElement('canvas'),
-    ctx = node.getContext('2d');
+    ctx = node.getContext('2d'),
+    startPointX = 8 * window.devicePixelRatio,
+    startPointY = 8 * window.devicePixelRatio;
+    
     ctx.fillStyle = '#f00';
     ctx.textBaseline = 'top';
     ctx.font = '32px Arial';
     ctx.fillText('\ud83d\udc28', 0, 0); // U+1F428 KOALA
-    return ctx.getImageData(16, 16, 1, 1).data[0] !== 0;
+    return ctx.getImageData(startPointX, startPointY, 1, 1).data[0] !== 0;
   });
 });


### PR DESCRIPTION
Sampling a pixel to detect if it has a fill color could vary with screen
pixel density and thus return inaccurate results.