### PR TITLE
Flash: Attach fake body only when actually needed

### DIFF
--- a/feature-detects/flash.js
+++ b/feature-detects/flash.js
@@ -13,6 +13,11 @@ define(['Modernizr', 'createElement', 'docElement', 'addTest', 'getBody', 'isSVG
   Modernizr.addAsyncTest(function() {
     /* jshint -W053 */
 
+    var attachBody = function(body) {
+      if (!docElement.contains(body)) {
+        docElement.appendChild(body);
+      }
+    };
     var removeFakeBody = function(body) {
       // If we’re rockin’ an attached fake body, clean it up
       if (body.fake && body.parentNode) {
@@ -64,11 +69,11 @@ define(['Modernizr', 'createElement', 'docElement', 'addTest', 'getBody', 'isSVG
 
       // Need to do this in the body (fake or otherwise) otherwise IE8 complains
       body.appendChild(embed);
-      docElement.appendChild(body);
 
       // Pan doesn't exist in the embed if its IE (its on the ActiveXObjeect)
       // so this check is for all other browsers.
       if (!('Pan' in embed) && !activex) {
+        attachBody(body);
         runTest('blocked', embed);
         removeFakeBody(body);
         return;
@@ -78,6 +83,7 @@ define(['Modernizr', 'createElement', 'docElement', 'addTest', 'getBody', 'isSVG
         // if we used a fake body originally, we need to restart this test, since
         // we haven't been attached to the DOM, and therefore none of the blockers
         // have had time to work.
+        attachBody(body);
         if (!docElement.contains(body)) {
           body = document.body || body;
           embed = createElement('embed');


### PR DESCRIPTION
I was getting the infamous IE8 error `HTML Parsing Error: Unable to modify the parent container element before the child element is closed (KB927917)` when trying to use and attach fake `body` to `html`. Little testing and trying and I came to the solution that attached `body` only when it’s actually needed for checking, and that’s in two places, but with additional check to se if it’s available inside `docElement`.

Is this making any sense? :)