### PR TITLE
Fixed a regression on webkit family browsers with devicePixelRatio 1

### DIFF
--- a/feature-detects/emoji.js
+++ b/feature-detects/emoji.js
@@ -11,7 +11,7 @@ define(['Modernizr', 'createElement', 'test/canvastext'], function( Modernizr, c
   Modernizr.addTest('emoji', function() {
     if (!Modernizr.canvastext) return false;
     var pixelRatio = window.devicePixelRatio || 1;
-    var offset = 8 * pixelRatio;
+    var offset = 12 * pixelRatio;
     var node = createElement('canvas');
     var ctx = node.getContext('2d');
     ctx.fillStyle = '#f00';


### PR DESCRIPTION
Shifting the image detection by a few pixels seems to solve a false negative on chrome and safari with devicePixelRatio 1.