### PR TITLE
Add jscs to check style

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -1,0 +1,9 @@
+{
+	"preset": "google",
+	"disallowKeywordsOnNewLine": null,
+	"disallowMultipleVarDecl": null,
+	"disallowMultipleLineBreaks": null,
+	"maximumLineLength": null,
+	"requireCamelCaseOrUpperCaseIdentifiers": null,
+	"validateIndentation": null
+}

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -2,7 +2,7 @@
 
 var browsers = require('./test/browser/sauce-browsers.json');
 
-module.exports = function( grunt ) {
+module.exports = function(grunt) {
   'use strict';
 
   // Load grunt dependencies
@@ -48,6 +48,16 @@ module.exports = function( grunt ) {
           }
         ]
       }
+    },
+    jscs: {
+      src: [
+        'Gruntfile.js',
+        'src/*.js',
+        'lib/*.js',
+        'feature-detects/**/*.js',
+        '!src/html5printshiv.js',
+        '!src/html5shiv.js'
+      ]
     },
     jshint: {
       options: {
@@ -216,17 +226,19 @@ module.exports = function( grunt ) {
 
   grunt.registerTask('browserTests', ['connect', 'mocha']);
 
-  grunt.registerTask('build', [ 'clean', 'generate' ]);
+  grunt.registerTask('build', ['clean', 'generate']);
 
-  grunt.registerTask('default', [ 'jshint', 'build' ]);
+  grunt.registerTask('lint', ['jshint', 'jscs']);
 
-  var tests = ['clean', 'jshint', 'jade', 'instrument', 'env:coverage', 'nodeTests' ];
+  grunt.registerTask('default', ['lint', 'build']);
+
+  var tests = ['clean', 'lint', 'jade', 'instrument', 'env:coverage', 'nodeTests'];
 
   if (process.env.APPVEYOR) {
     grunt.registerTask('test', tests);
   } else if (process.env.BROWSER_COVERAGE !== 'true') {
     grunt.registerTask('test', tests.concat(['generate', 'browserTests']));
   } else {
-    grunt.registerTask('test', tests.concat([ 'generate', 'storeCoverage', 'browserTests', 'saucelabs-custom', 'makeReport', 'coveralls' ]));
+    grunt.registerTask('test', tests.concat(['generate', 'storeCoverage', 'browserTests', 'saucelabs-custom', 'makeReport', 'coveralls']));
   }
 };

--- a/feature-detects/a/download.js
+++ b/feature-detects/a/download.js
@@ -14,6 +14,6 @@
 /* DOC
 When used on an `<a>`, this attribute signifies that the resource it points to should be downloaded by the browser rather than navigating to it.
 */
-define(['Modernizr', 'createElement'], function( Modernizr, createElement ) {
+define(['Modernizr', 'createElement'], function(Modernizr, createElement) {
   Modernizr.addTest('adownload', !window.externalHost && 'download' in createElement('a'));
 });

--- a/feature-detects/ambientlight.js
+++ b/feature-detects/ambientlight.js
@@ -11,6 +11,6 @@
 /* DOC
 Detects support for the API that provides information about the ambient light levels, as detected by the device's light detector, in terms of lux units.
 */
-define(['Modernizr', 'hasEvent'], function( Modernizr, hasEvent ) {
+define(['Modernizr', 'hasEvent'], function(Modernizr, hasEvent) {
   Modernizr.addTest('ambientlight', hasEvent('devicelight', window));
 });

--- a/feature-detects/applicationcache.js
+++ b/feature-detects/applicationcache.js
@@ -16,6 +16,6 @@ Detects support for the Application Cache, for storing data to enable web-based 
 
 The API has been [heavily criticized](http://alistapart.com/article/application-cache-is-a-douchebag) and discussions are underway to address this.
 */
-define(['Modernizr'], function( Modernizr ) {
+define(['Modernizr'], function(Modernizr) {
   Modernizr.addTest('applicationcache', 'applicationCache' in window);
 });

--- a/feature-detects/audio.js
+++ b/feature-detects/audio.js
@@ -8,7 +8,7 @@
 /* DOC
 Detects the audio element
 */
-define(['Modernizr', 'createElement'], function( Modernizr, createElement ) {
+define(['Modernizr', 'createElement'], function(Modernizr, createElement) {
   // This tests evaluates support of the audio element, as well as
   // testing what types of content it supports.
   //
@@ -28,20 +28,20 @@ define(['Modernizr', 'createElement'], function( Modernizr, createElement ) {
     var bool = false;
 
     try {
-      if ( bool = !!elem.canPlayType ) {
+      if (bool = !!elem.canPlayType) {
         bool      = new Boolean(bool);
-        bool.ogg  = elem.canPlayType('audio/ogg; codecs="vorbis"').replace(/^no$/,'');
-        bool.mp3  = elem.canPlayType('audio/mpeg;')               .replace(/^no$/,'');
-        bool.opus  = elem.canPlayType('audio/ogg; codecs="opus"') .replace(/^no$/,'');
+        bool.ogg  = elem.canPlayType('audio/ogg; codecs="vorbis"').replace(/^no$/, '');
+        bool.mp3  = elem.canPlayType('audio/mpeg;')               .replace(/^no$/, '');
+        bool.opus  = elem.canPlayType('audio/ogg; codecs="opus"') .replace(/^no$/, '');
 
         // Mimetypes accepted:
         //   developer.mozilla.org/En/Media_formats_supported_by_the_audio_and_video_elements
         //   bit.ly/iphoneoscodecs
-        bool.wav  = elem.canPlayType('audio/wav; codecs="1"')     .replace(/^no$/,'');
-        bool.m4a  = ( elem.canPlayType('audio/x-m4a;')            ||
-                     elem.canPlayType('audio/aac;'))             .replace(/^no$/,'');
+        bool.wav  = elem.canPlayType('audio/wav; codecs="1"')     .replace(/^no$/, '');
+        bool.m4a  = (elem.canPlayType('audio/x-m4a;')            ||
+                     elem.canPlayType('audio/aac;'))             .replace(/^no$/, '');
       }
-    } catch(e) { }
+    } catch (e) { }
 
     return bool;
   });

--- a/feature-detects/audio/loop.js
+++ b/feature-detects/audio/loop.js
@@ -8,6 +8,6 @@
 /* DOC
 Detects if an audio element can automatically restart, once it has finished
 */
-define(['Modernizr', 'createElement'], function( Modernizr, createElement ) {
+define(['Modernizr', 'createElement'], function(Modernizr, createElement) {
   Modernizr.addTest('audioloop', 'loop' in createElement('audio'));
 });

--- a/feature-detects/audio/preload.js
+++ b/feature-detects/audio/preload.js
@@ -8,6 +8,6 @@
 /* DOC
 Detects if audio can be downloaded in the background before it starts playing in the `<audio>` element
 */
-define(['Modernizr', 'createElement'], function( Modernizr, createElement ) {
+define(['Modernizr', 'createElement'], function(Modernizr, createElement) {
   Modernizr.addTest('audiopreload', 'preload' in createElement('audio'));
 });

--- a/feature-detects/audio/webaudio.js
+++ b/feature-detects/audio/webaudio.js
@@ -16,12 +16,14 @@
 /* DOC
 Detects the older non standard webaudio API, (as opposed to the standards based AudioContext API)
 */
-define(['Modernizr'], function( Modernizr ) {
+define(['Modernizr'], function(Modernizr) {
   Modernizr.addTest('webaudio', function() {
     var prefixed = 'webkitAudioContext' in window;
     var unprefixed = 'AudioContext' in window;
 
-    if (Modernizr._config.usePrefixes) return prefixed || unprefixed;
+    if (Modernizr._config.usePrefixes) {
+      return prefixed || unprefixed;
+    }
     return unprefixed;
   });
 });

--- a/feature-detects/battery.js
+++ b/feature-detects/battery.js
@@ -15,6 +15,6 @@
 /* DOC
 Detect support for the Battery API, for accessing information about the system's battery charge level.
 */
-define(['Modernizr', 'prefixed'], function( Modernizr, prefixed ) {
-  Modernizr.addTest('batteryapi', !!prefixed('battery', navigator), { aliases: ['battery-api'] });
+define(['Modernizr', 'prefixed'], function(Modernizr, prefixed) {
+  Modernizr.addTest('batteryapi', !!prefixed('battery', navigator), {aliases: ['battery-api']});
 });

--- a/feature-detects/battery/lowbattery.js
+++ b/feature-detects/battery/lowbattery.js
@@ -14,7 +14,7 @@
 /* DOC
 Enable a developer to remove CPU intensive CSS/JS when battery is low
 */
-define(['Modernizr', 'prefixed'], function( Modernizr, prefixed ) {
+define(['Modernizr', 'prefixed'], function(Modernizr, prefixed) {
   Modernizr.addTest('lowbattery', function() {
     var minLevel = 0.20;
     var battery = prefixed('battery', navigator);

--- a/feature-detects/blob.js
+++ b/feature-detects/blob.js
@@ -15,8 +15,8 @@
 /* DOC
 Detects support for the Blob constructor, for creating file-like objects of immutable, raw data.
 */
-define(['Modernizr'], function( Modernizr ) {
-  Modernizr.addTest('blobconstructor', function () {
+define(['Modernizr'], function(Modernizr) {
+  Modernizr.addTest('blobconstructor', function() {
     try {
       return !!new Blob();
     } catch (e) {

--- a/feature-detects/canvas.js
+++ b/feature-detects/canvas.js
@@ -10,7 +10,7 @@
 /* DOC
 Detects support for the `<canvas>` element for 2D drawing.
 */
-define(['Modernizr', 'createElement'], function( Modernizr, createElement ) {
+define(['Modernizr', 'createElement'], function(Modernizr, createElement) {
   // On the S60 and BB Storm, getContext exists, but always returns undefined
   // so we actually have to call getContext() to verify
   // github.com/Modernizr/Modernizr/issues/issue/97/

--- a/feature-detects/canvas/blending.js
+++ b/feature-detects/canvas/blending.js
@@ -17,10 +17,12 @@
 /* DOC
 Detects if Photoshop style blending modes are available in canvas.
 */
-define(['Modernizr', 'createElement', 'test/canvas'], function( Modernizr, createElement ) {
+define(['Modernizr', 'createElement', 'test/canvas'], function(Modernizr, createElement) {
 
   Modernizr.addTest('canvasblending', function() {
-    if (Modernizr.canvas === false) return false;
+    if (Modernizr.canvas === false) {
+      return false;
+    }
     var ctx = createElement('canvas').getContext('2d');
     // firefox 3 throws an error when setting an invalid `globalCompositeOperation`
     try {

--- a/feature-detects/canvas/todataurl.js
+++ b/feature-detects/canvas/todataurl.js
@@ -11,7 +11,7 @@
   }]
 }
 !*/
-define(['Modernizr', 'createElement', 'test/canvas'], function( Modernizr, createElement ) {
+define(['Modernizr', 'createElement', 'test/canvas'], function(Modernizr, createElement) {
 
   var canvas = createElement('canvas');
 
@@ -27,7 +27,7 @@ define(['Modernizr', 'createElement', 'test/canvas'], function( Modernizr, creat
     // firefox 3 throws an error when you use an "invalid" toDataUrl
     try {
       supports = !!Modernizr.canvas && canvas.toDataURL('image/webp').indexOf('data:image/webp') === 0;
-    } catch(e) {}
+    } catch (e) {}
 
     return supports;
   });

--- a/feature-detects/canvas/winding.js
+++ b/feature-detects/canvas/winding.js
@@ -13,10 +13,12 @@
 /* DOC
 Determines if winding rules, which controls if a path can go clockwise or counterclockwise
 */
-define(['Modernizr', 'createElement', 'test/canvas'], function( Modernizr, createElement ) {
+define(['Modernizr', 'createElement', 'test/canvas'], function(Modernizr, createElement) {
 
   Modernizr.addTest('canvaswinding', function() {
-    if (Modernizr.canvas === false) return false;
+    if (Modernizr.canvas === false) {
+      return false;
+    }
     var ctx = createElement('canvas').getContext('2d');
 
     ctx.rect(0, 0, 10, 10);

--- a/feature-detects/canvastext.js
+++ b/feature-detects/canvastext.js
@@ -10,9 +10,11 @@
 /* DOC
 Detects support for the text APIs for `<canvas>` elements.
 */
-define(['Modernizr', 'createElement', 'test/canvas'], function( Modernizr, createElement ) {
+define(['Modernizr', 'createElement', 'test/canvas'], function(Modernizr, createElement) {
   Modernizr.addTest('canvastext',  function() {
-    if (Modernizr.canvas  === false) return false;
+    if (Modernizr.canvas  === false) {
+      return false;
+    }
     return typeof createElement('canvas').getContext('2d').fillText == 'function';
   });
 });

--- a/feature-detects/contenteditable.js
+++ b/feature-detects/contenteditable.js
@@ -12,10 +12,12 @@
 /* DOC
 Detects support for the `contenteditable` attribute of elements, allowing their DOM text contents to be edited directly by the user.
 */
-define(['Modernizr', 'createElement', 'docElement'], function( Modernizr, createElement, docElement ) {
+define(['Modernizr', 'createElement', 'docElement'], function(Modernizr, createElement, docElement) {
   Modernizr.addTest('contenteditable', function() {
     // early bail out
-    if (!('contentEditable' in docElement)) return;
+    if (!('contentEditable' in docElement)) {
+      return;
+    }
 
     // some mobile browsers (android < 3.0, iOS < 5) claim to support
     // contentEditable, but but don't really. This test checks to see

--- a/feature-detects/contextmenu.js
+++ b/feature-detects/contextmenu.js
@@ -16,7 +16,7 @@
 /* DOC
 Detects support for custom context menus.
 */
-define(['Modernizr', 'docElement'], function( Modernizr, docElement ) {
+define(['Modernizr', 'docElement'], function(Modernizr, docElement) {
   Modernizr.addTest(
     'contextmenu',
     ('contextMenu' in docElement && 'HTMLMenuItemElement' in window)

--- a/feature-detects/cookies.js
+++ b/feature-detects/cookies.js
@@ -9,10 +9,10 @@
 /* DOC
 Detects whether cookie support is enabled.
 */
-define(['Modernizr'], function( Modernizr ) {
+define(['Modernizr'], function(Modernizr) {
   // https://github.com/Modernizr/Modernizr/issues/191
 
-  Modernizr.addTest('cookies', function () {
+  Modernizr.addTest('cookies', function() {
     // navigator.cookieEnabled cannot detect custom or nuanced cookie blocking
     // configurations. For example, when blocking cookies via the Advanced
     // Privacy Settings in IE9, it always returns true. And there have been

--- a/feature-detects/cors.js
+++ b/feature-detects/cors.js
@@ -14,6 +14,6 @@
 /* DOC
 Detects support for Cross-Origin Resource Sharing: method of performing XMLHttpRequests across domains.
 */
-define(['Modernizr'], function( Modernizr ) {
+define(['Modernizr'], function(Modernizr) {
   Modernizr.addTest('cors', 'XMLHttpRequest' in window && 'withCredentials' in new XMLHttpRequest());
 });

--- a/feature-detects/crypto/getrandomvalues.js
+++ b/feature-detects/crypto/getrandomvalues.js
@@ -17,7 +17,7 @@
 /* DOC
 Detects support for the window.crypto.getRandomValues for generate cryptographically secure random numbers
 */
-define(['Modernizr', 'prefixed', 'is'], function( Modernizr, prefixed, is ) {
+define(['Modernizr', 'prefixed', 'is'], function(Modernizr, prefixed, is) {
   // In Safari <=5.0 `window.crypto` exists (for some reason) but is `undefined`, so we have to check
   // it’s truthy before checking for existence of `getRandomValues`
   var crypto = prefixed('crypto', window);

--- a/feature-detects/css/all.js
+++ b/feature-detects/css/all.js
@@ -12,6 +12,6 @@
 Detects support for the `all` css property, which is a shorthand to reset all css properties (except direction and unicode-bidi) to their original value
 */
 
-define(['Modernizr', 'docElement'], function( Modernizr, docElement ) {
+define(['Modernizr', 'docElement'], function(Modernizr, docElement) {
   Modernizr.addTest('cssall', 'all' in docElement.style);
 });

--- a/feature-detects/css/animations.js
+++ b/feature-detects/css/animations.js
@@ -15,6 +15,6 @@
 /* DOC
 Detects whether or not elements can be animated using CSS
 */
-define(['Modernizr', 'testAllProps'], function( Modernizr, testAllProps ) {
+define(['Modernizr', 'testAllProps'], function(Modernizr, testAllProps) {
   Modernizr.addTest('cssanimations', testAllProps('animationName', 'a', true));
 });

--- a/feature-detects/css/appearance.js
+++ b/feature-detects/css/appearance.js
@@ -18,6 +18,6 @@ Detects support for the `appearance` css property, which is used to make an
 element inherit the style of a standard user interface element. It can also be
 used to remove the default styles of an element, such as input and buttons.
 */
-define(['Modernizr', 'testAllProps'], function( Modernizr, testAllProps ) {
+define(['Modernizr', 'testAllProps'], function(Modernizr, testAllProps) {
   Modernizr.addTest('appearance', testAllProps('appearance'));
 });

--- a/feature-detects/css/backgroundblendmode.js
+++ b/feature-detects/css/backgroundblendmode.js
@@ -18,6 +18,6 @@
 /* DOC
 Detects the ability for the browser to composite backgrounds using blending modes similar to ones found in Photoshop or Illustrator.
 */
-define(['Modernizr', 'prefixed'], function( Modernizr, prefixed ) {
+define(['Modernizr', 'prefixed'], function(Modernizr, prefixed) {
   Modernizr.addTest('backgroundblendmode', prefixed('backgroundBlendMode', 'text'));
 });

--- a/feature-detects/css/backgroundcliptext.js
+++ b/feature-detects/css/backgroundcliptext.js
@@ -24,7 +24,7 @@
 Detects the ability to control specifies whether or not an element's background
 extends beyond its border in CSS
 */
-define(['Modernizr', 'testAllProps'], function( Modernizr, testAllProps ) {
+define(['Modernizr', 'testAllProps'], function(Modernizr, testAllProps) {
   Modernizr.addTest('backgroundcliptext', function() {
     return testAllProps('backgroundClip', 'text');
   });

--- a/feature-detects/css/backgroundposition-shorthand.js
+++ b/feature-detects/css/backgroundposition-shorthand.js
@@ -22,7 +22,7 @@ element's background-position simultaniously.
 
 eg `background-position: right 10px bottom 10px`
 */
-define(['Modernizr', 'createElement'], function( Modernizr, createElement ) {
+define(['Modernizr', 'createElement'], function(Modernizr, createElement) {
   Modernizr.addTest('bgpositionshorthand', function() {
     var elem = createElement('a');
     var eStyle = elem.style;

--- a/feature-detects/css/backgroundposition-xy.js
+++ b/feature-detects/css/backgroundposition-xy.js
@@ -17,8 +17,8 @@
 /* DOC
 Detects the ability to control an element's background position using css
 */
-define(['Modernizr', 'testAllProps'], function( Modernizr, testAllProps ) {
-  Modernizr.addTest('bgpositionxy', function () {
+define(['Modernizr', 'testAllProps'], function(Modernizr, testAllProps) {
+  Modernizr.addTest('bgpositionxy', function() {
     return testAllProps('backgroundPositionX', '3px', true) && testAllProps('backgroundPositionY', '5px', true);
   });
 });

--- a/feature-detects/css/backgroundrepeat.js
+++ b/feature-detects/css/backgroundrepeat.js
@@ -20,7 +20,7 @@
 /* DOC
 Detects the ability to use round and space as properties for background-repeat
 */
-define(['Modernizr', 'testAllProps'], function( Modernizr, testAllProps ) {
+define(['Modernizr', 'testAllProps'], function(Modernizr, testAllProps) {
   // Must value-test these
   Modernizr.addTest('bgrepeatround', testAllProps('backgroundRepeat', 'round'));
   Modernizr.addTest('bgrepeatspace', testAllProps('backgroundRepeat', 'space'));

--- a/feature-detects/css/backgroundsize.js
+++ b/feature-detects/css/backgroundsize.js
@@ -10,6 +10,6 @@
   }]
 }
 !*/
-define(['Modernizr', 'testAllProps'], function( Modernizr, testAllProps ) {
+define(['Modernizr', 'testAllProps'], function(Modernizr, testAllProps) {
   Modernizr.addTest('backgroundsize', testAllProps('backgroundSize', '100%', true));
 });

--- a/feature-detects/css/backgroundsizecover.js
+++ b/feature-detects/css/backgroundsizecover.js
@@ -10,7 +10,7 @@
   }]
 }
 !*/
-define(['Modernizr', 'testAllProps'], function( Modernizr, testAllProps ) {
+define(['Modernizr', 'testAllProps'], function(Modernizr, testAllProps) {
   // Must test value, as this specifically tests the `cover` value
   Modernizr.addTest('bgsizecover', testAllProps('backgroundSize', 'cover'));
 });

--- a/feature-detects/css/borderimage.js
+++ b/feature-detects/css/borderimage.js
@@ -8,6 +8,6 @@
   "tags": ["css"]
 }
 !*/
-define(['Modernizr', 'testAllProps'], function( Modernizr, testAllProps ) {
+define(['Modernizr', 'testAllProps'], function(Modernizr, testAllProps) {
   Modernizr.addTest('borderimage', testAllProps('borderImage', 'url() 1', true));
 });

--- a/feature-detects/css/borderradius.js
+++ b/feature-detects/css/borderradius.js
@@ -11,6 +11,6 @@
   }]
 }
 !*/
-define(['Modernizr', 'testAllProps'], function( Modernizr, testAllProps ) {
+define(['Modernizr', 'testAllProps'], function(Modernizr, testAllProps) {
   Modernizr.addTest('borderradius', testAllProps('borderRadius', '0px', true));
 });

--- a/feature-detects/css/boxshadow.js
+++ b/feature-detects/css/boxshadow.js
@@ -10,6 +10,6 @@
   ]
 }
 !*/
-define(['Modernizr', 'testAllProps'], function( Modernizr, testAllProps ) {
+define(['Modernizr', 'testAllProps'], function(Modernizr, testAllProps) {
   Modernizr.addTest('boxshadow', testAllProps('boxShadow', '1px 1px', true));
 });

--- a/feature-detects/css/boxsizing.js
+++ b/feature-detects/css/boxsizing.js
@@ -15,6 +15,6 @@
   }]
 }
 !*/
-define(['Modernizr', 'testAllProps'], function( Modernizr, testAllProps ) {
+define(['Modernizr', 'testAllProps'], function(Modernizr, testAllProps) {
   Modernizr.addTest('boxsizing', testAllProps('boxSizing', 'border-box', true) && (document.documentMode === undefined || document.documentMode > 7));
 });

--- a/feature-detects/css/calc.js
+++ b/feature-detects/css/calc.js
@@ -12,12 +12,12 @@
 Method of allowing calculated values for length units. For example:
 
 ```css
-#elem {
+//lem {
   width: calc(100% - 3em);
 }
 ```
 */
-define(['Modernizr', 'createElement', 'prefixes'], function( Modernizr, createElement, prefixes ) {
+define(['Modernizr', 'createElement', 'prefixes'], function(Modernizr, createElement, prefixes) {
   Modernizr.addTest('csscalc', function() {
     var prop = 'width:';
     var value = 'calc(10px);';

--- a/feature-detects/css/checked.js
+++ b/feature-detects/css/checked.js
@@ -10,9 +10,9 @@
   }]
 }
 !*/
-define(['Modernizr', 'createElement', 'testStyles'], function( Modernizr, createElement, testStyles ) {
-  Modernizr.addTest('checked', function(){
-    return testStyles('#modernizr {position:absolute} #modernizr input {margin-left:10px} #modernizr :checked {margin-left:20px;display:block}', function( elem ){
+define(['Modernizr', 'createElement', 'testStyles'], function(Modernizr, createElement, testStyles) {
+  Modernizr.addTest('checked', function() {
+    return testStyles('#modernizr {position:absolute} #modernizr input {margin-left:10px} #modernizr :checked {margin-left:20px;display:block}', function(elem) {
       var cb = createElement('input');
       cb.setAttribute('type', 'checkbox');
       cb.setAttribute('checked', 'checked');

--- a/feature-detects/css/chunit.js
+++ b/feature-detects/css/chunit.js
@@ -10,8 +10,8 @@
   }]
 }
 !*/
-define(['Modernizr', 'modElem'], function (Modernizr, modElem) {
-  Modernizr.addTest('csschunit', function () {
+define(['Modernizr', 'modElem'], function(Modernizr, modElem) {
+  Modernizr.addTest('csschunit', function() {
     var elemStyle = modElem.elem.style;
     var supports;
     try {

--- a/feature-detects/css/columns.js
+++ b/feature-detects/css/columns.js
@@ -7,19 +7,19 @@
   "tags": ["css"]
 }
 !*/
-define(['Modernizr', 'testAllProps'], function( Modernizr, testAllProps ) {
+define(['Modernizr', 'testAllProps'], function(Modernizr, testAllProps) {
 
   (function() {
 
     /* jshint -W053 */
-    Modernizr.addTest('csscolumns', function(){
+    Modernizr.addTest('csscolumns', function() {
       var bool = false;
       var test = testAllProps('columnCount');
       try {
-        if ( bool = !!test ) {
+        if (bool = !!test) {
           bool = new Boolean(bool);
         }
-      } catch(e){}
+      } catch (e) {}
 
       return bool;
     });

--- a/feature-detects/css/cubicbezierrange.js
+++ b/feature-detects/css/cubicbezierrange.js
@@ -13,7 +13,7 @@
   }]
 }
 !*/
-define(['Modernizr', 'createElement', 'prefixes'], function( Modernizr, createElement, prefixes ) {
+define(['Modernizr', 'createElement', 'prefixes'], function(Modernizr, createElement, prefixes) {
   Modernizr.addTest('cubicbezierrange', function() {
     var el = createElement('a');
     el.style.cssText = prefixes.join('transition-timing-function:cubic-bezier(1,0,0,1.1); ');

--- a/feature-detects/css/displayrunin.js
+++ b/feature-detects/css/displayrunin.js
@@ -14,7 +14,7 @@
   }]
 }
 !*/
-define(['Modernizr', 'testAllProps'], function( Modernizr, testAllProps ) {
+define(['Modernizr', 'testAllProps'], function(Modernizr, testAllProps) {
   Modernizr.addTest('displayrunin', testAllProps('display', 'run-in'),
-    { aliases: ['display-runin'] });
+    {aliases: ['display-runin']});
 });

--- a/feature-detects/css/displaytable.js
+++ b/feature-detects/css/displaytable.js
@@ -15,13 +15,13 @@
 /* DOC
 `display: table` and `table-cell` test. (both are tested under one name `table-cell` )
 */
-define(['Modernizr', 'testStyles'], function( Modernizr, testStyles ) {
+define(['Modernizr', 'testStyles'], function(Modernizr, testStyles) {
   // If a document is in rtl mode this test will fail so we force ltr mode on the injeced
   // element https://github.com/Modernizr/Modernizr/issues/716
-  testStyles('#modernizr{display: table; direction: ltr}#modernizr div{display: table-cell; padding: 10px}', function( elem ) {
+  testStyles('#modernizr{display: table; direction: ltr}#modernizr div{display: table-cell; padding: 10px}', function(elem) {
     var ret;
     var child = elem.childNodes;
     ret = child[0].offsetLeft < child[1].offsetLeft;
-    Modernizr.addTest('displaytable', ret, { aliases: ['display-table'] });
-  },2);
+    Modernizr.addTest('displaytable', ret, {aliases: ['display-table']});
+  }, 2);
 });

--- a/feature-detects/css/ellipsis.js
+++ b/feature-detects/css/ellipsis.js
@@ -9,6 +9,6 @@
   "tags": ["css"]
 }
 !*/
-define(['Modernizr', 'testAllProps'], function( Modernizr, testAllProps ) {
+define(['Modernizr', 'testAllProps'], function(Modernizr, testAllProps) {
   Modernizr.addTest('ellipsis', testAllProps('textOverflow', 'ellipsis'));
 });

--- a/feature-detects/css/escape.js
+++ b/feature-detects/css/escape.js
@@ -14,7 +14,7 @@
 /* DOC
 Tests for `CSS.escape()` support.
 */
-define(['Modernizr'], function( Modernizr ) {
+define(['Modernizr'], function(Modernizr) {
   var CSS = window.CSS;
   Modernizr.addTest('cssescape', CSS ? typeof CSS.escape == 'function' : false);
 });

--- a/feature-detects/css/exunit.js
+++ b/feature-detects/css/exunit.js
@@ -10,8 +10,8 @@
   }]
 }
 !*/
-define(['Modernizr', 'modElem'], function (Modernizr, modElem) {
-  Modernizr.addTest('cssexunit', function () {
+define(['Modernizr', 'modElem'], function(Modernizr, modElem) {
+  Modernizr.addTest('cssexunit', function() {
     var elemStyle = modElem.elem.style;
     var supports;
     try {

--- a/feature-detects/css/filters.js
+++ b/feature-detects/css/filters.js
@@ -12,7 +12,7 @@
   }]
 }
 !*/
-define(['Modernizr', 'createElement', 'prefixes', 'testAllProps', 'test/css/supports'], function( Modernizr, createElement, testAllProps, prefixes ) {
+define(['Modernizr', 'createElement', 'prefixes', 'testAllProps', 'test/css/supports'], function(Modernizr, createElement, testAllProps, prefixes) {
   Modernizr.addTest('cssfilters', function() {
     if (Modernizr.supports) {
       return testAllProps('filter', 'blur(2px)');

--- a/feature-detects/css/flexbox.js
+++ b/feature-detects/css/flexbox.js
@@ -16,6 +16,6 @@
 /* DOC
 Detects support for the Flexible Box Layout model, a.k.a. Flexbox, which allows easy manipulation of layout order and sizing within a container.
 */
-define(['Modernizr', 'testAllProps'], function( Modernizr, testAllProps ) {
+define(['Modernizr', 'testAllProps'], function(Modernizr, testAllProps) {
   Modernizr.addTest('flexbox', testAllProps('flexBasis', '1px', true));
 });

--- a/feature-detects/css/flexboxlegacy.js
+++ b/feature-detects/css/flexboxlegacy.js
@@ -10,6 +10,6 @@
   }]
 }
 !*/
-define(['Modernizr', 'testAllProps'], function( Modernizr, testAllProps ) {
+define(['Modernizr', 'testAllProps'], function(Modernizr, testAllProps) {
   Modernizr.addTest('flexboxlegacy', testAllProps('boxDirection', 'reverse', true));
 });

--- a/feature-detects/css/flexboxtweener.js
+++ b/feature-detects/css/flexboxtweener.js
@@ -11,6 +11,6 @@
   "warnings": ["This represents an old syntax, not the latest standard syntax."]
 }
 !*/
-define(['Modernizr', 'testAllProps'], function( Modernizr, testAllProps ) {
+define(['Modernizr', 'testAllProps'], function(Modernizr, testAllProps) {
   Modernizr.addTest('flexboxtweener', testAllProps('flexAlign', 'end', true));
 });

--- a/feature-detects/css/flexwrap.js
+++ b/feature-detects/css/flexwrap.js
@@ -26,6 +26,6 @@ else {
 }
 ```
 */
-define(['Modernizr', 'testAllProps'], function( Modernizr, testAllProps ) {
+define(['Modernizr', 'testAllProps'], function(Modernizr, testAllProps) {
   Modernizr.addTest('flexwrap', testAllProps('flexWrap', 'wrap', true));
 });

--- a/feature-detects/css/fontface.js
+++ b/feature-detects/css/fontface.js
@@ -26,19 +26,19 @@
   }]
 }
 !*/
-define(['Modernizr', 'testStyles'], function( Modernizr, testStyles ) {
+define(['Modernizr', 'testStyles'], function(Modernizr, testStyles) {
   var blacklist = (function() {
     var ua = navigator.userAgent;
-    var wkvers = ua.match( /applewebkit\/([0-9]+)/gi ) && parseFloat( RegExp.$1 );
-    var webos = ua.match( /w(eb)?osbrowser/gi );
-    var wppre8 = ua.match( /windows phone/gi ) && ua.match( /iemobile\/([0-9])+/gi ) && parseFloat( RegExp.$1 ) >= 9;
-    var oldandroid = wkvers < 533 && ua.match( /android/gi );
+    var wkvers = ua.match(/applewebkit\/([0-9]+)/gi) && parseFloat(RegExp.$1);
+    var webos = ua.match(/w(eb)?osbrowser/gi);
+    var wppre8 = ua.match(/windows phone/gi) && ua.match(/iemobile\/([0-9])+/gi) && parseFloat(RegExp.$1) >= 9;
+    var oldandroid = wkvers < 533 && ua.match(/android/gi);
     return webos || oldandroid || wppre8;
   }());
-  if( blacklist ) {
+  if (blacklist) {
     Modernizr.addTest('fontface', false);
   } else {
-    testStyles('@font-face {font-family:"font";src:url("https://")}', function( node, rule ) {
+    testStyles('@font-face {font-family:"font";src:url("https://")}', function(node, rule) {
       var style = document.getElementById('smodernizr');
       var sheet = style.sheet || style.styleSheet;
       var cssText = sheet ? (sheet.cssRules && sheet.cssRules[0] ? sheet.cssRules[0].cssText : sheet.cssText || '') : '';

--- a/feature-detects/css/generatedcontent.js
+++ b/feature-detects/css/generatedcontent.js
@@ -16,8 +16,8 @@
   }]
 }
 !*/
-define(['Modernizr', 'testStyles'], function( Modernizr, testStyles ) {
-  testStyles('#modernizr{font:0/0 a}#modernizr:after{content:":)";visibility:hidden;font:7px/1 a}', function( node ) {
+define(['Modernizr', 'testStyles'], function(Modernizr, testStyles) {
+  testStyles('#modernizr{font:0/0 a}#modernizr:after{content:":)";visibility:hidden;font:7px/1 a}', function(node) {
     Modernizr.addTest('generatedcontent', node.offsetHeight >= 7);
   });
 });

--- a/feature-detects/css/gradients.js
+++ b/feature-detects/css/gradients.js
@@ -20,7 +20,7 @@
   }]
 }
 !*/
-define(['Modernizr', 'prefixes', 'createElement'], function( Modernizr, prefixes, createElement ) {
+define(['Modernizr', 'prefixes', 'createElement'], function(Modernizr, prefixes, createElement) {
 
   Modernizr.addTest('cssgradients', function() {
 

--- a/feature-detects/css/hsla.js
+++ b/feature-detects/css/hsla.js
@@ -6,7 +6,7 @@
   "tags": ["css"]
 }
 !*/
-define(['Modernizr', 'createElement', 'contains'], function( Modernizr, createElement, contains ) {
+define(['Modernizr', 'createElement', 'contains'], function(Modernizr, createElement, contains) {
   Modernizr.addTest('hsla', function() {
     var style = createElement('a').style;
     style.cssText = 'background-color:hsla(120,40%,100%,.5)';

--- a/feature-detects/css/hyphens.js
+++ b/feature-detects/css/hyphens.js
@@ -27,7 +27,7 @@
   }]
 }
 !*/
-define(['Modernizr', 'prefixes', 'createElement', 'testAllProps', 'addTest'], function( Modernizr, prefixes, createElement, testAllProps, addTest ) {
+define(['Modernizr', 'prefixes', 'createElement', 'testAllProps', 'addTest'], function(Modernizr, prefixes, createElement, testAllProps, addTest) {
 
   Modernizr.addAsyncTest(function() {
     var waitTime = 300;
@@ -63,8 +63,8 @@ define(['Modernizr', 'prefixes', 'createElement', 'testAllProps', 'addTest'], fu
           spanWidth = span.offsetWidth;
 
           /* compare size with hyphenated text */
-          divStyle.cssText = 'position:absolute;top:0;left:0;width:5em;text-align:justify;'+
-            'text-justification:newspaper;'+
+          divStyle.cssText = 'position:absolute;top:0;left:0;width:5em;text-align:justify;' +
+            'text-justification:newspaper;' +
             prefixes.join('hyphens:auto; ');
 
           result = (span.offsetHeight != spanHeight || span.offsetWidth != spanWidth);
@@ -74,13 +74,13 @@ define(['Modernizr', 'prefixes', 'createElement', 'testAllProps', 'addTest'], fu
           div.removeChild(span);
 
           return result;
-        } catch(e) {
+        } catch (e) {
           return false;
         }
       }
 
       // for the softhyphens test
-      function test_hyphens( delimiter, testWidth ) {
+      function test_hyphens(delimiter, testWidth) {
         try {
           /* create a div container and a span within that
            * these have to be appended to document.body, otherwise some browsers can give false negative */
@@ -126,13 +126,13 @@ define(['Modernizr', 'prefixes', 'createElement', 'testAllProps', 'addTest'], fu
           div.removeChild(span);
 
           return result;
-        } catch(e) {
+        } catch (e) {
           return false;
         }
       }
 
       // testing if in-browser Find functionality will work on hyphenated text
-      function test_hyphens_find( delimiter ) {
+      function test_hyphens_find(delimiter) {
         try {
           /* create a dummy input for resetting selection location, and a div container
            * these have to be appended to document.body, otherwise some browsers can give false negative
@@ -155,7 +155,7 @@ define(['Modernizr', 'prefixes', 'createElement', 'testAllProps', 'addTest'], fu
            *   stackoverflow.com/questions/499126/jquery-set-cursor-position-in-text-area */
           if (dummy.setSelectionRange) {
             dummy.focus();
-            dummy.setSelectionRange(0,0);
+            dummy.setSelectionRange(0, 0);
           } else if (dummy.createTextRange) {
             textrange = dummy.createTextRange();
             textrange.collapse(true);
@@ -171,7 +171,7 @@ define(['Modernizr', 'prefixes', 'createElement', 'testAllProps', 'addTest'], fu
             try {
               textrange = window.self.document.body.createTextRange();
               result = textrange.findText(testword + testword);
-            } catch(e) {
+            } catch (e) {
               result = false;
             }
           }
@@ -180,21 +180,23 @@ define(['Modernizr', 'prefixes', 'createElement', 'testAllProps', 'addTest'], fu
           document.body.removeChild(dummy);
 
           return result;
-        } catch(e) {
+        } catch (e) {
           return false;
         }
       }
 
       addTest('csshyphens', function() {
 
-        if (!testAllProps('hyphens', 'auto', true)) return false;
+        if (!testAllProps('hyphens', 'auto', true)) {
+          return false;
+        }
 
         /* Chrome lies about its hyphens support so we need a more robust test
            crbug.com/107111
            */
         try {
           return test_hyphens_css();
-        } catch(e) {
+        } catch (e) {
           return false;
         }
       });
@@ -203,7 +205,7 @@ define(['Modernizr', 'prefixes', 'createElement', 'testAllProps', 'addTest'], fu
         try {
           // use numeric entity instead of &shy; in case it's XHTML
           return test_hyphens('&#173;', true) && test_hyphens('&#8203;', false);
-        } catch(e) {
+        } catch (e) {
           return false;
         }
       });
@@ -211,7 +213,7 @@ define(['Modernizr', 'prefixes', 'createElement', 'testAllProps', 'addTest'], fu
       addTest('softhyphensfind', function() {
         try {
           return test_hyphens_find('&#173;') && test_hyphens_find('&#8203;');
-        } catch(e) {
+        } catch (e) {
           return false;
         }
       });

--- a/feature-detects/css/invalid.js
+++ b/feature-detects/css/invalid.js
@@ -11,7 +11,7 @@
 /* DOC
   Detects support for the ':invalid' CSS pseudo-class.
 */
-define(['Modernizr', 'testStyles', 'createElement'], function( Modernizr, testStyles, createElement ) {
+define(['Modernizr', 'testStyles', 'createElement'], function(Modernizr, testStyles, createElement) {
   Modernizr.addTest('cssinvalid', function() {
     return testStyles('#modernizr input{height:0;border:0;padding:0;margin:0;width:10px} #modernizr input:invalid{width:50px}', function(elem) {
       var input = createElement('input');

--- a/feature-detects/css/lastchild.js
+++ b/feature-detects/css/lastchild.js
@@ -11,8 +11,8 @@
   }]
 }
 !*/
-define(['Modernizr', 'testStyles'], function( Modernizr, testStyles ) {
-  testStyles('#modernizr div {width:100px} #modernizr :last-child{width:200px;display:block}', function( elem ) {
+define(['Modernizr', 'testStyles'], function(Modernizr, testStyles) {
+  testStyles('#modernizr div {width:100px} #modernizr :last-child{width:200px;display:block}', function(elem) {
     Modernizr.addTest('lastchild', elem.lastChild.offsetWidth > elem.firstChild.offsetWidth);
   }, 2);
 });

--- a/feature-detects/css/mask.js
+++ b/feature-detects/css/mask.js
@@ -25,6 +25,6 @@
   ]
 }
 !*/
-define(['Modernizr', 'testAllProps'], function( Modernizr, testAllProps ) {
+define(['Modernizr', 'testAllProps'], function(Modernizr, testAllProps) {
   Modernizr.addTest('cssmask', testAllProps('maskRepeat', 'repeat-x', true));
 });

--- a/feature-detects/css/mediaqueries.js
+++ b/feature-detects/css/mediaqueries.js
@@ -7,6 +7,6 @@
   "builderAliases": ["css_mediaqueries"]
 }
 !*/
-define(['Modernizr', 'mq'], function( Modernizr, mq ) {
+define(['Modernizr', 'mq'], function(Modernizr, mq) {
   Modernizr.addTest('mediaqueries', mq('only all'));
 });

--- a/feature-detects/css/multiplebgs.js
+++ b/feature-detects/css/multiplebgs.js
@@ -6,7 +6,7 @@
   "tags": ["css"]
 }
 !*/
-define(['Modernizr', 'createElement'], function( Modernizr, createElement ) {
+define(['Modernizr', 'createElement'], function(Modernizr, createElement) {
   // Setting multiple images AND a color on the background shorthand property
   // and then querying the style.background property value for the number of
   // occurrences of "url(" is a reliable method for detecting ACTUAL support for this!

--- a/feature-detects/css/nthchild.js
+++ b/feature-detects/css/nthchild.js
@@ -21,12 +21,12 @@
 /* DOC
 Detects support for the ':nth-child()' CSS pseudo-selector.
 */
-define(['Modernizr', 'testStyles'], function( Modernizr, testStyles ) {
+define(['Modernizr', 'testStyles'], function(Modernizr, testStyles) {
   // 5 `<div>` elements with `1px` width are created.
   // Then every other element has its `width` set to `2px`.
   // A Javascript loop then tests if the `<div>`s have the expected width
   // using the modulus operator.
-  testStyles('#modernizr div {width:1px} #modernizr div:nth-child(2n) {width:2px;}', function( elem ) {
+  testStyles('#modernizr div {width:1px} #modernizr div:nth-child(2n) {width:2px;}', function(elem) {
     Modernizr.addTest('nthchild', function() {
       var elems = elem.getElementsByTagName('div'),
       test = true;

--- a/feature-detects/css/objectfit.js
+++ b/feature-detects/css/objectfit.js
@@ -11,6 +11,6 @@
   }]
 }
 !*/
-define(['Modernizr', 'prefixed'], function( Modernizr, prefixed ) {
-  Modernizr.addTest('objectfit', !!prefixed('objectFit'), { aliases: ['object-fit'] });
+define(['Modernizr', 'prefixed'], function(Modernizr, prefixed) {
+  Modernizr.addTest('objectfit', !!prefixed('objectFit'), {aliases: ['object-fit']});
 });

--- a/feature-detects/css/opacity.js
+++ b/feature-detects/css/opacity.js
@@ -6,7 +6,7 @@
   "tags": ["css"]
 }
 !*/
-define(['Modernizr', 'createElement', 'prefixes'], function( Modernizr, createElement, prefixes ) {
+define(['Modernizr', 'createElement', 'prefixes'], function(Modernizr, createElement, prefixes) {
   // Browsers that actually have CSS Opacity implemented have done so
   // according to spec, which means their return values are within the
   // range of [0.0,1.0] - including the leading zero.

--- a/feature-detects/css/overflow-scrolling.js
+++ b/feature-detects/css/overflow-scrolling.js
@@ -11,6 +11,6 @@
   }]
 }
 !*/
-define(['Modernizr', 'testAllProps'], function( Modernizr, testAllProps ) {
+define(['Modernizr', 'testAllProps'], function(Modernizr, testAllProps) {
   Modernizr.addTest('overflowscrolling', testAllProps('overflowScrolling', 'touch', true));
 });

--- a/feature-detects/css/pointerevents.js
+++ b/feature-detects/css/pointerevents.js
@@ -24,7 +24,7 @@
   ]
 }
 !*/
-define(['Modernizr', 'createElement'], function( Modernizr, createElement ) {
+define(['Modernizr', 'createElement'], function(Modernizr, createElement) {
   Modernizr.addTest('csspointerevents', function() {
     var style = createElement('a').style;
     style.cssText = 'pointer-events:auto';

--- a/feature-detects/css/positionsticky.js
+++ b/feature-detects/css/positionsticky.js
@@ -11,7 +11,7 @@
   "warnings": [ "using position:sticky on anything but top aligned elements is buggy in Chrome < 37 and iOS <=7+" ]
 }
 !*/
-define(['Modernizr', 'createElement', 'prefixes'], function( Modernizr, createElement, prefixes ) {
+define(['Modernizr', 'createElement', 'prefixes'], function(Modernizr, createElement, prefixes) {
   // Sticky positioning - constrains an element to be positioned inside the
   // intersection of its container box, and the viewport.
   Modernizr.addTest('csspositionsticky', function() {

--- a/feature-detects/css/pseudoanimations.js
+++ b/feature-detects/css/pseudoanimations.js
@@ -5,8 +5,8 @@
   "tags": ["css"]
 }
 !*/
-define(['Modernizr', 'testStyles', 'test/css/animations'], function (Modernizr) {
-  Modernizr.addTest('csspseudoanimations', function () {
+define(['Modernizr', 'testStyles', 'test/css/animations'], function(Modernizr) {
+  Modernizr.addTest('csspseudoanimations', function() {
     var result = false;
 
     if (!Modernizr.cssanimations || !window.getComputedStyle) {
@@ -14,13 +14,13 @@ define(['Modernizr', 'testStyles', 'test/css/animations'], function (Modernizr) 
     }
 
     var styles = [
-      '@', Modernizr._prefixes.join('keyframes csspseudoanimations { from { font-size: 10px; } }@').replace(/\@$/,''),
+      '@', Modernizr._prefixes.join('keyframes csspseudoanimations { from { font-size: 10px; } }@').replace(/\@$/, ''),
       '#modernizr:before { content:" "; font-size:5px;',
       Modernizr._prefixes.join('animation:csspseudoanimations 1ms infinite;'),
       '}'
     ].join('');
 
-    Modernizr.testStyles(styles, function (elem) {
+    Modernizr.testStyles(styles, function(elem) {
       result = window.getComputedStyle(elem, ':before').getPropertyValue('font-size') === '10px';
     });
 

--- a/feature-detects/css/pseudotransitions.js
+++ b/feature-detects/css/pseudotransitions.js
@@ -5,8 +5,8 @@
   "tags": ["css"]
 }
 !*/
-define(['Modernizr', 'testStyles', 'test/css/transitions'], function (Modernizr) {
-  Modernizr.addTest('csspseudotransitions', function () {
+define(['Modernizr', 'testStyles', 'test/css/transitions'], function(Modernizr) {
+  Modernizr.addTest('csspseudotransitions', function() {
     var result = false;
 
     if (!Modernizr.csstransitions || !window.getComputedStyle) {
@@ -17,7 +17,7 @@ define(['Modernizr', 'testStyles', 'test/css/transitions'], function (Modernizr)
       '#modernizr:before { content:" "; font-size:5px;' + Modernizr._prefixes.join('transition:0s 100s;') + '}' +
       '#modernizr.trigger:before { font-size:10px; }';
 
-    Modernizr.testStyles(styles, function (elem) {
+    Modernizr.testStyles(styles, function(elem) {
       // Force rendering of the element's styles so that the transition will trigger
       window.getComputedStyle(elem, ':before').getPropertyValue('font-size');
       elem.className += 'trigger';

--- a/feature-detects/css/reflections.js
+++ b/feature-detects/css/reflections.js
@@ -6,6 +6,6 @@
   "tags": ["css"]
 }
 !*/
-define(['Modernizr', 'testAllProps'], function( Modernizr, testAllProps ) {
+define(['Modernizr', 'testAllProps'], function(Modernizr, testAllProps) {
   Modernizr.addTest('cssreflections', testAllProps('boxReflect', 'above', true));
 });

--- a/feature-detects/css/regions.js
+++ b/feature-detects/css/regions.js
@@ -12,7 +12,7 @@
   }]
 }
 !*/
-define(['Modernizr', 'createElement', 'docElement', 'isSVG'], function( Modernizr, createElement, docElement, isSVG ) {
+define(['Modernizr', 'createElement', 'docElement', 'isSVG'], function(Modernizr, createElement, docElement, isSVG) {
   // We start with a CSS parser test then we check page geometry to see if it's affected by regions
   // Later we might be able to retire the second part, as WebKit builds with the false positives die out
 
@@ -30,7 +30,7 @@ define(['Modernizr', 'createElement', 'docElement', 'isSVG'], function( Moderniz
     var flowIntoProperty = Modernizr.prefixed('flowInto');
     var result = false;
 
-    if (!flowFromProperty || !flowIntoProperty){
+    if (!flowFromProperty || !flowIntoProperty) {
       return result;
     }
 

--- a/feature-detects/css/remunit.js
+++ b/feature-detects/css/remunit.js
@@ -15,7 +15,7 @@
   }]
 }
 !*/
-define(['Modernizr', 'createElement'], function( Modernizr, createElement ) {
+define(['Modernizr', 'createElement'], function(Modernizr, createElement) {
   // "The 'rem' unit ('root em') is relative to the computed
   // value of the 'font-size' value of the root element."
   // you can test by checking if the prop was ditched
@@ -25,7 +25,7 @@ define(['Modernizr', 'createElement'], function( Modernizr, createElement ) {
     try {
       style.fontSize = '3rem';
     }
-    catch(e) {}
+    catch (e) {}
     return (/rem/).test(style.fontSize);
   });
 });

--- a/feature-detects/css/resize.js
+++ b/feature-detects/css/resize.js
@@ -17,6 +17,6 @@
 /* DOC
 Test for CSS 3 UI "resize" property
 */
-define(['Modernizr', 'testAllProps'], function( Modernizr, testAllProps ) {
+define(['Modernizr', 'testAllProps'], function(Modernizr, testAllProps) {
   Modernizr.addTest('cssresize', testAllProps('resize', 'both', true));
 });

--- a/feature-detects/css/rgba.js
+++ b/feature-detects/css/rgba.js
@@ -10,7 +10,7 @@
   }]
 }
 !*/
-define(['Modernizr', 'createElement'], function( Modernizr, createElement ) {
+define(['Modernizr', 'createElement'], function(Modernizr, createElement) {
   Modernizr.addTest('rgba', function() {
     var style = createElement('a').style;
     style.cssText = 'background-color:rgba(150,255,150,.5)';

--- a/feature-detects/css/scrollbars.js
+++ b/feature-detects/css/scrollbars.js
@@ -6,13 +6,13 @@
   "builderAliases": ["css_scrollbars"]
 }
 !*/
-define(['Modernizr', 'testStyles', 'prefixes'], function( Modernizr, testStyles, prefixes ) {
+define(['Modernizr', 'testStyles', 'prefixes'], function(Modernizr, testStyles, prefixes) {
   testStyles('#modernizr{overflow: scroll; width: 40px; height: 40px; }#' + prefixes
-    .join('scrollbar{width:0px}'+' #modernizr::')
+    .join('scrollbar{width:0px}' + ' #modernizr::')
     .split('#')
     .slice(1)
     .join('#') + 'scrollbar{width:0px}',
-  function( node ) {
+  function(node) {
     Modernizr.addTest('cssscrollbar', node.scrollWidth == 40);
   });
 });

--- a/feature-detects/css/shapes.js
+++ b/feature-detects/css/shapes.js
@@ -15,6 +15,6 @@
   }]
 }
 !*/
-define(['Modernizr', 'testAllProps'], function( Modernizr, testAllProps ) {
+define(['Modernizr', 'testAllProps'], function(Modernizr, testAllProps) {
   Modernizr.addTest('shapes', testAllProps('shapeOutside', 'content-box', true));
 });

--- a/feature-detects/css/siblinggeneral.js
+++ b/feature-detects/css/siblinggeneral.js
@@ -10,9 +10,9 @@
   }]
 }
 !*/
-define(['Modernizr', 'createElement', 'testStyles'], function( Modernizr, createElement, testStyles ) {
-  Modernizr.addTest('siblinggeneral', function(){
-    return testStyles('#modernizr div {width:100px} #modernizr div ~ div {width:200px;display:block}', function( elem ) {
+define(['Modernizr', 'createElement', 'testStyles'], function(Modernizr, createElement, testStyles) {
+  Modernizr.addTest('siblinggeneral', function() {
+    return testStyles('#modernizr div {width:100px} #modernizr div ~ div {width:200px;display:block}', function(elem) {
       return elem.lastChild.offsetWidth == 200;
     }, 2);
   });

--- a/feature-detects/css/subpixelfont.js
+++ b/feature-detects/css/subpixelfont.js
@@ -17,13 +17,13 @@
   }]
 }
 !*/
-define(['Modernizr', 'testStyles'], function( Modernizr, testStyles ) {
+define(['Modernizr', 'testStyles'], function(Modernizr, testStyles) {
   /*
    * (to infer if GDI or DirectWrite is used on Windows)
    */
   testStyles(
     '#modernizr{position: absolute; top: -10em; visibility:hidden; font: normal 10px arial;}#subpixel{float: left; font-size: 33.3333%;}',
-  function( elem ) {
+  function(elem) {
     var subpixel = elem.firstChild;
     subpixel.innerHTML = 'This is a text written in Arial';
     Modernizr.addTest('subpixelfont', window.getComputedStyle ?

--- a/feature-detects/css/supports.js
+++ b/feature-detects/css/supports.js
@@ -17,7 +17,7 @@
   }]
 }
 !*/
-define(['Modernizr'], function( Modernizr ) {
+define(['Modernizr'], function(Modernizr) {
   var newSyntax = 'CSS' in window && 'supports' in window.CSS;
   var oldSyntax = 'supportsCSS' in window;
   Modernizr.addTest('supports', newSyntax || oldSyntax);

--- a/feature-detects/css/target.js
+++ b/feature-detects/css/target.js
@@ -15,18 +15,18 @@
 /* DOC
 Detects support for the ':target' CSS pseudo-class.
 */
-define(['Modernizr'], function( Modernizr ) {
+define(['Modernizr'], function(Modernizr) {
   // querySelector
   Modernizr.addTest('target', function() {
     var doc = window.document;
-    if(!('querySelectorAll' in doc) ) {
+    if (!('querySelectorAll' in doc)) {
       return false;
     }
 
     try {
       doc.querySelectorAll(':target');
       return true;
-    } catch(e) {
+    } catch (e) {
       return false;
     }
   });

--- a/feature-detects/css/textshadow.js
+++ b/feature-detects/css/textshadow.js
@@ -7,6 +7,6 @@
   "knownBugs": ["FF3.0 will false positive on this test"]
 }
 !*/
-define(['Modernizr', 'testProp'], function( Modernizr, testProp ) {
+define(['Modernizr', 'testProp'], function(Modernizr, testProp) {
   Modernizr.addTest('textshadow', testProp('textShadow', '1px 1px'));
 });

--- a/feature-detects/css/transforms.js
+++ b/feature-detects/css/transforms.js
@@ -6,7 +6,7 @@
   "tags": ["css"]
 }
 !*/
-define(['Modernizr', 'testAllProps'], function( Modernizr, testAllProps ) {
+define(['Modernizr', 'testAllProps'], function(Modernizr, testAllProps) {
   Modernizr.addTest('csstransforms', function() {
     // Android < 3.0 is buggy, so we sniff and blacklist
     // http://git.io/hHzL7w

--- a/feature-detects/css/transforms3d.js
+++ b/feature-detects/css/transforms3d.js
@@ -9,7 +9,7 @@
   ]
 }
 !*/
-define(['Modernizr', 'testAllProps', 'testStyles', 'docElement', 'test/css/supports'], function( Modernizr, testAllProps, testStyles, docElement ) {
+define(['Modernizr', 'testAllProps', 'testStyles', 'docElement', 'test/css/supports'], function(Modernizr, testAllProps, testStyles, docElement) {
   Modernizr.addTest('csstransforms3d', function() {
     var ret = !!testAllProps('perspective', '1px', true);
     var usePrefix = Modernizr._config.usePrefixes;
@@ -18,7 +18,7 @@ define(['Modernizr', 'testAllProps', 'testStyles', 'docElement', 'test/css/suppo
     //   It works fine in Safari on Leopard and Snow Leopard, but not in Chrome in
     //   some conditions. As a result, Webkit typically recognizes the syntax but
     //   will sometimes throw a false positive, thus we must do a more thorough check:
-    if ( ret && (!usePrefix || 'webkitPerspective' in docElement.style )) {
+    if (ret && (!usePrefix || 'webkitPerspective' in docElement.style)) {
       var mq;
       // Use CSS Conditional Rules if available
       if (Modernizr.supports) {
@@ -27,12 +27,14 @@ define(['Modernizr', 'testAllProps', 'testStyles', 'docElement', 'test/css/suppo
         // Otherwise, Webkit allows this media query to succeed only if the feature is enabled.
         // `@media (transform-3d),(-webkit-transform-3d){ ... }`
         mq = '@media (transform-3d)';
-        if (usePrefix ) mq += ',(-webkit-transform-3d)';
+        if (usePrefix) {
+          mq += ',(-webkit-transform-3d)';
+        }
       }
       // If loaded inside the body tag and the test element inherits any padding, margin or borders it will fail #740
       mq += '{#modernizr{left:9px;position:absolute;height:5px;margin:0;padding:0;border:0}}';
 
-      testStyles(mq, function( elem ) {
+      testStyles(mq, function(elem) {
         ret = elem.offsetLeft === 9 && elem.offsetHeight === 5;
       });
     }

--- a/feature-detects/css/transformstylepreserve3d.js
+++ b/feature-detects/css/transformstylepreserve3d.js
@@ -16,6 +16,6 @@
 /* DOC
 Detects support for `transform-style: preserve-3d`, for getting a proper 3D perspective on elements.
 */
-define(['Modernizr', 'testAllProps'], function( Modernizr, testAllProps ) {
+define(['Modernizr', 'testAllProps'], function(Modernizr, testAllProps) {
   Modernizr.addTest('preserve3d', testAllProps('transformStyle', 'preserve-3d'));
 });

--- a/feature-detects/css/transitions.js
+++ b/feature-detects/css/transitions.js
@@ -6,6 +6,6 @@
   "tags": ["css"]
 }
 !*/
-define(['Modernizr', 'testAllProps'], function( Modernizr, testAllProps ) {
+define(['Modernizr', 'testAllProps'], function(Modernizr, testAllProps) {
   Modernizr.addTest('csstransitions', testAllProps('transition', 'all', true));
 });

--- a/feature-detects/css/userselect.js
+++ b/feature-detects/css/userselect.js
@@ -12,7 +12,7 @@
   }]
 }
 !*/
-define(['Modernizr', 'testAllProps'], function( Modernizr, testAllProps ) {
+define(['Modernizr', 'testAllProps'], function(Modernizr, testAllProps) {
   //https://github.com/Modernizr/Modernizr/issues/250
   Modernizr.addTest('userselect', testAllProps('userSelect', 'none', true));
 });

--- a/feature-detects/css/valid.js
+++ b/feature-detects/css/valid.js
@@ -11,7 +11,7 @@
 /* DOC
   Detects support for the ':valid' CSS pseudo-class.
 */
-define(['Modernizr', 'testStyles', 'createElement'], function( Modernizr, testStyles, createElement ) {
+define(['Modernizr', 'testStyles', 'createElement'], function(Modernizr, testStyles, createElement) {
   Modernizr.addTest('cssvalid', function() {
     return testStyles('#modernizr input{height:0;border:0;padding:0;margin:0;width:10px} #modernizr input:valid{width:50px}', function(elem) {
       var input = createElement('input');

--- a/feature-detects/css/vhunit.js
+++ b/feature-detects/css/vhunit.js
@@ -14,12 +14,12 @@
   }]
 }
 !*/
-define(['Modernizr', 'testStyles'], function( Modernizr, testStyles ) {
-  testStyles('#modernizr { height: 50vh; }', function( elem ) {
-    var height = parseInt(window.innerHeight/2,10);
+define(['Modernizr', 'testStyles'], function(Modernizr, testStyles) {
+  testStyles('#modernizr { height: 50vh; }', function(elem) {
+    var height = parseInt(window.innerHeight / 2, 10);
     var compStyle = parseInt((window.getComputedStyle ?
                               getComputedStyle(elem, null) :
-                              elem.currentStyle)['height'],10);
+                              elem.currentStyle)['height'], 10);
     Modernizr.addTest('cssvhunit', compStyle == height);
   });
 });

--- a/feature-detects/css/vmaxunit.js
+++ b/feature-detects/css/vmaxunit.js
@@ -14,18 +14,18 @@
   }]
 }
 !*/
-define(['Modernizr', 'docElement', 'testStyles', 'roundedEquals'], function( Modernizr, docElement, testStyles, roundedEquals ) {
+define(['Modernizr', 'docElement', 'testStyles', 'roundedEquals'], function(Modernizr, docElement, testStyles, roundedEquals) {
   testStyles('#modernizr1{width: 50vmax}#modernizr2{width:50px;height:50px;overflow:scroll}', function(node) {
     var elem = node.childNodes[1];
     var scroller = node.childNodes[0];
     var scrollbarWidth = parseInt((scroller.offsetWidth - scroller.clientWidth) / 2, 10);
 
-    var one_vw = docElement.clientWidth/100;
-    var one_vh = docElement.clientHeight/100;
+    var one_vw = docElement.clientWidth / 100;
+    var one_vh = docElement.clientHeight / 100;
     var expectedWidth = parseInt(Math.max(one_vw, one_vh) * 50, 10);
     var compWidth = parseInt((window.getComputedStyle ?
                           getComputedStyle(elem, null) :
-                          elem.currentStyle)['width'],10);
+                          elem.currentStyle)['width'], 10);
 
     Modernizr.addTest('cssvmaxunit', roundedEquals(expectedWidth, compWidth) || roundedEquals(expectedWidth, compWidth - scrollbarWidth));
   }, 2);

--- a/feature-detects/css/vminunit.js
+++ b/feature-detects/css/vminunit.js
@@ -14,18 +14,18 @@
   }]
 }
 !*/
-define(['Modernizr', 'docElement', 'testStyles', 'roundedEquals'], function( Modernizr, docElement, testStyles, roundedEquals ) {
+define(['Modernizr', 'docElement', 'testStyles', 'roundedEquals'], function(Modernizr, docElement, testStyles, roundedEquals) {
   testStyles('#modernizr1{width: 50vm;width:50vmin}#modernizr2{width:50px;height:50px;overflow:scroll}', function(node) {
     var elem = node.childNodes[1];
     var scroller = node.childNodes[0];
     var scrollbarWidth = parseInt((scroller.offsetWidth - scroller.clientWidth) / 2, 10);
 
-    var one_vw = docElement.clientWidth/100;
-    var one_vh = docElement.clientHeight/100;
+    var one_vw = docElement.clientWidth / 100;
+    var one_vh = docElement.clientHeight / 100;
     var expectedWidth = parseInt(Math.min(one_vw, one_vh) * 50, 10);
     var compWidth = parseInt((window.getComputedStyle ?
                           getComputedStyle(elem, null) :
-                          elem.currentStyle)['width'],10);
+                          elem.currentStyle)['width'], 10);
 
     Modernizr.addTest('cssvminunit', roundedEquals(expectedWidth, compWidth) || roundedEquals(expectedWidth, compWidth - scrollbarWidth));
   }, 2);

--- a/feature-detects/css/vwunit.js
+++ b/feature-detects/css/vwunit.js
@@ -14,8 +14,8 @@
   }]
 }
 !*/
-define(['Modernizr', 'testStyles'], function( Modernizr, testStyles ) {
-  testStyles('#modernizr { width: 50vw; }', function( elem ) {
+define(['Modernizr', 'testStyles'], function(Modernizr, testStyles) {
+  testStyles('#modernizr { width: 50vw; }', function(elem) {
     var width = parseInt(window.innerWidth / 2, 10);
     var compStyle = parseInt((window.getComputedStyle ?
                               getComputedStyle(elem, null) :

--- a/feature-detects/css/will-change.js
+++ b/feature-detects/css/will-change.js
@@ -12,6 +12,6 @@
 Detects support for the `will-change` css property, which formally signals to the
 browser that an element will be animating.
 */
-define(['Modernizr', 'docElement'], function( Modernizr, docElement ) {
+define(['Modernizr', 'docElement'], function(Modernizr, docElement) {
   Modernizr.addTest('willchange', 'willChange' in docElement.style);
 });

--- a/feature-detects/css/wrapflow.js
+++ b/feature-detects/css/wrapflow.js
@@ -15,14 +15,14 @@
   ]
 }
 !*/
-define(['Modernizr', 'prefixed', 'docElement', 'createElement', 'isSVG'], function( Modernizr, prefixed, docElement, createElement, isSVG) {
-  Modernizr.addTest('wrapflow', function () {
+define(['Modernizr', 'prefixed', 'docElement', 'createElement', 'isSVG'], function(Modernizr, prefixed, docElement, createElement, isSVG) {
+  Modernizr.addTest('wrapflow', function() {
     var prefixedProperty = prefixed('wrapFlow');
     if (!prefixedProperty || isSVG) {
       return false;
     }
 
-    var wrapFlowProperty = prefixedProperty.replace(/([A-Z])/g, function (str, m1) { return '-' + m1.toLowerCase(); }).replace(/^ms-/, '-ms-');
+    var wrapFlowProperty = prefixedProperty.replace(/([A-Z])/g, function(str, m1) { return '-' + m1.toLowerCase(); }).replace(/^ms-/, '-ms-');
 
     /* If the CSS parsing is there we need to determine if wrap-flow actually works to avoid false positive cases, e.g. the browser parses
        the property, but it hasn't got the implementation for the functionality yet. */

--- a/feature-detects/custom-protocol-handler.js
+++ b/feature-detects/custom-protocol-handler.js
@@ -18,10 +18,12 @@
 /* DOC
 Detects support for the `window.registerProtocolHandler()` API to allow websites to register themselves as possible handlers for particular protocols.
 */
-define(['Modernizr'], function( Modernizr ) {
+define(['Modernizr'], function(Modernizr) {
   Modernizr.addTest('customprotocolhandler', function() {
     // early bailout where it doesn't exist at all
-    if ( !navigator.registerProtocolHandler ) return false;
+    if (!navigator.registerProtocolHandler) {
+      return false;
+    }
 
     // registerProtocolHandler was stubbed in webkit for a while, and didn't
     // actually do anything. We intentionally set it improperly to test for

--- a/feature-detects/customevent.js
+++ b/feature-detects/customevent.js
@@ -19,6 +19,6 @@
 Detects support for CustomEvent.
 
 */
-define(['Modernizr'], function( Modernizr ) {
+define(['Modernizr'], function(Modernizr) {
   Modernizr.addTest('customevent', 'CustomEvent' in window && typeof window.CustomEvent === 'function');
 });

--- a/feature-detects/dart.js
+++ b/feature-detects/dart.js
@@ -12,6 +12,6 @@
 /* DOC
 Detects native support for the Dart programming language.
 */
-define(['Modernizr', 'prefixed'], function( Modernizr, prefixed ) {
+define(['Modernizr', 'prefixed'], function(Modernizr, prefixed) {
   Modernizr.addTest('dart', !!prefixed('startDart', navigator));
 });

--- a/feature-detects/dataview-api.js
+++ b/feature-detects/dataview-api.js
@@ -14,6 +14,6 @@
 /* DOC
 Detects support for the DataView interface for reading data from an ArrayBuffer as part of the Typed Array spec.
 */
-define(['Modernizr'], function( Modernizr ) {
+define(['Modernizr'], function(Modernizr) {
   Modernizr.addTest('dataview', (typeof DataView !== 'undefined' && 'getFloat64' in DataView.prototype));
 });

--- a/feature-detects/dom/classlist.js
+++ b/feature-detects/dom/classlist.js
@@ -11,6 +11,6 @@
   }]
 }
 !*/
-define(['Modernizr', 'docElement'], function( Modernizr, docElement ) {
+define(['Modernizr', 'docElement'], function(Modernizr, docElement) {
   Modernizr.addTest('classlist', 'classList' in docElement);
 });

--- a/feature-detects/dom/createElement-attrs.js
+++ b/feature-detects/dom/createElement-attrs.js
@@ -11,11 +11,11 @@
   }]
 }
 !*/
-define(['Modernizr', 'createElement'], function( Modernizr, createElement ) {
+define(['Modernizr', 'createElement'], function(Modernizr, createElement) {
   Modernizr.addTest('createelementattrs', function() {
     try {
       return createElement('<input name="test" />').getAttribute('name') == 'test';
-    } catch( e ) {
+    } catch (e) {
       return false;
     }
   }, {

--- a/feature-detects/dom/dataset.js
+++ b/feature-detects/dom/dataset.js
@@ -8,7 +8,7 @@
   "authors": ["@phiggins42"]
 }
 !*/
-define(['Modernizr', 'createElement'], function( Modernizr, createElement ) {
+define(['Modernizr', 'createElement'], function(Modernizr, createElement) {
   // dataset API for data-* attributes
   Modernizr.addTest('dataset', function() {
     var n = createElement('div');

--- a/feature-detects/dom/hidden.js
+++ b/feature-detects/dom/hidden.js
@@ -17,6 +17,6 @@
 /* DOC
 Does the browser support the HTML5 [hidden] attribute?
 */
-define(['Modernizr', 'createElement'], function( Modernizr, createElement ) {
+define(['Modernizr', 'createElement'], function(Modernizr, createElement) {
   Modernizr.addTest('hidden', 'hidden' in createElement('a'));
 });

--- a/feature-detects/dom/microdata.js
+++ b/feature-detects/dom/microdata.js
@@ -10,6 +10,6 @@
   }]
 }
 !*/
-define(['Modernizr'], function( Modernizr ) {
+define(['Modernizr'], function(Modernizr) {
   Modernizr.addTest('microdata', 'getItems' in document);
 });

--- a/feature-detects/dom/mutationObserver.js
+++ b/feature-detects/dom/mutationObserver.js
@@ -17,7 +17,7 @@
 Determines if DOM4 MutationObserver support is available.
 
 */
-define(['Modernizr'], function( Modernizr ) {
+define(['Modernizr'], function(Modernizr) {
   Modernizr.addTest('mutationobserver',
     !!window.MutationObserver || !!window.WebKitMutationObserver);
 });

--- a/feature-detects/draganddrop.js
+++ b/feature-detects/draganddrop.js
@@ -14,7 +14,7 @@
 /* DOC
 Detects support for native drag & drop of elements.
 */
-define(['Modernizr', 'createElement'], function( Modernizr, createElement ) {
+define(['Modernizr', 'createElement'], function(Modernizr, createElement) {
   Modernizr.addTest('draganddrop', function() {
     var div = createElement('div');
     return ('draggable' in div) || ('ondragstart' in div && 'ondrop' in div);

--- a/feature-detects/elem/datalist.js
+++ b/feature-detects/elem/datalist.js
@@ -18,9 +18,9 @@
   }]
 }
 !*/
-define(['Modernizr', 'test/input'], function( Modernizr ) {
+define(['Modernizr', 'test/input'], function(Modernizr) {
   // lol. we already have a test for datalist built in! silly you.
   // Leaving it around in case anyone's using it
 
-  Modernizr.addTest('datalistelem', Modernizr.input.list );
+  Modernizr.addTest('datalistelem', Modernizr.input.list);
 });

--- a/feature-detects/elem/details.js
+++ b/feature-detects/elem/details.js
@@ -12,7 +12,7 @@
   }]
 }
 !*/
-define(['Modernizr', 'createElement', 'docElement', 'testStyles'], function( Modernizr, createElement, docElement, testStyles ) {
+define(['Modernizr', 'createElement', 'docElement', 'testStyles'], function(Modernizr, createElement, docElement, testStyles) {
   Modernizr.addTest('details', function() {
     var el = createElement('details');
     var diff;
@@ -22,7 +22,7 @@ define(['Modernizr', 'createElement', 'docElement', 'testStyles'], function( Mod
       return false;
     }
 
-    testStyles('#modernizr details{display:block}', function( node ) {
+    testStyles('#modernizr details{display:block}', function(node) {
       node.appendChild(el);
       el.innerHTML = '<summary>a</summary>b';
       diff = el.offsetHeight;

--- a/feature-detects/elem/output.js
+++ b/feature-detects/elem/output.js
@@ -10,6 +10,6 @@
   }]
 }
 !*/
-define(['Modernizr', 'createElement'], function( Modernizr, createElement ) {
+define(['Modernizr', 'createElement'], function(Modernizr, createElement) {
   Modernizr.addTest('outputelem', 'value' in createElement('output'));
 });

--- a/feature-detects/elem/picture.js
+++ b/feature-detects/elem/picture.js
@@ -13,6 +13,6 @@
   }]
 }
 !*/
-define(['Modernizr'], function( Modernizr ) {
-  Modernizr.addTest('picture', 'HTMLPictureElement' in window );
+define(['Modernizr'], function(Modernizr) {
+  Modernizr.addTest('picture', 'HTMLPictureElement' in window);
 });

--- a/feature-detects/elem/progress-meter.js
+++ b/feature-detects/elem/progress-meter.js
@@ -8,7 +8,7 @@
   "authors": ["Stefan Wallin"]
 }
 !*/
-define(['Modernizr', 'createElement'], function( Modernizr, createElement ) {
+define(['Modernizr', 'createElement'], function(Modernizr, createElement) {
   // Tests for progressbar-support. All browsers that don't support progressbar returns undefined =)
   Modernizr.addTest('progressbar', createElement('progress').max !== undefined);
 

--- a/feature-detects/elem/ruby.js
+++ b/feature-detects/elem/ruby.js
@@ -12,8 +12,8 @@
   }]
 }
 !*/
-define(['Modernizr', 'createElement', 'docElement'], function( Modernizr, createElement, docElement ) {
-  Modernizr.addTest('ruby', function () {
+define(['Modernizr', 'createElement', 'docElement'], function(Modernizr, createElement, docElement) {
+  Modernizr.addTest('ruby', function() {
 
     var ruby = createElement('ruby');
     var rt = createElement('rt');
@@ -27,10 +27,10 @@ define(['Modernizr', 'createElement', 'docElement'], function( Modernizr, create
     docElement.appendChild(ruby);
 
     // browsers that support <ruby> hide the <rp> via "display:none"
-    if ( getStyle(rp, displayStyleProperty) == 'none' ||                                                        // for non-IE browsers
+    if (getStyle(rp, displayStyleProperty) == 'none' ||                                                        // for non-IE browsers
          // but in IE browsers <rp> has "display:inline" so, the test needs other conditions:
          getStyle(ruby, displayStyleProperty) == 'ruby' && getStyle(rt, displayStyleProperty) == 'ruby-text' || // for IE8+
-         getStyle(rp, fontSizeStyleProperty) == '6pt' && getStyle(rt, fontSizeStyleProperty) == '6pt' ) {       // for IE6 & IE7
+         getStyle(rp, fontSizeStyleProperty) == '6pt' && getStyle(rt, fontSizeStyleProperty) == '6pt') {       // for IE6 & IE7
 
       cleanUp();
       return true;
@@ -40,12 +40,12 @@ define(['Modernizr', 'createElement', 'docElement'], function( Modernizr, create
       return false;
     }
 
-    function getStyle( element, styleProperty ) {
+    function getStyle(element, styleProperty) {
       var result;
 
-      if ( window.getComputedStyle ) {     // for non-IE browsers
-        result = document.defaultView.getComputedStyle(element,null).getPropertyValue(styleProperty);
-      } else if ( element.currentStyle ) { // for IE
+      if (window.getComputedStyle) {     // for non-IE browsers
+        result = document.defaultView.getComputedStyle(element, null).getPropertyValue(styleProperty);
+      } else if (element.currentStyle) { // for IE
         result = element.currentStyle[styleProperty];
       }
 

--- a/feature-detects/elem/template.js
+++ b/feature-detects/elem/template.js
@@ -12,6 +12,6 @@
   }]
 }
 !*/
-define(['Modernizr', 'createElement'], function( Modernizr, createElement ) {
+define(['Modernizr', 'createElement'], function(Modernizr, createElement) {
   Modernizr.addTest('template', 'content' in createElement('template'));
 });

--- a/feature-detects/elem/time.js
+++ b/feature-detects/elem/time.js
@@ -10,6 +10,6 @@
   }]
 }
 !*/
-define(['Modernizr', 'createElement'], function( Modernizr, createElement ) {
+define(['Modernizr', 'createElement'], function(Modernizr, createElement) {
   Modernizr.addTest('time', 'valueAsDate' in createElement('time'));
 });

--- a/feature-detects/elem/track.js
+++ b/feature-detects/elem/track.js
@@ -15,7 +15,7 @@
   "warnings": ["While IE10 has implemented the track element, IE10 does not expose the underlying APIs to create timed text tracks by JS (really sad)"]
 }
 !*/
-define(['Modernizr', 'createElement'], function( Modernizr, createElement ) {
+define(['Modernizr', 'createElement'], function(Modernizr, createElement) {
   Modernizr.addTest('texttrackapi', typeof (createElement('video').addTextTrack) === 'function');
 
   // a more strict test for track including UI support: document.createElement('track').kind === 'subtitles'

--- a/feature-detects/elem/unknown.js
+++ b/feature-detects/elem/unknown.js
@@ -17,8 +17,8 @@
 /* DOC
 Does the browser support HTML with non-standard / new elements?
 */
-define(['Modernizr', 'createElement'], function( Modernizr, createElement ) {
-  Modernizr.addTest('unknownelements', function () {
+define(['Modernizr', 'createElement'], function(Modernizr, createElement) {
+  Modernizr.addTest('unknownelements', function() {
     var a = createElement('a');
     a.innerHTML = '<xyz></xyz>';
     return a.childNodes.length === 1;

--- a/feature-detects/emoji.js
+++ b/feature-detects/emoji.js
@@ -7,9 +7,11 @@
 /* DOC
 Detects support for emoji character sets.
 */
-define(['Modernizr', 'createElement', 'test/canvastext'], function( Modernizr, createElement ) {
+define(['Modernizr', 'createElement', 'test/canvastext'], function(Modernizr, createElement) {
   Modernizr.addTest('emoji', function() {
-    if (!Modernizr.canvastext) return false;
+    if (!Modernizr.canvastext) {
+      return false;
+    }
     var pixelRatio = window.devicePixelRatio || 1;
     var offset = 12 * pixelRatio;
     var node = createElement('canvas');

--- a/feature-detects/es5/array.js
+++ b/feature-detects/es5/array.js
@@ -14,8 +14,8 @@
 /* DOC
 Check if browser implements ECMAScript 5 Array per specification.
 */
-define(['Modernizr'], function (Modernizr) {
-  Modernizr.addTest('es5array', function () {
+define(['Modernizr'], function(Modernizr) {
+  Modernizr.addTest('es5array', function() {
     return !!(Array.prototype &&
       Array.prototype.every &&
       Array.prototype.filter &&

--- a/feature-detects/es5/date.js
+++ b/feature-detects/es5/date.js
@@ -14,8 +14,8 @@
 /* DOC
 Check if browser implements ECMAScript 5 Date per specification.
 */
-define(['Modernizr'], function (Modernizr) {
-  Modernizr.addTest('es5date', function () {
+define(['Modernizr'], function(Modernizr) {
+  Modernizr.addTest('es5date', function() {
     var isoDate = '2013-04-12T06:06:37.307Z',
       canParseISODate = false;
     try {

--- a/feature-detects/es5/function.js
+++ b/feature-detects/es5/function.js
@@ -14,8 +14,8 @@
 /* DOC
 Check if browser implements ECMAScript 5 Function per specification.
 */
-define(['Modernizr'], function (Modernizr) {
-  Modernizr.addTest('es5function', function () {
+define(['Modernizr'], function(Modernizr) {
+  Modernizr.addTest('es5function', function() {
     return !!(Function.prototype && Function.prototype.bind);
   });
 });

--- a/feature-detects/es5/object.js
+++ b/feature-detects/es5/object.js
@@ -14,8 +14,8 @@
 /* DOC
 Check if browser implements ECMAScript 5 Object per specification.
 */
-define(['Modernizr'], function (Modernizr) {
-  Modernizr.addTest('es5object', function () {
+define(['Modernizr'], function(Modernizr) {
+  Modernizr.addTest('es5object', function() {
     return !!(Object.keys &&
       Object.create &&
       Object.getPrototypeOf &&

--- a/feature-detects/es5/specification.js
+++ b/feature-detects/es5/specification.js
@@ -14,8 +14,8 @@
 /* DOC
 Check if browser implements everything as specified in ECMAScript 5.
 */
-define([ 'Modernizr', 'test/es5/array', 'test/es5/date', 'test/es5/function', 'test/es5/object', 'test/es5/strictmode', 'test/es5/string', 'test/json', 'test/es5/syntax', 'test/es5/undefined'], function (Modernizr) {
-  Modernizr.addTest('es5', function () {
+define(['Modernizr', 'test/es5/array', 'test/es5/date', 'test/es5/function', 'test/es5/object', 'test/es5/strictmode', 'test/es5/string', 'test/json', 'test/es5/syntax', 'test/es5/undefined'], function(Modernizr) {
+  Modernizr.addTest('es5', function() {
     return !!(
       Modernizr.es5array &&
       Modernizr.es5date &&

--- a/feature-detects/es5/strictmode.js
+++ b/feature-detects/es5/strictmode.js
@@ -15,6 +15,6 @@
 /* DOC
 Check if browser implements ECMAScript 5 Object strict mode.
 */
-define(['Modernizr'], function( Modernizr ) {
-  Modernizr.addTest('strictmode', (function(){'use strict'; return !this; })());
+define(['Modernizr'], function(Modernizr) {
+  Modernizr.addTest('strictmode', (function() {'use strict'; return !this; })());
 });

--- a/feature-detects/es5/string.js
+++ b/feature-detects/es5/string.js
@@ -14,8 +14,8 @@
 /* DOC
 Check if browser implements ECMAScript 5 String per specification.
 */
-define(['Modernizr'], function (Modernizr) {
-  Modernizr.addTest('es5string', function () {
+define(['Modernizr'], function(Modernizr) {
+  Modernizr.addTest('es5string', function() {
     return !!(String.prototype && String.prototype.trim);
   });
 });

--- a/feature-detects/es5/syntax.js
+++ b/feature-detects/es5/syntax.js
@@ -17,8 +17,8 @@
 /* DOC
 Check if browser accepts ECMAScript 5 syntax.
 */
-define(['Modernizr'], function (Modernizr) {
-  Modernizr.addTest('es5syntax', function () {
+define(['Modernizr'], function(Modernizr) {
+  Modernizr.addTest('es5syntax', function() {
     var value, obj, stringAccess, getter, setter, reservedWords, zeroWidthChars;
     try {
       // Property access on strings

--- a/feature-detects/es5/undefined.js
+++ b/feature-detects/es5/undefined.js
@@ -16,8 +16,8 @@
 /* DOC
 Check if browser prevents assignment to global `undefined` per ECMAScript 5.
 */
-define(['Modernizr'], function (Modernizr) {
-  Modernizr.addTest('es5undefined', function () {
+define(['Modernizr'], function(Modernizr) {
+  Modernizr.addTest('es5undefined', function() {
     var result, originalUndefined;
     try {
       originalUndefined = window.undefined;

--- a/feature-detects/es6/array.js
+++ b/feature-detects/es6/array.js
@@ -15,7 +15,7 @@
 /* DOC
 Check if browser implements ECMAScript 6 Array per specification.
 */
-define(['Modernizr'], function (Modernizr) {
+define(['Modernizr'], function(Modernizr) {
   Modernizr.addTest('es6array', !!(Array.prototype &&
     Array.prototype.copyWithin &&
     Array.prototype.fill &&

--- a/feature-detects/es6/contains.js
+++ b/feature-detects/es6/contains.js
@@ -9,6 +9,6 @@
 /* DOC
 Check if browser implements ECMAScript 6 `String.prototype.contains` per specification.
 */
-define(['Modernizr', 'is'], function( Modernizr, is ) {
+define(['Modernizr', 'is'], function(Modernizr, is) {
   Modernizr.addTest('contains', is(String.prototype.contains, 'function'));
 });

--- a/feature-detects/es6/generators.js
+++ b/feature-detects/es6/generators.js
@@ -9,12 +9,12 @@
 /* DOC
 Check if browser implements ECMAScript 6 Generators per specification.
 */
-define(['Modernizr'], function( Modernizr ) {
+define(['Modernizr'], function(Modernizr) {
   Modernizr.addTest('generators', function() {
     try {
       /* jshint evil: true */
       new Function('function* test() {}')();
-    } catch(e) {
+    } catch (e) {
       return false;
     }
     return true;

--- a/feature-detects/es6/math.js
+++ b/feature-detects/es6/math.js
@@ -15,7 +15,7 @@
 /* DOC
 Check if browser implements ECMAScript 6 Math per specification.
 */
-define(['Modernizr'], function (Modernizr) {
+define(['Modernizr'], function(Modernizr) {
   Modernizr.addTest('es6math', !!(Math &&
     Math.clz32 &&
     Math.cbrt &&

--- a/feature-detects/es6/number.js
+++ b/feature-detects/es6/number.js
@@ -15,7 +15,7 @@
 /* DOC
 Check if browser implements ECMAScript 6 Number per specification.
 */
-define(['Modernizr'], function (Modernizr) {
+define(['Modernizr'], function(Modernizr) {
   Modernizr.addTest('es6number', !!(Number.isFinite &&
     Number.isInteger &&
     Number.isSafeInteger &&

--- a/feature-detects/es6/object.js
+++ b/feature-detects/es6/object.js
@@ -15,7 +15,7 @@
 /* DOC
 Check if browser implements ECMAScript 6 Object per specification.
 */
-define(['Modernizr'], function (Modernizr) {
+define(['Modernizr'], function(Modernizr) {
   Modernizr.addTest('es6object', !!(Object.assign &&
     Object.is &&
     Object.setPrototypeOf));

--- a/feature-detects/es6/promises.js
+++ b/feature-detects/es6/promises.js
@@ -21,7 +21,7 @@
 /* DOC
 Check if browser implements ECMAScript 6 Promises per specification.
 */
-define(['Modernizr'], function( Modernizr ) {
+define(['Modernizr'], function(Modernizr) {
   Modernizr.addTest('promises', function() {
     return 'Promise' in window &&
     // Some of these methods are missing from

--- a/feature-detects/es6/string.js
+++ b/feature-detects/es6/string.js
@@ -15,7 +15,7 @@
 /* DOC
 Check if browser implements ECMAScript 6 String per specification.
 */
-define(['Modernizr'], function (Modernizr) {
+define(['Modernizr'], function(Modernizr) {
   Modernizr.addTest('es6string', !!(String.fromCodePoint &&
     String.raw &&
     String.prototype.codePointAt &&

--- a/feature-detects/event/deviceorientation-motion.js
+++ b/feature-detects/event/deviceorientation-motion.js
@@ -25,7 +25,7 @@ Part of Device Access aspect of HTML5, same category as geolocation.
 
 `deviceorientation` tests for Device Orientation Event support, returns boolean value true/false
 */
-define(['Modernizr'], function( Modernizr ) {
+define(['Modernizr'], function(Modernizr) {
   Modernizr.addTest('devicemotion', 'DeviceMotionEvent' in window);
   Modernizr.addTest('deviceorientation', 'DeviceOrientationEvent' in window);
 });

--- a/feature-detects/event/oninput.js
+++ b/feature-detects/event/oninput.js
@@ -19,7 +19,7 @@
 /* DOC
 `oninput` tests if the browser is able to detect the input event
 */
-define(['Modernizr', 'docElement', 'createElement', 'testStyles', 'hasEvent'], function( Modernizr, docElement, createElement, testStyles, hasEvent ) {
+define(['Modernizr', 'docElement', 'createElement', 'testStyles', 'hasEvent'], function(Modernizr, docElement, createElement, testStyles, hasEvent) {
 
   Modernizr.addTest('oninput', function() {
     var input = createElement('input');

--- a/feature-detects/eventlistener.js
+++ b/feature-detects/eventlistener.js
@@ -13,6 +13,6 @@
 /* DOC
 Detects native support for addEventListener
 */
-define(['Modernizr'], function( Modernizr ) {
+define(['Modernizr'], function(Modernizr) {
   Modernizr.addTest('eventlistener', 'addEventListener' in window);
 });

--- a/feature-detects/exif-orientation.js
+++ b/feature-detects/exif-orientation.js
@@ -20,7 +20,7 @@ Detects support for EXIF Orientation in JPEG images.
 
 iOS looks at the EXIF Orientation flag in JPEGs and rotates the image accordingly. Most desktop browsers just ignore this data.
 */
-define(['Modernizr', 'addTest'], function( Modernizr, addTest ) {
+define(['Modernizr', 'addTest'], function(Modernizr, addTest) {
   // Bug trackers:
   //    bugzil.la/298619 (unimplemented)
   //    crbug.com/56845 (looks incomplete)
@@ -29,11 +29,11 @@ define(['Modernizr', 'addTest'], function( Modernizr, addTest ) {
     var img = new Image();
 
     img.onerror = function() {
-      addTest('exiforientation', false, { aliases: ['exif-orientation'] });
+      addTest('exiforientation', false, {aliases: ['exif-orientation']});
     };
 
     img.onload = function() {
-      addTest('exiforientation', img.width !== 2, { aliases: ['exif-orientation'] });
+      addTest('exiforientation', img.width !== 2, {aliases: ['exif-orientation']});
     };
 
     // There may be a way to shrink this more, it's a 1x2 white jpg with the orientation flag set to 6

--- a/feature-detects/file/api.js
+++ b/feature-detects/file/api.js
@@ -19,6 +19,6 @@ Tests for objects specific to the File API W3C specification without
 being redundant (don't bother testing for Blob since it is assumed
 to be the File object's prototype.)
 */
-define(['Modernizr'], function( Modernizr ) {
+define(['Modernizr'], function(Modernizr) {
   Modernizr.addTest('filereader', !!(window.File && window.FileList && window.FileReader));
 });

--- a/feature-detects/file/filesystem.js
+++ b/feature-detects/file/filesystem.js
@@ -13,6 +13,6 @@
   "knownBugs": ["The API will be present in Chrome incognito, but will throw an exception. See crbug.com/93417"]
 }
 !*/
-define(['Modernizr', 'prefixed'], function( Modernizr, prefixed ) {
+define(['Modernizr', 'prefixed'], function(Modernizr, prefixed) {
   Modernizr.addTest('filesystem', !!prefixed('requestFileSystem', window));
 });

--- a/feature-detects/flash.js
+++ b/feature-detects/flash.js
@@ -9,11 +9,11 @@
 /* DOC
 Detects support flash, as well as flash blocking plugins
 */
-define(['Modernizr', 'createElement', 'docElement', 'addTest', 'getBody', 'isSVG'], function( Modernizr, createElement, docElement, addTest, getBody, isSVG ) {
+define(['Modernizr', 'createElement', 'docElement', 'addTest', 'getBody', 'isSVG'], function(Modernizr, createElement, docElement, addTest, getBody, isSVG) {
   Modernizr.addAsyncTest(function() {
     /* jshint -W053 */
 
-    var removeFakeBody = function (body) {
+    var removeFakeBody = function(body) {
       // If we’re rockin’ an attached fake body, clean it up
       if (body.fake && body.parentNode) {
         body.parentNode.removeChild(body);
@@ -45,9 +45,9 @@ define(['Modernizr', 'createElement', 'docElement', 'addTest', 'getBody', 'isSVG
     try {
       // Pan is an API that exists for flash objects.
       activex = 'ActiveXObject' in window && 'Pan' in new window.ActiveXObject('ShockwaveFlash.ShockwaveFlash');
-    } catch(e) {}
+    } catch (e) {}
 
-    easy_detect = !( ( 'plugins' in navigator && 'Shockwave Flash' in navigator.plugins ) || activex );
+    easy_detect = !(('plugins' in navigator && 'Shockwave Flash' in navigator.plugins) || activex);
 
     if (easy_detect || isSVG) {
       runTest(false);

--- a/feature-detects/forms/capture.js
+++ b/feature-detects/forms/capture.js
@@ -12,7 +12,7 @@
 /* DOC
 When used on an `<input>`, this attribute signifies that the resource it takes should be generated via device's camera, camcorder, sound recorder.
 */
-define(['Modernizr', 'createElement'], function( Modernizr, createElement ) {
+define(['Modernizr', 'createElement'], function(Modernizr, createElement) {
   // testing for capture attribute in inputs
   Modernizr.addTest('capture', ('capture' in createElement('input')));
 });

--- a/feature-detects/forms/fileinput.js
+++ b/feature-detects/forms/fileinput.js
@@ -12,9 +12,9 @@ Detects whether input type="file" is available on the platform
 
 E.g. iOS < 6 and some android version don't support this
 */
-define(['Modernizr', 'createElement'], function( Modernizr, createElement ) {
+define(['Modernizr', 'createElement'], function(Modernizr, createElement) {
   Modernizr.addTest('fileinput', function() {
-    if(navigator.userAgent.match(/(Android (1.0|1.1|1.5|1.6|2.0|2.1))|(Windows Phone (OS 7|8.0))|(XBLWP)|(ZuneWP)|(w(eb)?OSBrowser)|(webOS)|(Kindle\/(1.0|2.0|2.5|3.0))/)) {
+    if (navigator.userAgent.match(/(Android (1.0|1.1|1.5|1.6|2.0|2.1))|(Windows Phone (OS 7|8.0))|(XBLWP)|(ZuneWP)|(w(eb)?OSBrowser)|(webOS)|(Kindle\/(1.0|2.0|2.5|3.0))/)) {
       return false;
     }
     var elem = createElement('input');

--- a/feature-detects/forms/fileinputdirectory.js
+++ b/feature-detects/forms/fileinputdirectory.js
@@ -11,7 +11,7 @@ When used on an `<input type="file">`, the `directory` attribute instructs
 the user agent to present a directory selection dialog instead of the usual
 file selection dialog.
 */
-define(['Modernizr', 'createElement', 'domPrefixes'], function( Modernizr, createElement, domPrefixes ) {
+define(['Modernizr', 'createElement', 'domPrefixes'], function(Modernizr, createElement, domPrefixes) {
   Modernizr.addTest('fileinputdirectory', function() {
     var elem = createElement('input'), dir = 'directory';
     elem.type = 'file';

--- a/feature-detects/forms/formattribute.js
+++ b/feature-detects/forms/formattribute.js
@@ -10,7 +10,7 @@
 Detects whether input form="form_id" is available on the platform
 E.g. IE 10 (and below), don't support this
 */
-define(['Modernizr', 'createElement', 'docElement'], function( Modernizr, createElement, docElement ) {
+define(['Modernizr', 'createElement', 'docElement'], function(Modernizr, createElement, docElement) {
 
   Modernizr.addTest('formattribute', function() {
     var form = createElement('form');
@@ -26,8 +26,8 @@ define(['Modernizr', 'createElement', 'docElement'], function( Modernizr, create
     try {
       input.setAttribute('form', id);
     }
-    catch( e ) {
-      if( document.createAttribute ) {
+    catch (e) {
+      if (document.createAttribute) {
         attr = document.createAttribute('form');
         attr.nodeValue = id;
         input.setAttributeNode(attr);

--- a/feature-detects/forms/inputnumber-l10n.js
+++ b/feature-detects/forms/inputnumber-l10n.js
@@ -17,7 +17,7 @@
 /* DOC
 Detects whether input type="number" is capable of receiving and displaying localized numbers, e.g. with comma separator.
 */
-define(['Modernizr', 'createElement', 'docElement', 'getBody', 'test/inputtypes', 'test/forms/validation'], function( Modernizr, createElement, docElement, getBody ) {
+define(['Modernizr', 'createElement', 'docElement', 'getBody', 'test/inputtypes', 'test/forms/validation'], function(Modernizr, createElement, docElement, getBody) {
   Modernizr.addTest('localizednumber', function() {
     // this extends our testing of input[type=number], so bomb out if that's missing
     if (!Modernizr.inputtypes.number) { return false; }
@@ -37,7 +37,7 @@ define(['Modernizr', 'createElement', 'docElement', 'getBody', 'test/inputtypes'
     input.focus();
     try {
       document.execCommand('InsertText', false, '1,1');
-    } catch(e) { // prevent warnings in IE
+    } catch (e) { // prevent warnings in IE
     }
     diff = input.type === 'number' && input.valueAsNumber === 1.1 && input.checkValidity();
     root.removeChild(el);

--- a/feature-detects/forms/placeholder.js
+++ b/feature-detects/forms/placeholder.js
@@ -9,6 +9,6 @@
 /* DOC
 Tests for placeholder attribute in inputs and textareas
 */
-define(['Modernizr', 'createElement'], function( Modernizr, createElement ) {
+define(['Modernizr', 'createElement'], function(Modernizr, createElement) {
   Modernizr.addTest('placeholder', ('placeholder' in createElement('input') && 'placeholder' in createElement('textarea')));
 });

--- a/feature-detects/forms/validation.js
+++ b/feature-detects/forms/validation.js
@@ -14,10 +14,10 @@ the test can be combined:
 - `Modernizr.inputtypes.number && Modernizr.formvalidation` (browser supports rangeOverflow, typeMismatch etc. for type=number)
 - `Modernizr.input.required && Modernizr.formvalidation` (browser supports valueMissing)
 */
-define(['Modernizr', 'createElement', 'docElement', 'testStyles'], function( Modernizr, createElement, docElement, testStyles ) {
+define(['Modernizr', 'createElement', 'docElement', 'testStyles'], function(Modernizr, createElement, docElement, testStyles) {
   Modernizr.addTest('formvalidation', function() {
     var form = createElement('form');
-    if ( !('checkValidity' in form) || !('addEventListener' in form) ) {
+    if (!('checkValidity' in form) || !('addEventListener' in form)) {
       return false;
     }
     if ('reportValidity' in form) {
@@ -31,7 +31,7 @@ define(['Modernizr', 'createElement', 'docElement', 'testStyles'], function( Mod
     // Prevent form from being submitted
     form.addEventListener('submit', function(e) {
       //Opera does not validate form, if submit is prevented
-      if ( !window.opera ) {
+      if (!window.opera) {
         e.preventDefault();
       }
       e.stopPropagation();
@@ -42,7 +42,7 @@ define(['Modernizr', 'createElement', 'docElement', 'testStyles'], function( Mod
     //older opera browsers need a name attribute
     form.innerHTML = '<input name="modTest" required><button></button>';
 
-    testStyles('#modernizr form{position:absolute;top:-99999em}', function( node ) {
+    testStyles('#modernizr form{position:absolute;top:-99999em}', function(node) {
       node.appendChild(form);
 
       input = form.getElementsByTagName('input')[0];

--- a/feature-detects/fullscreen-api.js
+++ b/feature-detects/fullscreen-api.js
@@ -14,7 +14,7 @@
 /* DOC
 Detects support for the ability to make the current website take over the user's entire screen
 */
-define(['Modernizr', 'domPrefixes', 'prefixed'], function( Modernizr, domPrefixes, prefixed ) {
+define(['Modernizr', 'domPrefixes', 'prefixed'], function(Modernizr, domPrefixes, prefixed) {
   // github.com/Modernizr/Modernizr/issues/739
   Modernizr.addTest('fullscreen', !!(prefixed('exitFullscreen', document, false) || prefixed('cancelFullScreen', document, false)));
 });

--- a/feature-detects/gamepad.js
+++ b/feature-detects/gamepad.js
@@ -18,7 +18,7 @@
 /* DOC
 Detects support for the Gamepad API, for access to gamepads and controllers.
 */
-define(['Modernizr', 'prefixed'], function( Modernizr, prefixed ) {
+define(['Modernizr', 'prefixed'], function(Modernizr, prefixed) {
   // FF has Gamepad API support only in special builds, but not in any release (even behind a flag)
   // Their current implementation has no way to feature detect, only events to bind to, but a patch
   // will bring them up to date with the spec when it lands (and they'll pass this test)

--- a/feature-detects/geolocation.js
+++ b/feature-detects/geolocation.js
@@ -19,7 +19,7 @@
 /* DOC
 Detects support for the Geolocation API for users to provide their location to web applications.
 */
-define(['Modernizr'], function( Modernizr ) {
+define(['Modernizr'], function(Modernizr) {
   // geolocation is often considered a trivial feature detect...
   // Turns out, it's quite tricky to get right:
   //

--- a/feature-detects/hashchange.js
+++ b/feature-detects/hashchange.js
@@ -20,7 +20,7 @@
 /* DOC
 Detects support for the `hashchange` event, fired when the current location fragment changes.
 */
-define(['Modernizr', 'hasEvent'], function( Modernizr, hasEvent ) {
+define(['Modernizr', 'hasEvent'], function(Modernizr, hasEvent) {
   Modernizr.addTest('hashchange', function() {
     if (hasEvent('hashchange', window) === false) {
       return false;

--- a/feature-detects/hiddenscroll.js
+++ b/feature-detects/hiddenscroll.js
@@ -8,7 +8,7 @@
 /* DOC
 Detects whether scrollbars on overflowed blocks are hidden (a-la iPhone)
 */
-define(['Modernizr', 'testStyles'], function( Modernizr, testStyles ) {
+define(['Modernizr', 'testStyles'], function(Modernizr, testStyles) {
   Modernizr.addTest('hiddenscroll', function() {
     return testStyles('#modernizr {width:100px;height:100px;overflow:scroll}', function(elem) {
       return elem.offsetWidth === elem.clientWidth;

--- a/feature-detects/history.js
+++ b/feature-detects/history.js
@@ -18,7 +18,7 @@
 /* DOC
 Detects support for the History API for manipulating the browser session history.
 */
-define(['Modernizr'], function( Modernizr ) {
+define(['Modernizr'], function(Modernizr) {
   Modernizr.addTest('history', function() {
     // Issue #733
     // The stock browser on Android 2.2 & 2.3, and 4.0.x returns positive on history support

--- a/feature-detects/htmlimports.js
+++ b/feature-detects/htmlimports.js
@@ -20,6 +20,6 @@
 Detects support for HTML import, a feature that is used for loading in Web Components.
  */
 
-define(['addTest', 'createElement'], function ( addTest, createElement ) {
+define(['addTest', 'createElement'], function(addTest, createElement) {
   addTest('htmlimports', 'import' in createElement('link'));
 });

--- a/feature-detects/ie8compat.js
+++ b/feature-detects/ie8compat.js
@@ -8,7 +8,7 @@
 /* DOC
 Detects whether or not the current browser is IE8 in compatibility mode (i.e. acting as IE7).
 */
-define(['Modernizr'], function( Modernizr ) {
+define(['Modernizr'], function(Modernizr) {
   // In this case, IE8 will be acting as IE7. You may choose to remove features in this case.
 
   // related:

--- a/feature-detects/iframe/sandbox.js
+++ b/feature-detects/iframe/sandbox.js
@@ -15,6 +15,6 @@
 /* DOC
 Test for `sandbox` attribute in iframes.
 */
-define(['Modernizr', 'createElement'], function( Modernizr, createElement ) {
+define(['Modernizr', 'createElement'], function(Modernizr, createElement) {
   Modernizr.addTest('sandbox', 'sandbox' in createElement('iframe'));
 });

--- a/feature-detects/iframe/seamless.js
+++ b/feature-detects/iframe/seamless.js
@@ -13,6 +13,6 @@
 /* DOC
 Test for `seamless` attribute in iframes.
 */
-define(['Modernizr', 'createElement'], function( Modernizr, createElement ) {
+define(['Modernizr', 'createElement'], function(Modernizr, createElement) {
   Modernizr.addTest('seamless', 'seamless' in createElement('iframe'));
 });

--- a/feature-detects/iframe/srcdoc.js
+++ b/feature-detects/iframe/srcdoc.js
@@ -13,6 +13,6 @@
 /* DOC
 Test for `srcdoc` attribute in iframes.
 */
-define(['Modernizr', 'createElement'], function( Modernizr, createElement ) {
+define(['Modernizr', 'createElement'], function(Modernizr, createElement) {
   Modernizr.addTest('srcdoc', 'srcdoc' in createElement('iframe'));
 });

--- a/feature-detects/img/apng.js
+++ b/feature-detects/img/apng.js
@@ -14,8 +14,8 @@
 /* DOC
 Test for animated png support.
 */
-define(['Modernizr', 'createElement', 'addTest', 'test/canvas'], function( Modernizr, createElement, addTest ) {
-  Modernizr.addAsyncTest(function () {
+define(['Modernizr', 'createElement', 'addTest', 'test/canvas'], function(Modernizr, createElement, addTest) {
+  Modernizr.addAsyncTest(function() {
     if (!Modernizr.canvas) {
       return false;
     }
@@ -24,8 +24,8 @@ define(['Modernizr', 'createElement', 'addTest', 'test/canvas'], function( Moder
     var canvas = createElement('canvas');
     var ctx = canvas.getContext('2d');
 
-    image.onload = function () {
-      addTest('apng', function () {
+    image.onload = function() {
+      addTest('apng', function() {
         if (typeof canvas.getContext == 'undefined') {
           return false;
         }

--- a/feature-detects/img/jpegxr.js
+++ b/feature-detects/img/jpegxr.js
@@ -14,13 +14,13 @@
 /* DOC
 Test for JPEG XR support
 */
-define(['Modernizr', 'addTest'], function( Modernizr, addTest ) {
+define(['Modernizr', 'addTest'], function(Modernizr, addTest) {
 
   Modernizr.addAsyncTest(function() {
     var image = new Image();
 
     image.onload = image.onerror = function() {
-      addTest('jpegxr', image.width == 1, { aliases: ['jpeg-xr'] });
+      addTest('jpegxr', image.width == 1, {aliases: ['jpeg-xr']});
     };
 
     image.src = 'data:image/vnd.ms-photo;base64,SUm8AQgAAAAFAAG8AQAQAAAASgAAAIC8BAABAAAAAQAAAIG8BAABAAAAAQAAAMC8BAABAAAAWgAAAMG8BAABAAAAHwAAAAAAAAAkw91vA07+S7GFPXd2jckNV01QSE9UTwAZAYBxAAAAABP/gAAEb/8AAQAAAQAAAA==';

--- a/feature-detects/img/sizes.js
+++ b/feature-detects/img/sizes.js
@@ -16,6 +16,6 @@
 /* DOC
 Test for the `sizes` attribute on images
 */
-define(['Modernizr', 'createElement'], function( Modernizr, createElement ) {
+define(['Modernizr', 'createElement'], function(Modernizr, createElement) {
   Modernizr.addTest('sizes', 'sizes' in createElement('img'));
 });

--- a/feature-detects/img/srcset.js
+++ b/feature-detects/img/srcset.js
@@ -15,6 +15,6 @@
 /* DOC
 Test for the srcset attribute of images
 */
-define(['Modernizr', 'createElement'], function( Modernizr, createElement ) {
+define(['Modernizr', 'createElement'], function(Modernizr, createElement) {
   Modernizr.addTest('srcset', 'srcset' in createElement('img'));
 });

--- a/feature-detects/img/webp-alpha.js
+++ b/feature-detects/img/webp-alpha.js
@@ -21,16 +21,16 @@
 /* DOC
 Tests for transparent webp support.
 */
-define(['Modernizr', 'addTest'], function( Modernizr, addTest ) {
-  Modernizr.addAsyncTest(function(){
+define(['Modernizr', 'addTest'], function(Modernizr, addTest) {
+  Modernizr.addAsyncTest(function() {
     var image = new Image();
 
     image.onerror = function() {
-      addTest('webpalpha', false, { aliases: ['webp-alpha'] });
+      addTest('webpalpha', false, {aliases: ['webp-alpha']});
     };
 
     image.onload = function() {
-      addTest('webpalpha', image.width == 1, { aliases: ['webp-alpha'] });
+      addTest('webpalpha', image.width == 1, {aliases: ['webp-alpha']});
     };
 
     image.src = 'data:image/webp;base64,UklGRkoAAABXRUJQVlA4WAoAAAAQAAAAAAAAAAAAQUxQSAwAAAABBxAR/Q9ERP8DAABWUDggGAAAADABAJ0BKgEAAQADADQlpAADcAD++/1QAA==';

--- a/feature-detects/img/webp-animation.js
+++ b/feature-detects/img/webp-animation.js
@@ -18,16 +18,16 @@
 /* DOC
 Tests for animated webp support.
 */
-define(['Modernizr', 'addTest'], function( Modernizr, addTest ) {
-  Modernizr.addAsyncTest(function(){
+define(['Modernizr', 'addTest'], function(Modernizr, addTest) {
+  Modernizr.addAsyncTest(function() {
     var image = new Image();
 
     image.onerror = function() {
-      addTest('webpanimation', false, { aliases: ['webp-animation'] });
+      addTest('webpanimation', false, {aliases: ['webp-animation']});
     };
 
     image.onload = function() {
-      addTest('webpanimation', image.width == 1, { aliases: ['webp-animation'] });
+      addTest('webpanimation', image.width == 1, {aliases: ['webp-animation']});
     };
 
     image.src = 'data:image/webp;base64,UklGRlIAAABXRUJQVlA4WAoAAAASAAAAAAAAAAAAQU5JTQYAAAD/////AABBTk1GJgAAAAAAAAAAAAAAAAAAAGQAAABWUDhMDQAAAC8AAAAQBxAREYiI/gcA';

--- a/feature-detects/img/webp-lossless.js
+++ b/feature-detects/img/webp-lossless.js
@@ -17,16 +17,16 @@
 /* DOC
 Tests for non-alpha lossless webp support.
 */
-define(['Modernizr', 'addTest'], function( Modernizr, addTest ) {
-  Modernizr.addAsyncTest(function(){
+define(['Modernizr', 'addTest'], function(Modernizr, addTest) {
+  Modernizr.addAsyncTest(function() {
     var image = new Image();
 
     image.onerror = function() {
-      addTest('webplossless', false, { aliases: ['webp-lossless'] });
+      addTest('webplossless', false, {aliases: ['webp-lossless']});
     };
 
     image.onload = function() {
-      addTest('webplossless', image.width == 1, { aliases: ['webp-lossless'] });
+      addTest('webplossless', image.width == 1, {aliases: ['webp-lossless']});
     };
 
     image.src = 'data:image/webp;base64,UklGRh4AAABXRUJQVlA4TBEAAAAvAAAAAAfQ//73v/+BiOh/AAA=';

--- a/feature-detects/img/webp.js
+++ b/feature-detects/img/webp.js
@@ -36,17 +36,17 @@ Tests for all forms of webp support (lossless, lossy, alpha, and animated)..
   Modernizr.webp.animation    // Animated WebP
 
 */
-define(['Modernizr', 'addTest'], function( Modernizr, addTest ) {
+define(['Modernizr', 'addTest'], function(Modernizr, addTest) {
 
   Modernizr.addAsyncTest(function() {
 
     var webpTests = [{
       'uri': 'data:image/webp;base64,UklGRiQAAABXRUJQVlA4IBgAAAAwAQCdASoBAAEAAwA0JaQAA3AA/vuUAAA=',
       'name': 'webp'
-    },{
+    }, {
       'uri': 'data:image/webp;base64,UklGRkoAAABXRUJQVlA4WAoAAAAQAAAAAAAAAAAAQUxQSAwAAAABBxAR/Q9ERP8DAABWUDggGAAAADABAJ0BKgEAAQADADQlpAADcAD++/1QAA==',
       'name': 'webp.alpha'
-    },{
+    }, {
       'uri': 'data:image/webp;base64,UklGRlIAAABXRUJQVlA4WAoAAAASAAAAAAAAAAAAQU5JTQYAAAD/////AABBTk1GJgAAAAAAAAAAAAAAAAAAAGQAAABWUDhMDQAAAC8AAAAQBxAREYiI/gcA',
       'name': 'webp.animation'
     }, {
@@ -69,7 +69,9 @@ define(['Modernizr', 'addTest'], function( Modernizr, addTest ) {
         /* jshint -W053 */
         addTest(name, baseTest ? new Boolean(result) : result);
 
-        if (cb) cb(event);
+        if (cb) {
+          cb(event);
+        }
       }
 
       image.onerror = addResult;

--- a/feature-detects/indexeddb.js
+++ b/feature-detects/indexeddb.js
@@ -10,7 +10,7 @@
 /* DOC
 Detects support for the IndexedDB client-side storage API (final spec).
 */
-define(['Modernizr', 'prefixed'], function( Modernizr, prefixed ) {
+define(['Modernizr', 'prefixed'], function(Modernizr, prefixed) {
   // Vendors had inconsistent prefixing with the experimental Indexed DB:
   // - Webkit's implementation is accessible through webkitIndexedDB
   // - Firefox shipped moz_indexedDB before FF4b9, but since then has been mozIndexedDB

--- a/feature-detects/indexeddbblob.js
+++ b/feature-detects/indexeddbblob.js
@@ -7,7 +7,7 @@
 /* DOC
 Detects if the browser can save File/Blob objects to IndexedDB
 */
-define(['Modernizr', 'addTest', 'prefixed', 'test/indexeddb'], function( Modernizr, addTest, prefixed ) {
+define(['Modernizr', 'addTest', 'prefixed', 'test/indexeddb'], function(Modernizr, addTest, prefixed) {
   // Vendors had inconsistent prefixing with the experimental Indexed DB:
   // - Webkit's implementation is accessible through webkitIndexedDB
   // - Firefox shipped moz_indexedDB before FF4b9, but since then has been mozIndexedDB
@@ -21,12 +21,14 @@ define(['Modernizr', 'addTest', 'prefixed', 'test/indexeddb'], function( Moderni
     var request;
     var db;
 
-    if (!(Modernizr.indexeddb && Modernizr.indexeddb.deleteDatabase)) return false;
+    if (!(Modernizr.indexeddb && Modernizr.indexeddb.deleteDatabase)) {
+      return false;
+    }
 
     // Calling `deleteDatabase` in a try…catch because some contexts (e.g. data URIs)
     // will throw a `SecurityError`
     try {
-      indexeddb.deleteDatabase(dbname).onsuccess = function () {
+      indexeddb.deleteDatabase(dbname).onsuccess = function() {
         request = indexeddb.open(dbname, 1);
         request.onupgradeneeded = function() {
           request.result.createObjectStore('store');

--- a/feature-detects/input.js
+++ b/feature-detects/input.js
@@ -27,7 +27,7 @@ Modernizr.input.required
 Modernizr.input.step
 ```
 */
-define(['Modernizr', 'createElement', 'attrs', 'inputattrs', 'inputElem'], function( Modernizr, createElement, attrs, inputattrs, inputElem ) {
+define(['Modernizr', 'createElement', 'attrs', 'inputattrs', 'inputElem'], function(Modernizr, createElement, attrs, inputattrs, inputElem) {
   // Run through HTML5's new input attributes to see if the UA understands any.
   // Mike Taylr has created a comprehensive resource for testing these attributes
   //   when applied to all input types:
@@ -36,11 +36,11 @@ define(['Modernizr', 'createElement', 'attrs', 'inputattrs', 'inputElem'], funct
   // Only input placeholder is tested while textarea's placeholder is not.
   // Currently Safari 4 and Opera 11 have support only for the input placeholder
   // Both tests are available in feature-detects/forms-placeholder.js
-  Modernizr['input'] = (function( props ) {
-    for ( var i = 0, len = props.length; i < len; i++ ) {
+  Modernizr['input'] = (function(props) {
+    for (var i = 0, len = props.length; i < len; i++) {
       attrs[ props[i] ] = !!(props[i] in inputElem);
     }
-    if (attrs.list){
+    if (attrs.list) {
       // safari false positive's on datalist: webk.it/74252
       // see also github.com/Modernizr/Modernizr/issues/146
       attrs.list = !!(createElement('datalist') && window.HTMLDataListElement);

--- a/feature-detects/input/formaction.js
+++ b/feature-detects/input/formaction.js
@@ -18,6 +18,6 @@
 /* DOC
 Detect support for the formaction attribute on form inputs
 */
-define(['Modernizr', 'createElement'], function( Modernizr, createElement ) {
-  Modernizr.addTest('inputformaction', !!('formAction' in createElement('input')), { aliases: ['input-formaction'] });
+define(['Modernizr', 'createElement'], function(Modernizr, createElement) {
+  Modernizr.addTest('inputformaction', !!('formAction' in createElement('input')), {aliases: ['input-formaction']});
 });

--- a/feature-detects/input/formenctype.js
+++ b/feature-detects/input/formenctype.js
@@ -18,6 +18,6 @@
 /* DOC
 Detect support for the formenctype attribute on form inputs, which overrides the form enctype attribute
 */
-define(['Modernizr', 'createElement'], function( Modernizr, createElement ) {
-  Modernizr.addTest('inputformenctype', !!('formEnctype' in createElement('input')), { aliases: ['input-formenctype'] });
+define(['Modernizr', 'createElement'], function(Modernizr, createElement) {
+  Modernizr.addTest('inputformenctype', !!('formEnctype' in createElement('input')), {aliases: ['input-formenctype']});
 });

--- a/feature-detects/input/formmethod.js
+++ b/feature-detects/input/formmethod.js
@@ -17,6 +17,6 @@
 /* DOC
 Detect support for the formmethod attribute on form inputs
 */
-define(['Modernizr', 'createElement'], function( Modernizr, createElement ) {
+define(['Modernizr', 'createElement'], function(Modernizr, createElement) {
   Modernizr.addTest('inputformmethod', !!('formMethod' in createElement('input')));
 });

--- a/feature-detects/input/formtarget.js
+++ b/feature-detects/input/formtarget.js
@@ -18,6 +18,6 @@
 /* DOC
 Detect support for the formtarget attribute on form inputs, which overrides the form target attribute
 */
-define(['Modernizr', 'createElement'], function( Modernizr, createElement ) {
-  Modernizr.addTest('inputformtarget', !!('formtarget' in createElement('input')), { aliases: ['input-formtarget'] });
+define(['Modernizr', 'createElement'], function(Modernizr, createElement) {
+  Modernizr.addTest('inputformtarget', !!('formtarget' in createElement('input')), {aliases: ['input-formtarget']});
 });

--- a/feature-detects/inputsearchevent.js
+++ b/feature-detects/inputsearchevent.js
@@ -16,6 +16,6 @@
 /* DOC
 There is a custom `search` event implemented in webkit browsers when using an `input[search]` element.
 */
-define(['Modernizr', 'hasEvent'], function( Modernizr, hasEvent ) {
+define(['Modernizr', 'hasEvent'], function(Modernizr, hasEvent) {
   Modernizr.addTest('inputsearchevent',  hasEvent('search'));
 });

--- a/feature-detects/inputtypes.js
+++ b/feature-detects/inputtypes.js
@@ -40,7 +40,7 @@ Modernizr.inputtypes.url
 Modernizr.inputtypes.week
 ```
 */
-define(['Modernizr', 'inputElem', 'docElement', 'inputtypes', 'inputs', 'smile'], function( Modernizr, inputElem, docElement, inputtypes, inputs, smile ) {
+define(['Modernizr', 'inputElem', 'docElement', 'inputtypes', 'inputs', 'smile'], function(Modernizr, inputElem, docElement, inputtypes, inputs, smile) {
   // Run through HTML5's new input types to see if the UA understands any.
   //   This is put behind the tests runloop because it doesn't return a
   //   true/false like all the other tests; instead, it returns an object
@@ -53,7 +53,7 @@ define(['Modernizr', 'inputElem', 'docElement', 'inputtypes', 'inputs', 'smile']
     var defaultView;
     var len = props.length;
 
-    for ( var i = 0; i < len; i++ ) {
+    for (var i = 0; i < len; i++) {
 
       inputElem.setAttribute('type', inputElemType = props[i]);
       bool = inputElem.type !== 'text' && 'style' in inputElem;
@@ -61,12 +61,12 @@ define(['Modernizr', 'inputElem', 'docElement', 'inputtypes', 'inputs', 'smile']
       // We first check to see if the type we give it sticks..
       // If the type does, we feed it a textual value, which shouldn't be valid.
       // If the value doesn't stick, we know there's input sanitization which infers a custom UI
-      if ( bool ) {
+      if (bool) {
 
         inputElem.value         = smile;
         inputElem.style.cssText = 'position:absolute;visibility:hidden;';
 
-        if ( /^range$/.test(inputElemType) && inputElem.style.WebkitAppearance !== undefined ) {
+        if (/^range$/.test(inputElemType) && inputElem.style.WebkitAppearance !== undefined) {
 
           docElement.appendChild(inputElem);
           defaultView = document.defaultView;
@@ -80,14 +80,14 @@ define(['Modernizr', 'inputElem', 'docElement', 'inputtypes', 'inputs', 'smile']
 
           docElement.removeChild(inputElem);
 
-        } else if ( /^(search|tel)$/.test(inputElemType) ){
+        } else if (/^(search|tel)$/.test(inputElemType)) {
           // Spec doesn't define any special parsing or detectable UI
           //   behaviors so we pass these through as true
 
           // Interestingly, opera fails the earlier test, so it doesn't
           //  even make it here.
 
-        } else if ( /^(url|email|number)$/.test(inputElemType) ) {
+        } else if (/^(url|email|number)$/.test(inputElemType)) {
           // Real url and email support comes with prebaked validation.
           bool = inputElem.checkValidity && inputElem.checkValidity() === false;
 

--- a/feature-detects/intl.js
+++ b/feature-detects/intl.js
@@ -15,6 +15,6 @@
 Detects support for the Internationalization API which allow easy formatting of number and dates and sorting string
 based on a locale
 */
-define(['Modernizr', 'prefixed'], function( Modernizr, prefixed ) {
+define(['Modernizr', 'prefixed'], function(Modernizr, prefixed) {
   Modernizr.addTest('intl', !!prefixed('Intl', window));
 });

--- a/feature-detects/json.js
+++ b/feature-detects/json.js
@@ -13,7 +13,7 @@
 /* DOC
 Detects native support for JSON handling functions.
 */
-define(['Modernizr'], function( Modernizr ) {
+define(['Modernizr'], function(Modernizr) {
   // this will also succeed if you've loaded the JSON2.js polyfill ahead of time
   //   ... but that should be obvious. :)
 

--- a/feature-detects/lists-reversed.js
+++ b/feature-detects/lists-reversed.js
@@ -12,6 +12,6 @@
 /* DOC
 Detects support for the `reversed` attribute on the `<ol>` element.
 */
-define(['Modernizr', 'createElement'], function( Modernizr, createElement ) {
+define(['Modernizr', 'createElement'], function(Modernizr, createElement) {
   Modernizr.addTest('olreversed', 'reversed' in createElement('ol'));
 });

--- a/feature-detects/mathml.js
+++ b/feature-detects/mathml.js
@@ -15,14 +15,14 @@
 /* DOC
 Detects support for MathML, for mathematic equations in web pages.
 */
-define(['Modernizr', 'testStyles'], function( Modernizr, testStyles ) {
+define(['Modernizr', 'testStyles'], function(Modernizr, testStyles) {
   // Based on work by Davide (@dpvc) and David (@davidcarlisle)
   // in https://github.com/mathjax/MathJax/issues/182
 
   Modernizr.addTest('mathml', function() {
     var ret;
 
-    testStyles('#modernizr{position:absolute;display:inline-block}', function(node){
+    testStyles('#modernizr{position:absolute;display:inline-block}', function(node) {
       node.innerHTML += '<math><mfrac><mi>xx</mi><mi>yy</mi></mfrac></math>';
 
       ret = node.offsetHeight > node.offsetWidth;

--- a/feature-detects/network/beacon.js
+++ b/feature-detects/network/beacon.js
@@ -16,6 +16,6 @@
 /* DOC
 Detects support for an API that allows for asynchronous transfer of small HTTP data from the client to a server.
 */
-define(['Modernizr'], function( Modernizr ) {
+define(['Modernizr'], function(Modernizr) {
   Modernizr.addTest('beacon', 'sendBeacon' in navigator);
 });

--- a/feature-detects/network/connection.js
+++ b/feature-detects/network/connection.js
@@ -24,10 +24,10 @@ Unknown devices are assumed as fast
 
 For more rigorous network testing, consider boomerang.js: http://github.com/bluesmoon/boomerang/
 */
-define(['Modernizr'], function( Modernizr ) {
+define(['Modernizr'], function(Modernizr) {
   Modernizr.addTest('lowbandwidth', function() {
     // polyfill
-    var connection = navigator.connection || { type: 0 };
+    var connection = navigator.connection || {type: 0};
 
     return connection.type == 3 || // connection.CELL_2G
       connection.type == 4 || // connection.CELL_3G

--- a/feature-detects/network/eventsource.js
+++ b/feature-detects/network/eventsource.js
@@ -13,6 +13,6 @@
 /* DOC
 Tests for server sent events aka eventsource.
 */
-define(['Modernizr'], function( Modernizr ) {
+define(['Modernizr'], function(Modernizr) {
   Modernizr.addTest('eventsource', 'EventSource' in window);
 });

--- a/feature-detects/network/xhr-responsetype-arraybuffer.js
+++ b/feature-detects/network/xhr-responsetype-arraybuffer.js
@@ -12,6 +12,6 @@
 /* DOC
 Tests for XMLHttpRequest xhr.responseType='arraybuffer'.
 */
-define(['Modernizr', 'testXhrType'], function( Modernizr, testXhrType ) {
+define(['Modernizr', 'testXhrType'], function(Modernizr, testXhrType) {
   Modernizr.addTest('xhrresponsetypearraybuffer', testXhrType('arraybuffer'));
 });

--- a/feature-detects/network/xhr-responsetype-blob.js
+++ b/feature-detects/network/xhr-responsetype-blob.js
@@ -12,6 +12,6 @@
 /* DOC
 Tests for XMLHttpRequest xhr.responseType='blob'.
 */
-define(['Modernizr', 'testXhrType'], function( Modernizr, testXhrType ) {
+define(['Modernizr', 'testXhrType'], function(Modernizr, testXhrType) {
   Modernizr.addTest('xhrresponsetypeblob', testXhrType('blob'));
 });

--- a/feature-detects/network/xhr-responsetype-document.js
+++ b/feature-detects/network/xhr-responsetype-document.js
@@ -12,6 +12,6 @@
 /* DOC
 Tests for XMLHttpRequest xhr.responseType='document'.
 */
-define(['Modernizr', 'testXhrType'], function( Modernizr, testXhrType ) {
+define(['Modernizr', 'testXhrType'], function(Modernizr, testXhrType) {
   Modernizr.addTest('xhrresponsetypedocument', testXhrType('document'));
 });

--- a/feature-detects/network/xhr-responsetype-json.js
+++ b/feature-detects/network/xhr-responsetype-json.js
@@ -15,6 +15,6 @@
 /* DOC
 Tests for XMLHttpRequest xhr.responseType='json'.
 */
-define(['Modernizr', 'testXhrType'], function( Modernizr, testXhrType ) {
+define(['Modernizr', 'testXhrType'], function(Modernizr, testXhrType) {
   Modernizr.addTest('xhrresponsetypejson', testXhrType('json'));
 });

--- a/feature-detects/network/xhr-responsetype-text.js
+++ b/feature-detects/network/xhr-responsetype-text.js
@@ -12,6 +12,6 @@
 /* DOC
 Tests for XMLHttpRequest xhr.responseType='text'.
 */
-define(['Modernizr', 'testXhrType'], function( Modernizr, testXhrType ) {
+define(['Modernizr', 'testXhrType'], function(Modernizr, testXhrType) {
   Modernizr.addTest('xhrresponsetypetext', testXhrType('text'));
 });

--- a/feature-detects/network/xhr-responsetype.js
+++ b/feature-detects/network/xhr-responsetype.js
@@ -12,7 +12,7 @@
 /* DOC
 Tests for XMLHttpRequest xhr.responseType.
 */
-define(['Modernizr'], function( Modernizr ) {
+define(['Modernizr'], function(Modernizr) {
   Modernizr.addTest('xhrresponsetype', (function() {
     if (typeof XMLHttpRequest == 'undefined') {
       return false;

--- a/feature-detects/network/xhr2.js
+++ b/feature-detects/network/xhr2.js
@@ -16,7 +16,7 @@
 /* DOC
 Tests for XHR2.
 */
-define(['Modernizr'], function( Modernizr ) {
+define(['Modernizr'], function(Modernizr) {
   // all three of these details report consistently across all target browsers:
   //   !!(window.ProgressEvent);
   //   'XMLHttpRequest' in window && 'withCredentials' in new XMLHttpRequest

--- a/feature-detects/pagevisibility-api.js
+++ b/feature-detects/pagevisibility-api.js
@@ -20,6 +20,6 @@
 /* DOC
 Detects support for the Page Visibility API, which can be used to disable unnecessary actions and otherwise improve user experience.
 */
-define(['Modernizr', 'prefixed'], function( Modernizr, prefixed ) {
+define(['Modernizr', 'prefixed'], function(Modernizr, prefixed) {
   Modernizr.addTest('pagevisibility', !!prefixed('hidden', document, false));
 });

--- a/feature-detects/performance.js
+++ b/feature-detects/performance.js
@@ -18,6 +18,6 @@
 /* DOC
 Detects support for the Navigation Timing API, for measuring browser and connection performance.
 */
-define(['Modernizr', 'prefixed'], function( Modernizr, prefixed ) {
+define(['Modernizr', 'prefixed'], function(Modernizr, prefixed) {
   Modernizr.addTest('performance', !!prefixed('performance', window));
 });

--- a/feature-detects/pointerevents.js
+++ b/feature-detects/pointerevents.js
@@ -17,10 +17,10 @@
 /* DOC
 Detects support for the DOM Pointer Events API, which provides a unified event interface for pointing input devices, as implemented in IE10+.
 */
-define(['Modernizr', 'domPrefixes', 'hasEvent'], function( Modernizr, domPrefixes, hasEvent ) {
+define(['Modernizr', 'domPrefixes', 'hasEvent'], function(Modernizr, domPrefixes, hasEvent) {
   // **Test name hijacked!**
   // Now refers to W3C DOM PointerEvents spec rather than the CSS pointer-events property.
-  Modernizr.addTest('pointerevents', function () {
+  Modernizr.addTest('pointerevents', function() {
     // Cannot use `.prefixed()` for events, so test each prefix
     var bool = false,
     i = domPrefixes.length;

--- a/feature-detects/pointerlock-api.js
+++ b/feature-detects/pointerlock-api.js
@@ -12,7 +12,7 @@
 /* DOC
 Detects support the pointer lock API which allows you to lock the mouse cursor to the browser window.
 */
-define(['Modernizr', 'prefixed'], function( Modernizr, prefixed ) {
+define(['Modernizr', 'prefixed'], function(Modernizr, prefixed) {
   // https://developer.mozilla.org/en-US/docs/API/Pointer_Lock_API
   Modernizr.addTest('pointerlock', !!prefixed('exitPointerLock', document));
 });

--- a/feature-detects/postmessage.js
+++ b/feature-detects/postmessage.js
@@ -13,6 +13,6 @@
 /* DOC
 Detects support for the `window.postMessage` protocol for cross-document messaging.
 */
-define(['Modernizr'], function( Modernizr ) {
+define(['Modernizr'], function(Modernizr) {
   Modernizr.addTest('postmessage', 'postMessage' in window);
 });

--- a/feature-detects/proximity.js
+++ b/feature-detects/proximity.js
@@ -17,9 +17,9 @@
 /* DOC
 Detects support for an API that allows users to get proximity related information from the device's proximity sensor.
 */
-define(['Modernizr', 'addTest'], function( Modernizr, addTest ) {
+define(['Modernizr', 'addTest'], function(Modernizr, addTest) {
 
-  Modernizr.addAsyncTest(function () {
+  Modernizr.addAsyncTest(function() {
 
     var timeout;
     var timeoutTime = 300;
@@ -37,7 +37,7 @@ define(['Modernizr', 'addTest'], function( Modernizr, addTest ) {
     }
 
     // Check if the browser has support for the API
-    if ( 'ondeviceproximity' in window && 'onuserproximity' in window ) {
+    if ('ondeviceproximity' in window && 'onuserproximity' in window) {
 
       // Check if the device has a proximity sensor
       // ( devices without such a sensor support the events but

--- a/feature-detects/queryselector.js
+++ b/feature-detects/queryselector.js
@@ -15,6 +15,6 @@
 /* DOC
 Detects support for querySelector.
 */
-define(['Modernizr'], function( Modernizr ) {
+define(['Modernizr'], function(Modernizr) {
   Modernizr.addTest('queryselector', 'querySelector' in document && 'querySelectorAll' in document);
 });

--- a/feature-detects/quota-management-api.js
+++ b/feature-detects/quota-management-api.js
@@ -13,7 +13,7 @@
 /* DOC
 Detects the ability to request a specific amount of space for filesystem access
 */
-define(['Modernizr', 'prefixed'], function( Modernizr, prefixed ) {
+define(['Modernizr', 'prefixed'], function(Modernizr, prefixed) {
   Modernizr.addTest('quotamanagement', function() {
     var tempStorage = prefixed('temporaryStorage', navigator);
     var persStorage = prefixed('persistentStorage', navigator);

--- a/feature-detects/requestanimationframe.js
+++ b/feature-detects/requestanimationframe.js
@@ -16,6 +16,6 @@
 /* DOC
 Detects support for the `window.requestAnimationFrame` API, for offloading animation repainting to the browser for optimized performance.
 */
-define(['Modernizr', 'prefixed'], function( Modernizr, prefixed ) {
-  Modernizr.addTest('requestanimationframe', !!prefixed('requestAnimationFrame', window), { aliases: ['raf'] });
+define(['Modernizr', 'prefixed'], function(Modernizr, prefixed) {
+  Modernizr.addTest('requestanimationframe', !!prefixed('requestAnimationFrame', window), {aliases: ['raf']});
 });

--- a/feature-detects/script/async.js
+++ b/feature-detects/script/async.js
@@ -11,6 +11,6 @@
 /* DOC
 Detects support for the `async` attribute on the `<script>` element.
 */
-define(['Modernizr', 'createElement'], function( Modernizr, createElement ) {
+define(['Modernizr', 'createElement'], function(Modernizr, createElement) {
   Modernizr.addTest('scriptasync', 'async' in createElement('script'));
 });

--- a/feature-detects/script/defer.js
+++ b/feature-detects/script/defer.js
@@ -13,6 +13,6 @@
 /* DOC
 Detects support for the `defer` attribute on the `<script>` element.
 */
-define(['Modernizr', 'createElement'], function( Modernizr, createElement ) {
+define(['Modernizr', 'createElement'], function(Modernizr, createElement) {
   Modernizr.addTest('scriptdefer', 'defer' in createElement('script'));
 });

--- a/feature-detects/serviceworker.js
+++ b/feature-detects/serviceworker.js
@@ -11,6 +11,6 @@
 /* DOC
 ServiceWorkers (formerly Navigation Controllers) are a way to persistently cache resources to built apps that work better offline.
 */
-define(['Modernizr'], function( Modernizr ) {
+define(['Modernizr'], function(Modernizr) {
   Modernizr.addTest('serviceworker', 'serviceWorker' in navigator);
 });

--- a/feature-detects/speech/speech-recognition.js
+++ b/feature-detects/speech/speech-recognition.js
@@ -17,6 +17,6 @@
 }
 !*/
 
-define(['Modernizr', 'prefixed'], function (Modernizr, prefixed) {
+define(['Modernizr', 'prefixed'], function(Modernizr, prefixed) {
   Modernizr.addTest('speechrecognition', !!prefixed('SpeechRecognition', window));
 });

--- a/feature-detects/speech/speech-synthesis.js
+++ b/feature-detects/speech/speech-synthesis.js
@@ -13,6 +13,6 @@
 }
 !*/
 
-define(['Modernizr'], function ( Modernizr ) {
+define(['Modernizr'], function(Modernizr) {
   Modernizr.addTest('speechsynthesis', 'SpeechSynthesisUtterance' in window);
 });

--- a/feature-detects/storage/localstorage.js
+++ b/feature-detects/storage/localstorage.js
@@ -16,7 +16,7 @@
   ]
 }
 !*/
-define(['Modernizr'], function( Modernizr ) {
+define(['Modernizr'], function(Modernizr) {
   // In FF4, if disabled, window.localStorage should === null.
 
   // Normally, we could not test that directly and need to do a
@@ -40,7 +40,7 @@ define(['Modernizr'], function( Modernizr ) {
       localStorage.setItem(mod, mod);
       localStorage.removeItem(mod);
       return true;
-    } catch(e) {
+    } catch (e) {
       return false;
     }
   });

--- a/feature-detects/storage/sessionstorage.js
+++ b/feature-detects/storage/sessionstorage.js
@@ -6,7 +6,7 @@
   "polyfills": ["joshuabell-polyfill", "cupcake", "sessionstorage"]
 }
 !*/
-define(['Modernizr'], function( Modernizr ) {
+define(['Modernizr'], function(Modernizr) {
   // Because we are forced to try/catch this, we'll go aggressive.
 
   // Just FWIW: IE8 Compat mode supports these features completely:
@@ -18,7 +18,7 @@ define(['Modernizr'], function( Modernizr ) {
       sessionStorage.setItem(mod, mod);
       sessionStorage.removeItem(mod);
       return true;
-    } catch(e) {
+    } catch (e) {
       return false;
     }
   });

--- a/feature-detects/storage/websqldatabase.js
+++ b/feature-detects/storage/websqldatabase.js
@@ -6,7 +6,7 @@
   "tags": ["storage"]
 }
 !*/
-define(['Modernizr'], function( Modernizr ) {
+define(['Modernizr'], function(Modernizr) {
   // Chrome incognito mode used to throw an exception when using openDatabase
   // It doesn't anymore.
   Modernizr.addTest('websqldatabase', 'openDatabase' in window);

--- a/feature-detects/style/scoped.js
+++ b/feature-detects/style/scoped.js
@@ -16,6 +16,6 @@
 /* DOC
 Support for the `scoped` attribute of the `<style>` element.
 */
-define(['Modernizr', 'createElement'], function( Modernizr, createElement ) {
+define(['Modernizr', 'createElement'], function(Modernizr, createElement) {
   Modernizr.addTest('stylescoped', 'scoped' in createElement('style'));
 });

--- a/feature-detects/svg.js
+++ b/feature-detects/svg.js
@@ -20,6 +20,6 @@
 /* DOC
 Detects support for SVG in `<embed>` or `<object>` elements.
 */
-define(['Modernizr'], function( Modernizr ) {
+define(['Modernizr'], function(Modernizr) {
   Modernizr.addTest('svg', !!document.createElementNS && !!document.createElementNS('http://www.w3.org/2000/svg', 'svg').createSVGRect);
 });

--- a/feature-detects/svg/asimg.js
+++ b/feature-detects/svg/asimg.js
@@ -11,7 +11,7 @@
   }]
 }
 !*/
-define(['Modernizr', 'addTest'], function( Modernizr ) {
+define(['Modernizr', 'addTest'], function(Modernizr) {
 
   // Original Async test by Stu Cox
   // https://gist.github.com/chriscoyier/8774501

--- a/feature-detects/svg/clippaths.js
+++ b/feature-detects/svg/clippaths.js
@@ -14,7 +14,7 @@ Detects support for clip paths in SVG (only, not on HTML content).
 
 See [this discussion](http://github.com/Modernizr/Modernizr/issues/213) regarding applying SVG clip paths to HTML content.
 */
-define(['Modernizr', 'toStringFn'], function( Modernizr, toStringFn ) {
+define(['Modernizr', 'toStringFn'], function(Modernizr, toStringFn) {
   Modernizr.addTest('svgclippaths', function() {
     return !!document.createElementNS &&
       /SVGClipPath/.test(toStringFn.call(document.createElementNS('http://www.w3.org/2000/svg', 'clipPath')));

--- a/feature-detects/svg/filters.js
+++ b/feature-detects/svg/filters.js
@@ -12,7 +12,7 @@
   }]
 }
 !*/
-define(['Modernizr'], function( Modernizr ) {
+define(['Modernizr'], function(Modernizr) {
   // Should fail in Safari: http://stackoverflow.com/questions/9739955/feature-detecting-support-for-svg-filters.
   Modernizr.addTest('svgfilters', function() {
     var result = false;
@@ -20,7 +20,7 @@ define(['Modernizr'], function( Modernizr ) {
       result = 'SVGFEColorMatrixElement' in window &&
         SVGFEColorMatrixElement.SVG_FECOLORMATRIX_TYPE_SATURATE == 2;
     }
-    catch(e) {}
+    catch (e) {}
     return result;
   });
 });

--- a/feature-detects/svg/foreignobject.js
+++ b/feature-detects/svg/foreignobject.js
@@ -12,7 +12,7 @@
 /* DOC
 Detects support for foreignObject tag in SVG.
 */
-define(['Modernizr', 'toStringFn'], function( Modernizr, toStringFn  ) {
+define(['Modernizr', 'toStringFn'], function(Modernizr, toStringFn) {
   Modernizr.addTest('svgforeignobject', function() {
     return !!document.createElementNS &&
       /SVGForeignObject/.test(toStringFn.call(document.createElementNS('http://www.w3.org/2000/svg', 'foreignObject')));

--- a/feature-detects/svg/inline.js
+++ b/feature-detects/svg/inline.js
@@ -14,7 +14,7 @@
 /* DOC
 Detects support for inline SVG in HTML (not within XHTML).
 */
-define(['Modernizr', 'createElement'], function( Modernizr, createElement ) {
+define(['Modernizr', 'createElement'], function(Modernizr, createElement) {
   Modernizr.addTest('inlinesvg', function() {
     var div = createElement('div');
     div.innerHTML = '<svg/>';

--- a/feature-detects/svg/smil.js
+++ b/feature-detects/svg/smil.js
@@ -10,7 +10,7 @@
   }]
 }
 !*/
-define(['Modernizr', 'toStringFn'], function( Modernizr, toStringFn ) {
+define(['Modernizr', 'toStringFn'], function(Modernizr, toStringFn) {
   // SVG SMIL animation
   Modernizr.addTest('smil', function() {
     return !!document.createElementNS &&

--- a/feature-detects/textarea/maxlength.js
+++ b/feature-detects/textarea/maxlength.js
@@ -15,6 +15,6 @@
 /* DOC
 Detect support for the maxlength attribute of a textarea element
 */
-define(['Modernizr', 'createElement'], function( Modernizr, createElement ) {
+define(['Modernizr', 'createElement'], function(Modernizr, createElement) {
   Modernizr.addTest('textareamaxlength', !!('maxLength' in createElement('textarea')));
 });

--- a/feature-detects/touchevents.js
+++ b/feature-detects/touchevents.js
@@ -33,15 +33,15 @@ It's recommended to bind both mouse and touch/pointer events simultaneously – 
 
 This test will also return `true` for Firefox 4 Multitouch support.
 */
-define(['Modernizr', 'prefixes', 'testStyles'], function( Modernizr, prefixes, testStyles ) {
+define(['Modernizr', 'prefixes', 'testStyles'], function(Modernizr, prefixes, testStyles) {
   // Chrome (desktop) used to lie about its support on this, but that has since been rectified: http://crbug.com/36415
   Modernizr.addTest('touchevents', function() {
     var bool;
-    if(('ontouchstart' in window) || window.DocumentTouch && document instanceof DocumentTouch) {
+    if (('ontouchstart' in window) || window.DocumentTouch && document instanceof DocumentTouch) {
       bool = true;
     } else {
-      var query = ['@media (',prefixes.join('touch-enabled),('),'heartz',')','{#modernizr{top:9px;position:absolute}}'].join('');
-      testStyles(query, function( node ) {
+      var query = ['@media (', prefixes.join('touch-enabled),('), 'heartz', ')', '{#modernizr{top:9px;position:absolute}}'].join('');
+      testStyles(query, function(node) {
         bool = node.offsetTop === 9;
       });
     }

--- a/feature-detects/typed-arrays.js
+++ b/feature-detects/typed-arrays.js
@@ -20,7 +20,7 @@ Detects support for native binary data manipulation via Typed Arrays in JavaScri
 
 Does not check for DataView support; use `Modernizr.dataview` for that.
 */
-define(['Modernizr'], function( Modernizr ) {
+define(['Modernizr'], function(Modernizr) {
   // Should fail in:
   // Internet Explorer <= 9
   // Firefox <= 3.6
@@ -32,5 +32,5 @@ define(['Modernizr'], function( Modernizr ) {
   // Android Browser < 4.0
   // Blackberry Browser < 10.0
 
-  Modernizr.addTest('typedarrays', 'ArrayBuffer' in window );
+  Modernizr.addTest('typedarrays', 'ArrayBuffer' in window);
 });

--- a/feature-detects/unicode-range.js
+++ b/feature-detects/unicode-range.js
@@ -11,10 +11,10 @@
   }]
 }
 !*/
-define(['Modernizr', 'testStyles', 'createElement'], function (Modernizr, testStyles, createElement) {
-  Modernizr.addTest('unicoderange', function () {
+define(['Modernizr', 'testStyles', 'createElement'], function(Modernizr, testStyles, createElement) {
+  Modernizr.addTest('unicoderange', function() {
 
-    return Modernizr.testStyles('@font-face{font-family:"unicodeRange";src:local("Arial");unicode-range:U+0020,U+002E}#modernizr span{font-size:20px;display:inline-block;font-family:"unicodeRange",monospace}#modernizr .mono{font-family:monospace}', function (elem) {
+    return Modernizr.testStyles('@font-face{font-family:"unicodeRange";src:local("Arial");unicode-range:U+0020,U+002E}#modernizr span{font-size:20px;display:inline-block;font-family:"unicodeRange",monospace}#modernizr .mono{font-family:monospace}', function(elem) {
 
       // we use specify a unicode-range of 002E (the `.` glyph,
       // and a monospace font as the fallback. If the first of

--- a/feature-detects/unicode.js
+++ b/feature-detects/unicode.js
@@ -11,7 +11,7 @@
 /* DOC
 Detects if unicode characters are supported in the current document.
 */
-define(['Modernizr', 'createElement', 'testStyles', 'isSVG'], function( Modernizr, createElement, testStyles, isSVG ) {
+define(['Modernizr', 'createElement', 'testStyles', 'isSVG'], function(Modernizr, createElement, testStyles, isSVG) {
   /**
    * Unicode special character support
    *
@@ -24,7 +24,7 @@ define(['Modernizr', 'createElement', 'testStyles', 'isSVG'], function( Moderniz
     var missingGlyph = createElement('span');
     var star = createElement('span');
 
-    testStyles('#modernizr{font-family:Arial,sans;font-size:300em;}', function( node ) {
+    testStyles('#modernizr{font-family:Arial,sans;font-size:300em;}', function(node) {
 
       missingGlyph.innerHTML = isSVG ? '\u5987' : '&#5987';
       star.innerHTML = isSVG ? '\u2606' : '&#9734';

--- a/feature-detects/url/bloburls.js
+++ b/feature-detects/url/bloburls.js
@@ -14,7 +14,7 @@
 /* DOC
 Detects support for creating Blob URLs
 */
-define(['Modernizr', 'prefixed'], function( Modernizr, prefixed ) {
+define(['Modernizr', 'prefixed'], function(Modernizr, prefixed) {
   var url = prefixed('URL', window, false);
   url = url && window[url];
   Modernizr.addTest('bloburls', url && 'revokeObjectURL' in url && 'createObjectURL' in url);

--- a/feature-detects/url/data-uri.js
+++ b/feature-detects/url/data-uri.js
@@ -21,7 +21,7 @@ Modernizr.datauri           // true
 Modernizr.datauri.over32kb  // false in IE8
 ```
 */
-define(['Modernizr', 'addTest'], function( Modernizr, addTest ) {
+define(['Modernizr', 'addTest'], function(Modernizr, addTest) {
   // https://github.com/Modernizr/Modernizr/issues/14
   Modernizr.addAsyncTest(function() {
     /* jshint -W053 */
@@ -29,9 +29,9 @@ define(['Modernizr', 'addTest'], function( Modernizr, addTest ) {
     // IE7 throw a mixed content warning on HTTPS for this test, so we'll
     // just blacklist it (we know it doesn't support data URIs anyway)
     // https://github.com/Modernizr/Modernizr/issues/362
-    if(navigator.userAgent.indexOf('MSIE 7.') !== -1) {
+    if (navigator.userAgent.indexOf('MSIE 7.') !== -1) {
       // Keep the test async
-      setTimeout(function () {
+      setTimeout(function() {
         addTest('datauri', false);
       }, 10);
     }
@@ -42,7 +42,7 @@ define(['Modernizr', 'addTest'], function( Modernizr, addTest ) {
       addTest('datauri', false);
     };
     datauri.onload = function() {
-      if(datauri.width == 1 && datauri.height == 1) {
+      if (datauri.width == 1 && datauri.height == 1) {
         testOver32kb();
       }
       else {
@@ -54,7 +54,7 @@ define(['Modernizr', 'addTest'], function( Modernizr, addTest ) {
 
     // Once we have datauri, let's check to see if we can use data URIs over
     // 32kb (IE8 can't). https://github.com/Modernizr/Modernizr/issues/321
-    function testOver32kb(){
+    function testOver32kb() {
 
       var datauriBig = new Image();
 
@@ -73,7 +73,7 @@ define(['Modernizr', 'addTest'], function( Modernizr, addTest ) {
       while (base64str.length < 33000) {
         base64str = '\r\n' + base64str;
       }
-      datauriBig.src= 'data:image/gif;base64,' + base64str;
+      datauriBig.src = 'data:image/gif;base64,' + base64str;
     }
 
   });

--- a/feature-detects/url/parser.js
+++ b/feature-detects/url/parser.js
@@ -14,8 +14,8 @@
 /* DOC
 Check if browser implements the URL constructor for parsing URLs.
 */
-define(['Modernizr'], function (Modernizr) {
-  Modernizr.addTest('urlparser', function () {
+define(['Modernizr'], function(Modernizr) {
+  Modernizr.addTest('urlparser', function() {
     var url;
     try {
       // have to actually try use it, because Safari defines a dud constructor

--- a/feature-detects/userdata.js
+++ b/feature-detects/userdata.js
@@ -13,6 +13,6 @@
 /* DOC
 Detects support for IE userData for persisting data, an API similar to localStorage but supported since IE5.
 */
-define(['Modernizr', 'createElement'], function( Modernizr, createElement ) {
+define(['Modernizr', 'createElement'], function(Modernizr, createElement) {
   Modernizr.addTest('userdata', !!createElement('div').addBehavior);
 });

--- a/feature-detects/vibration.js
+++ b/feature-detects/vibration.js
@@ -14,6 +14,6 @@
 /* DOC
 Detects support for the API that provides access to the vibration mechanism of the hosting device, to provide tactile feedback.
 */
-define(['Modernizr', 'prefixed'], function( Modernizr, prefixed ) {
+define(['Modernizr', 'prefixed'], function(Modernizr, prefixed) {
   Modernizr.addTest('vibrate', !!prefixed('vibrate', navigator));
 });

--- a/feature-detects/video.js
+++ b/feature-detects/video.js
@@ -27,7 +27,7 @@ Modernizr.video         // true
 Modernizr.video.ogg     // 'probably'
 ```
 */
-define(['Modernizr', 'createElement'], function( Modernizr, createElement ) {
+define(['Modernizr', 'createElement'], function(Modernizr, createElement) {
   // Codec values from : github.com/NielsLeenheer/html5test/blob/9106a8/index.html#L845
   //                     thx to NielsLeenheer and zcorpan
 
@@ -42,20 +42,20 @@ define(['Modernizr', 'createElement'], function( Modernizr, createElement ) {
 
     // IE9 Running on Windows Server SKU can cause an exception to be thrown, bug #224
     try {
-      if ( bool = !!elem.canPlayType ) {
+      if (bool = !!elem.canPlayType) {
         bool = new Boolean(bool);
-        bool.ogg = elem.canPlayType('video/ogg; codecs="theora"').replace(/^no$/,'');
+        bool.ogg = elem.canPlayType('video/ogg; codecs="theora"').replace(/^no$/, '');
 
         // Without QuickTime, this value will be `undefined`. github.com/Modernizr/Modernizr/issues/546
-        bool.h264 = elem.canPlayType('video/mp4; codecs="avc1.42E01E"').replace(/^no$/,'');
+        bool.h264 = elem.canPlayType('video/mp4; codecs="avc1.42E01E"').replace(/^no$/, '');
 
-        bool.webm = elem.canPlayType('video/webm; codecs="vp8, vorbis"').replace(/^no$/,'');
+        bool.webm = elem.canPlayType('video/webm; codecs="vp8, vorbis"').replace(/^no$/, '');
 
-        bool.vp9 = elem.canPlayType('video/webm; codecs="vp9"').replace(/^no$/,'');
+        bool.vp9 = elem.canPlayType('video/webm; codecs="vp9"').replace(/^no$/, '');
 
-        bool.hls = elem.canPlayType('application/x-mpegURL; codecs="avc1.42E01E"').replace(/^no$/,'');
+        bool.hls = elem.canPlayType('application/x-mpegURL; codecs="avc1.42E01E"').replace(/^no$/, '');
       }
-    } catch(e){}
+    } catch (e) {}
 
     return bool;
   });

--- a/feature-detects/video/autoplay.js
+++ b/feature-detects/video/autoplay.js
@@ -11,7 +11,7 @@
 /* DOC
 Checks for support of the autoplay attribute of the video element.
 */
-define(['Modernizr', 'addTest', 'docElement', 'createElement', 'test/video'], function( Modernizr, addTest, docElement, createElement ) {
+define(['Modernizr', 'addTest', 'docElement', 'createElement', 'test/video'], function(Modernizr, addTest, docElement, createElement) {
 
   Modernizr.addAsyncTest(function() {
     var timeout;
@@ -55,7 +55,7 @@ define(['Modernizr', 'addTest', 'docElement', 'createElement', 'test/video'], fu
       return;
     }
 
-    elem.setAttribute('autoplay','');
+    elem.setAttribute('autoplay', '');
     elem.style.cssText = 'display:none';
     docElement.appendChild(elem);
     // wait for the next tick to add the listener, otherwise the element may

--- a/feature-detects/video/loop.js
+++ b/feature-detects/video/loop.js
@@ -5,6 +5,6 @@
   "tags": ["video", "media"]
 }
 !*/
-define(['Modernizr', 'createElement'], function( Modernizr, createElement ) {
+define(['Modernizr', 'createElement'], function(Modernizr, createElement) {
   Modernizr.addTest('videoloop', 'loop' in createElement('video'));
 });

--- a/feature-detects/video/preload.js
+++ b/feature-detects/video/preload.js
@@ -5,6 +5,6 @@
   "tags": ["video", "media"]
 }
 !*/
-define(['Modernizr', 'createElement'], function( Modernizr, createElement ) {
+define(['Modernizr', 'createElement'], function(Modernizr, createElement) {
   Modernizr.addTest('videopreload', 'preload' in createElement('video'));
 });

--- a/feature-detects/vml.js
+++ b/feature-detects/vml.js
@@ -17,7 +17,7 @@
 /* DOC
 Detects support for VML.
 */
-define(['Modernizr', 'createElement', 'isSVG'], function( Modernizr, createElement, isSVG) {
+define(['Modernizr', 'createElement', 'isSVG'], function(Modernizr, createElement, isSVG) {
   Modernizr.addTest('vml', function() {
     var containerDiv = createElement('div');
     var supports = false;
@@ -27,7 +27,7 @@ define(['Modernizr', 'createElement', 'isSVG'], function( Modernizr, createEleme
       containerDiv.innerHTML = '<v:shape id="vml_flag1" adj="1" />';
       shape = containerDiv.firstChild;
       shape.style.behavior = 'url(#default#VML)';
-      supports = shape ? typeof shape.adj == 'object': true;
+      supports = shape ? typeof shape.adj == 'object' : true;
     }
 
     return supports;

--- a/feature-detects/web-intents.js
+++ b/feature-detects/web-intents.js
@@ -17,6 +17,6 @@ Detects native support for the Web Intents APIs for service discovery and inter-
 Chrome added support for this in v19, but [removed it again in v24](http://lists.w3.org/Archives/Public/public-web-intents/2012Nov/0000.html) because of "a number of areas for
 development in both the API and specific user experience in Chrome". No other browsers currently support it, however a [JavaScript shim](http://webintents.org/#javascriptshim) is available.
 */
-define(['Modernizr', 'prefixed'], function( Modernizr, prefixed ) {
+define(['Modernizr', 'prefixed'], function(Modernizr, prefixed) {
   Modernizr.addTest('webintents', !!prefixed('startActivity', navigator));
 });

--- a/feature-detects/webanimations.js
+++ b/feature-detects/webanimations.js
@@ -13,6 +13,6 @@
 /* DOC
 Detects support for the Web Animation API, a way to create css animations in js
 */
-define(['Modernizr', 'createElement'], function( Modernizr, createElement ) {
+define(['Modernizr', 'createElement'], function(Modernizr, createElement) {
   Modernizr.addTest('webanimations', 'animate' in createElement('div'));
 });

--- a/feature-detects/webgl.js
+++ b/feature-detects/webgl.js
@@ -7,7 +7,7 @@
   "polyfills": ["jebgl", "cwebgl", "iewebgl"]
 }
 !*/
-define(['Modernizr', 'createElement'], function( Modernizr, createElement ) {
+define(['Modernizr', 'createElement'], function(Modernizr, createElement) {
   Modernizr.addTest('webgl', function() {
     var canvas = createElement('canvas');
     var supports = 'probablySupportsContext' in canvas ? 'probablySupportsContext' :  'supportsContext';

--- a/feature-detects/webgl/extensions.js
+++ b/feature-detects/webgl/extensions.js
@@ -25,7 +25,7 @@ if ('OES_vertex_array_object' in Modernizr.webglextensions) {
 }
 ```
 */
-define(['Modernizr', 'createElement', 'test/webgl'], function( Modernizr, createElement ) {
+define(['Modernizr', 'createElement', 'test/webgl'], function(Modernizr, createElement) {
   // based on code from ilmari heikkinen
   // code.google.com/p/graphics-detect/source/browse/js/detect.js
 
@@ -57,7 +57,7 @@ define(['Modernizr', 'createElement', 'test/webgl'], function( Modernizr, create
       Modernizr.webglextensions = new Boolean(true);
     }
 
-    for (var i = -1, len = exts.length; ++i < len; ){
+    for (var i = -1, len = exts.length; ++i < len;) {
       Modernizr.webglextensions[exts[i]] = true;
     }
 

--- a/feature-detects/webrtc/datachannel.js
+++ b/feature-detects/webrtc/datachannel.js
@@ -11,7 +11,7 @@
 /* DOC
 Detect for the RTCDataChannel API that allows for transfer data directly from one peer to another
 */
-define(['Modernizr', 'prefixed', 'domPrefixes', 'test/webrtc/peerconnection'], function( Modernizr, prefixed, domPrefixes ) {
+define(['Modernizr', 'prefixed', 'domPrefixes', 'test/webrtc/peerconnection'], function(Modernizr, prefixed, domPrefixes) {
 
   Modernizr.addTest('datachannel', function() {
     if (!Modernizr.peerconnection) {
@@ -22,7 +22,7 @@ define(['Modernizr', 'prefixed', 'domPrefixes', 'test/webrtc/peerconnection'], f
 
       if (peerConnectionConstructor) {
         var peerConnection = new peerConnectionConstructor({
-          'iceServers': [{ 'url': 'stun:0' }]
+          'iceServers': [{'url': 'stun:0'}]
         });
 
         return 'createDataChannel' in peerConnection;

--- a/feature-detects/webrtc/getusermedia.js
+++ b/feature-detects/webrtc/getusermedia.js
@@ -12,6 +12,6 @@
   "polyfills": ["getusermedia"]
 }
 !*/
-define(['Modernizr', 'prefixed'], function( Modernizr, prefixed ) {
+define(['Modernizr', 'prefixed'], function(Modernizr, prefixed) {
   Modernizr.addTest('getusermedia', !!prefixed('getUserMedia', navigator));
 });

--- a/feature-detects/webrtc/peerconnection.js
+++ b/feature-detects/webrtc/peerconnection.js
@@ -10,6 +10,6 @@
   }]
 }
 !*/
-define(['Modernizr', 'prefixed'], function( Modernizr, prefixed ) {
+define(['Modernizr', 'prefixed'], function(Modernizr, prefixed) {
   Modernizr.addTest('peerconnection', !!prefixed('RTCPeerConnection', window));
 });

--- a/feature-detects/websockets.js
+++ b/feature-detects/websockets.js
@@ -24,6 +24,6 @@
   ]
 }
 !*/
-define(['Modernizr'], function( Modernizr ) {
+define(['Modernizr'], function(Modernizr) {
   Modernizr.addTest('websockets', 'WebSocket' in window && window.WebSocket.CLOSING === 2);
 });

--- a/feature-detects/websockets/binary.js
+++ b/feature-detects/websockets/binary.js
@@ -6,22 +6,22 @@
   "builderAliases": ["websockets_binary"]
 }
 !*/
-define(['Modernizr'], function( Modernizr ) {
+define(['Modernizr'], function(Modernizr) {
   // binaryType is truthy if there is support.. returns "blob" in new-ish chrome.
   // plus.google.com/115535723976198353696/posts/ERN6zYozENV
   // github.com/Modernizr/Modernizr/issues/370
 
   Modernizr.addTest('websocketsbinary', function() {
-    var protocol = 'https:'==location.protocol?'wss':'ws',
+    var protocol = 'https:' == location.protocol ? 'wss' : 'ws',
     protoBin;
 
-    if('WebSocket' in window) {
-      if( protoBin = 'binaryType' in WebSocket.prototype ) {
+    if ('WebSocket' in window) {
+      if (protoBin = 'binaryType' in WebSocket.prototype) {
         return protoBin;
       }
       try {
-        return !!(new WebSocket(protocol+'://.').binaryType);
-      } catch (e){}
+        return !!(new WebSocket(protocol + '://.').binaryType);
+      } catch (e) {}
     }
 
     return false;

--- a/feature-detects/window/framed.js
+++ b/feature-detects/window/framed.js
@@ -9,7 +9,7 @@
 /* DOC
 Tests if page is iframed.
 */
-define(['Modernizr'], function( Modernizr ) {
+define(['Modernizr'], function(Modernizr) {
   // github.com/Modernizr/Modernizr/issues/242
 
   Modernizr.addTest('framed', window.location != top.location);

--- a/feature-detects/window/matchmedia.js
+++ b/feature-detects/window/matchmedia.js
@@ -20,6 +20,6 @@
 Detects support for matchMedia.
 
 */
-define(['Modernizr', 'prefixed'], function( Modernizr, prefixed ) {
+define(['Modernizr', 'prefixed'], function(Modernizr, prefixed) {
   Modernizr.addTest('matchmedia', !!prefixed('matchMedia', window));
 });

--- a/feature-detects/workers/blobworkers.js
+++ b/feature-detects/workers/blobworkers.js
@@ -16,7 +16,7 @@
 /* DOC
 Detects support for creating Web Workers from Blob URIs.
 */
-define(['Modernizr', 'addTest'], function( Modernizr, addTest ) {
+define(['Modernizr', 'addTest'], function(Modernizr, addTest) {
   Modernizr.addAsyncTest(function() {
     try {
       // we're avoiding using Modernizr._domPrefixes as the prefix capitalization on
@@ -37,7 +37,7 @@ define(['Modernizr', 'addTest'], function( Modernizr, addTest ) {
 
       try {
         blob = new Blob([scriptText], {type:'text/javascript'});
-      } catch(e) {
+      } catch (e) {
         // we'll fall back to the deprecated BlobBuilder
       }
       if (!blob) {

--- a/feature-detects/workers/dataworkers.js
+++ b/feature-detects/workers/dataworkers.js
@@ -16,7 +16,7 @@
 /* DOC
 Detects support for creating Web Workers from Data URIs.
 */
-define(['Modernizr', 'addTest'], function( Modernizr, addTest ) {
+define(['Modernizr', 'addTest'], function(Modernizr, addTest) {
   Modernizr.addAsyncTest(function() {
     try {
       var data    = 'Modernizr',
@@ -40,7 +40,7 @@ define(['Modernizr', 'addTest'], function( Modernizr, addTest ) {
 
       worker.postMessage(data);
     } catch (e) {
-      setTimeout(function () {
+      setTimeout(function() {
         addTest('dataworkers', false);
       }, 0);
     }

--- a/feature-detects/workers/sharedworkers.js
+++ b/feature-detects/workers/sharedworkers.js
@@ -14,6 +14,6 @@
 /* DOC
 Detects support for the `SharedWorker` API from the Web Workers spec.
 */
-define(['Modernizr'], function( Modernizr ) {
+define(['Modernizr'], function(Modernizr) {
   Modernizr.addTest('sharedworkers', 'SharedWorker' in window);
 });

--- a/feature-detects/workers/transferables.js
+++ b/feature-detects/workers/transferables.js
@@ -14,7 +14,7 @@
 /* DOC
 Detects whether web workers can use `transferables` objects.
 */
-define(['Modernizr', 'addTest', 'test/blob', 'test/url/bloburls', 'test/workers/webworkers', 'test/typed-arrays'], function( Modernizr, addTest ) {
+define(['Modernizr', 'addTest', 'test/blob', 'test/url/bloburls', 'test/workers/webworkers', 'test/typed-arrays'], function(Modernizr, addTest) {
   Modernizr.addAsyncTest(function() {
     var prerequisites = !!(Modernizr.blobconstructor &&
                            Modernizr.bloburls &&

--- a/feature-detects/workers/webworkers.js
+++ b/feature-detects/workers/webworkers.js
@@ -20,6 +20,6 @@
 /* DOC
 Detects support for the basic `Worker` API from the Web Workers spec. Web Workers provide a simple means for web content to run scripts in background threads.
 */
-define(['Modernizr'], function( Modernizr ) {
+define(['Modernizr'], function(Modernizr) {
   Modernizr.addTest('webworkers', 'Worker' in window);
 });

--- a/lib/build-hash.js
+++ b/lib/build-hash.js
@@ -2,7 +2,7 @@
 define(['lodash', 'metadata'], function(_, metadata) {
 
   function getDetectObjByAmdPath(amdPath) {
-    return _.find(metadata, function (detect) {
+    return _.find(metadata, function(detect) {
       return detect.amdPath == amdPath || detect.amdPath == 'test/' + amdPath;
     });
   }
@@ -14,7 +14,7 @@ define(['lodash', 'metadata'], function(_, metadata) {
     var dontmin = !config.minify;
 
     // Config uses amdPaths, but build hash uses property names
-    var props = _.map(config['feature-detects'], function (amdPath) {
+    var props = _.map(config['feature-detects'], function(amdPath) {
       var detect = getDetectObjByAmdPath(amdPath);
       var property = detect && detect.property;
       property = _.isArray(property) ?
@@ -26,12 +26,12 @@ define(['lodash', 'metadata'], function(_, metadata) {
     // Config uses amdPaths, but the option's just use their names.
     // A few of the values have to be massaged in order to match
     // the `value`
-    var opts = _.map(config.options, function (opt) {
+    var opts = _.map(config.options, function(opt) {
       if (opt == 'setClasses') {
         return 'cssclasses';
       }
       if (opt.indexOf('html5') === 0) {
-        opt = opt.replace('html5','');
+        opt = opt.replace('html5', '');
       }
       return opt.toLowerCase();
     });
@@ -41,9 +41,9 @@ define(['lodash', 'metadata'], function(_, metadata) {
 
     // Options are AMD paths in the config, but need to be converted to
     var buildHash = '#-' + sortedProps.concat(sortedOpts).join('-') +
-        ( dontmin ? '-dontmin' : '' ) +
-        ( (config.classPrefix) ?
-          '-cssclassprefix:' + config.classPrefix : '' );
+        (dontmin ? '-dontmin' : '') +
+        ((config.classPrefix) ?
+          '-cssclassprefix:' + config.classPrefix : '');
 
     return buildHash;
   };

--- a/lib/build.js
+++ b/lib/build.js
@@ -29,7 +29,7 @@ var requireConfig = {
     start: '\n;(function(window, document, undefined){',
     end: '})(window, document);'
   },
-  onBuildWrite: function (id, path, contents) {
+  onBuildWrite: function(id, path, contents) {
     if (this.optimize === 'uglify2') {
       // strip out documentation comments
       contents = contents.replace(/\/\*\![\s\S]*\!\*\//m, '');
@@ -39,15 +39,15 @@ var requireConfig = {
       // remove AMD ceremony for use without require.js or almond.js
       contents = contents.replace(/define\(.*?\{/, '');
 
-      contents = contents.replace(/\}\);\s*?$/,'');
+      contents = contents.replace(/\}\);\s*?$/, '');
 
-      if ( !contents.match(/Modernizr\.add(Async)?Test\(/) ) {
+      if (!contents.match(/Modernizr\.add(Async)?Test\(/)) {
         // remove last return statement and trailing })
-        contents = contents.replace(/return.*[^return]*$/,'');
+        contents = contents.replace(/return.*[^return]*$/, '');
       }
     } else if ((/require\([^\{]*?\{/).test(contents)) {
       contents = contents.replace(/require[^\{]+\{/, '');
-      contents = contents.replace(/\}\);\s*$/,'');
+      contents = contents.replace(/\}\);\s*$/, '');
     }
 
     return contents;
@@ -57,7 +57,7 @@ var requireConfig = {
 function build(generate, generateBanner, pkg) {
   return function build(config, cb) {
     config = config || {};
-    cb = cb || function noop(){};
+    cb = cb || function noop() {};
     var banner;
 
     requireConfig.rawText = {
@@ -80,7 +80,7 @@ function build(generate, generateBanner, pkg) {
       requireConfig.optimize = 'none';
     }
 
-    requireConfig.out = function (output) {
+    requireConfig.out = function(output) {
       output = banner + output;
 
       // Remove `define('modernizr-init' ...)` and `define('modernizr-build' ...)`
@@ -88,7 +88,7 @@ function build(generate, generateBanner, pkg) {
       output = output.replace(/__VERSION__/g, pkg.version);
 
       // Hack the prefix into place. Anything is way too big for something so small.
-      if ( config && config.classPrefix ) {
+      if (config && config.classPrefix) {
         output = output.replace(/(classPrefix'?\s?:\s?)['""']{2}(,)/, '$1"' + config.classPrefix.replace(/"/g, '\\"') + '"$2');
       }
 
@@ -122,9 +122,9 @@ if (inBrowser) {
   if (self._modernizrMetadata) {
     requirejs.define('metadata', [], function() {return self._modernizrMetadata;});
   } else {
-    requirejs.define('metadata', [ 'json!' + metadataUrl ], function(pkg) {return pkg;});
+    requirejs.define('metadata', ['json!' + metadataUrl], function(pkg) {return pkg;});
   }
-  requirejs.define('package', [ 'json!' + packageUrl ], function(pkg) {return pkg;});
+  requirejs.define('package', ['json!' + packageUrl], function(pkg) {return pkg;});
 } else {
   var requirejs = require('requirejs');
   var metadata = require('./metadata')();

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -5,18 +5,18 @@ module.exports = {
   metadata: require('./metadata'),
   options: function() {
     return [
-      {'name':'Modernizr.addTest()','property':'addTest'},
-      {'name':'Modernizr.atRule()','property':'atRule'},
-      {'name':'Modernizr.hasEvent()','property':'hasEvent'},
-      {'name':'Modernizr.mq()','property':'mq'},
-      {'name':'Modernizr.prefixed()','property':'prefixed'},
-      {'name':'Modernizr._domPrefixes','property':'domPrefixes'},
-      {'name':'Modernizr._prefixes','property':'prefixes'},
-      {'name':'Modernizr.prefixedCSS()','property':'prefixedCSS'},
-      {'name':'Modernizr.testAllProps()','property':'testAllProps'},
-      {'name':'Modernizr.testProp()','property':'testProp'},
-      {'name':'Modernizr.testStyles()','property':'testStyles'},
-      {'name':'html5printshiv','property':'html5printshiv'},
-      {'name':'html5shiv','property':'html5shiv'}
+      {'name':'Modernizr.addTest()', 'property':'addTest'},
+      {'name':'Modernizr.atRule()', 'property':'atRule'},
+      {'name':'Modernizr.hasEvent()', 'property':'hasEvent'},
+      {'name':'Modernizr.mq()', 'property':'mq'},
+      {'name':'Modernizr.prefixed()', 'property':'prefixed'},
+      {'name':'Modernizr._domPrefixes', 'property':'domPrefixes'},
+      {'name':'Modernizr._prefixes', 'property':'prefixes'},
+      {'name':'Modernizr.prefixedCSS()', 'property':'prefixedCSS'},
+      {'name':'Modernizr.testAllProps()', 'property':'testAllProps'},
+      {'name':'Modernizr.testProp()', 'property':'testProp'},
+      {'name':'Modernizr.testStyles()', 'property':'testStyles'},
+      {'name':'html5printshiv', 'property':'html5printshiv'},
+      {'name':'html5shiv', 'property':'html5shiv'}
     ];}
 };

--- a/lib/generate-banner.js
+++ b/lib/generate-banner.js
@@ -1,7 +1,7 @@
 /*global location, define*/
 define(['lodash', 'package', 'lib/build-hash'], function(_, pkg, buildHash) {
   var domain = 'modernizr.com';
-  if ( typeof location !== 'undefined' && 'host' in location ) {
+  if (typeof location !== 'undefined' && 'host' in location) {
     domain = location.host;
   }
 

--- a/lib/metadata.js
+++ b/lib/metadata.js
@@ -6,9 +6,9 @@ var viewRoot = fs.realpathSync(__dirname + '/../feature-detects');
 
 function metadata(cb) {
   var tests = [];
-  file.walkSync(viewRoot, function (start, dirs, files) {
-    files.forEach(function (file) {
-      if ( file === '.DS_Store') {
+  file.walkSync(viewRoot, function(start, dirs, files) {
+    files.forEach(function(file) {
+      if (file === '.DS_Store') {
         return;
       }
       var test = fs.readFileSync(start + '/' + file, 'utf8');
@@ -25,7 +25,7 @@ function metadata(cb) {
       if (matches && matches[1]) {
         try {
           metadata = JSON.parse(matches[1]);
-        } catch(e) {
+        } catch (e) {
           throw new Error('Error Parsing Metadata: ' + file + '\nInput: `' + matches[1] + '`');
         }
       }
@@ -50,7 +50,7 @@ function metadata(cb) {
         } catch (e) {
           throw new Error('Couldn\'t parse dependencies for `' + file + '`:\n`' + depMatches[1] + '\n`');
         }
-        matchedDeps.forEach(function( dep ) {
+        matchedDeps.forEach(function(dep) {
           if (dep === 'Modernizr') {
             return;
           }
@@ -72,7 +72,7 @@ function metadata(cb) {
       var pfs = [];
       if (metadata.polyfills && metadata.polyfills.length) {
         metadata.polyfills.forEach(function(polyname) {
-          if ( polyfills[polyname] ) {
+          if (polyfills[polyname]) {
             pfs.push(polyfills[polyname]);
           }
           else {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "grunt-coveralls": "^1.0.0",
     "grunt-env": "^0.4.2",
     "grunt-istanbul": "^0.4.0",
+    "grunt-jscs": "^1.6.0",
     "grunt-mocha": "^0.4.11",
     "grunt-mocha-test": "^0.12.7",
     "grunt-saucelabs": "^8.6.0",

--- a/src/Modernizr.js
+++ b/src/Modernizr.js
@@ -1,8 +1,8 @@
-define(['ModernizrProto'], function( ModernizrProto ) {
+define(['ModernizrProto'], function(ModernizrProto) {
   // Fake some of Object.create
   // so we can force non test results
   // to be non "own" properties.
-  var Modernizr = function(){};
+  var Modernizr = function() {};
   Modernizr.prototype = ModernizrProto;
 
   // Leak modernizr globally when you `require` it

--- a/src/ModernizrProto.js
+++ b/src/ModernizrProto.js
@@ -1,4 +1,4 @@
-define(['tests'], function ( tests ) {
+define(['tests'], function(tests) {
   var ModernizrProto = {
     // The current version, dummy
     _version: '__VERSION__',
@@ -16,7 +16,7 @@ define(['tests'], function ( tests ) {
     _q: [],
 
     // Stub these for people who are listening
-    on: function( test, cb ) {
+    on: function(test, cb) {
       // I don't really think people should do this, but we can
       // safe guard it a bit.
       // -- NOTE:: this gets WAY overridden in src/addTest for
@@ -30,11 +30,11 @@ define(['tests'], function ( tests ) {
       }, 0);
     },
 
-    addTest: function( name, fn, options ) {
-      tests.push({name : name, fn : fn, options : options });
+    addTest: function(name, fn, options) {
+      tests.push({name : name, fn : fn, options : options});
     },
 
-    addAsyncTest: function (fn) {
+    addAsyncTest: function(fn) {
       tests.push({name : null, fn : fn});
     }
   };

--- a/src/addTest.js
+++ b/src/addTest.js
@@ -1,4 +1,4 @@
-define(['ModernizrProto', 'Modernizr', 'hasOwnProp', 'setClasses'], function( ModernizrProto, Modernizr, hasOwnProp, setClasses ) {
+define(['ModernizrProto', 'Modernizr', 'hasOwnProp', 'setClasses'], function(ModernizrProto, Modernizr, hasOwnProp, setClasses) {
   // As far as I can think of, we shouldn't need or
   // allow 'on' for non-async tests, and you can't do
   // async tests without this 'addTest' module.
@@ -8,7 +8,7 @@ define(['ModernizrProto', 'Modernizr', 'hasOwnProp', 'setClasses'], function( Mo
 
   // 'addTest' implies a test after the core runloop,
   // So we'll add in the events
-  ModernizrProto.on = function( test, cb ) {
+  ModernizrProto.on = function(test, cb) {
     // Create the list of listeners if it doesn't exist
     if (!this._l[test]) {
       this._l[test] = [];
@@ -26,7 +26,7 @@ define(['ModernizrProto', 'Modernizr', 'hasOwnProp', 'setClasses'], function( Mo
     }
   };
 
-  ModernizrProto._trigger = function( test, res ) {
+  ModernizrProto._trigger = function(test, res) {
     if (!this._l[test]) {
       return;
     }
@@ -40,7 +40,7 @@ define(['ModernizrProto', 'Modernizr', 'hasOwnProp', 'setClasses'], function( Mo
         cb = cbs[i];
         cb(res);
       }
-    },0);
+    }, 0);
 
     // Don't trigger these again
     delete this._l[test];
@@ -54,11 +54,11 @@ define(['ModernizrProto', 'Modernizr', 'hasOwnProp', 'setClasses'], function( Mo
    * @param feature - String naming the feature
    * @param test - Function returning true if feature is supported, false if not
    */
-  function addTest( feature, test ) {
-    if ( typeof feature == 'object' ) {
-      for ( var key in feature ) {
-        if ( hasOwnProp( feature, key ) ) {
-          addTest( key, feature[ key ] );
+  function addTest(feature, test) {
+    if (typeof feature == 'object') {
+      for (var key in feature) {
+        if (hasOwnProp(feature, key)) {
+          addTest(key, feature[ key ]);
         }
       }
     } else {
@@ -72,7 +72,7 @@ define(['ModernizrProto', 'Modernizr', 'hasOwnProp', 'setClasses'], function( Mo
         last = last[featureNameSplit[1]];
       }
 
-      if ( typeof last != 'undefined' ) {
+      if (typeof last != 'undefined') {
         // we're going to quit if you're trying to overwrite an existing test
         // if we were to allow it, we'd do this:
         //   var re = new RegExp("\\b(no-)?" + feature + "\\b");

--- a/src/atRule.js
+++ b/src/atRule.js
@@ -1,4 +1,4 @@
-define(['ModernizrProto', 'cssomPrefixes'], function( ModernizrProto, prefixes ) {
+define(['ModernizrProto', 'cssomPrefixes'], function(ModernizrProto, prefixes) {
   /**
    * atRule returns a given CSS property at-rule (eg @keyframes), possibly in
    * some prefixed form, or false, in the case of an unsupported rule
@@ -20,16 +20,16 @@ define(['ModernizrProto', 'cssomPrefixes'], function( ModernizrProto, prefixes )
     }
 
     // remove literal @ from beginning of provided property
-    prop = prop.replace(/^@/,'');
+    prop = prop.replace(/^@/, '');
 
     // CSSRules use underscores instead of dashes
-    rule = prop.replace(/-/g,'_').toUpperCase() + '_RULE';
+    rule = prop.replace(/-/g, '_').toUpperCase() + '_RULE';
 
     if (rule in cssrule) {
       return '@' + prop;
     }
 
-    for ( var i = 0; i < length; i++ ) {
+    for (var i = 0; i < length; i++) {
       // prefixes gives us something like -o-, and we want O_
       var prefix = prefixes[i];
       var thisRule = prefix.toUpperCase() + '_' + rule;

--- a/src/contains.js
+++ b/src/contains.js
@@ -2,7 +2,7 @@ define(function() {
   /**
    * contains returns a boolean for if substr is found within str.
    */
-  function contains( str, substr ) {
+  function contains(str, substr) {
     return !!~('' + str).indexOf(substr);
   }
 

--- a/src/cssToDOM.js
+++ b/src/cssToDOM.js
@@ -1,7 +1,7 @@
 define(function() {
   // Helper function for converting kebab-case to camelCase,
   // e.g. box-sizing -> boxSizing
-  function cssToDOM( name ) {
+  function cssToDOM(name) {
     return name.replace(/([a-z])-([a-z])/g, function(str, m1, m2) {
       return m1 + m2.toUpperCase();
     }).replace(/^-/, '');

--- a/src/cssomPrefixes.js
+++ b/src/cssomPrefixes.js
@@ -1,4 +1,4 @@
-define(['ModernizrProto', 'omPrefixes'], function( ModernizrProto, omPrefixes ) {
+define(['ModernizrProto', 'omPrefixes'], function(ModernizrProto, omPrefixes) {
   var cssomPrefixes = (ModernizrProto._config.usePrefixes ? omPrefixes.split(' ') : []);
   ModernizrProto._cssomPrefixes = cssomPrefixes;
   return cssomPrefixes;

--- a/src/domPrefixes.js
+++ b/src/domPrefixes.js
@@ -1,4 +1,4 @@
-define(['ModernizrProto', 'omPrefixes'], function( ModernizrProto, omPrefixes ) {
+define(['ModernizrProto', 'omPrefixes'], function(ModernizrProto, omPrefixes) {
   var domPrefixes = (ModernizrProto._config.usePrefixes ? omPrefixes.toLowerCase().split(' ') : []);
   ModernizrProto._domPrefixes = domPrefixes;
   return domPrefixes;

--- a/src/domToCSS.js
+++ b/src/domToCSS.js
@@ -1,7 +1,7 @@
 define(function() {
   // Helper function for converting camelCase to kebab-case,
   // e.g. boxSizing -> box-sizing
-  function domToCSS( name ) {
+  function domToCSS(name) {
     return name.replace(/([A-Z])/g, function(str, m1) {
       return '-' + m1.toLowerCase();
     }).replace(/^ms-/, '-ms-');

--- a/src/generate.js
+++ b/src/generate.js
@@ -1,5 +1,5 @@
 define(['lodash'], function(_) {
-  return function( config ) {
+  return function(config) {
     // Set some defaults
     if (!config) {
       config = {};
@@ -21,17 +21,17 @@ define(['lodash'], function(_) {
     }
 
     // Only allow one shiv at a time
-    if  (_.includes(config.options, 'html5printshiv')) {
+    if (_.includes(config.options, 'html5printshiv')) {
       config.options = _.without(config.options, 'html5shiv');
     }
 
     // Load in the rest of the options (they dont return values, so they aren't declared
-    _.forEach(config.options, function (option) {
+    _.forEach(config.options, function(option) {
       output += ', "' + option + '"';
     });
 
     // Load in all the detects
-    _.forEach(config['feature-detects'], function (detect) {
+    _.forEach(config['feature-detects'], function(detect) {
       detect = detect.indexOf('test/') === 0 ? detect : 'test/' + detect;
       output += ', "' + detect + '"';
     });

--- a/src/getBody.js
+++ b/src/getBody.js
@@ -1,9 +1,9 @@
-define(['createElement', 'isSVG'], function( createElement, isSVG) {
+define(['createElement', 'isSVG'], function(createElement, isSVG) {
   function getBody() {
     // After page load injecting a fake body doesn't work so check if body exists
     var body = document.body;
 
-    if(!body) {
+    if (!body) {
       // Can't use the real body create a fake one.
       body = createElement(isSVG ? 'svg' : 'body');
       body.fake = true;

--- a/src/hasEvent.js
+++ b/src/hasEvent.js
@@ -1,4 +1,4 @@
-define(['ModernizrProto', 'isEventSupported'], function( ModernizrProto, isEventSupported ) {
+define(['ModernizrProto', 'isEventSupported'], function(ModernizrProto, isEventSupported) {
   // Modernizr.hasEvent() detects support for a given event, with an optional element to test on
   // Modernizr.hasEvent('gesturestart', elem)
   var hasEvent = ModernizrProto.hasEvent = isEventSupported;

--- a/src/hasOwnProp.js
+++ b/src/hasOwnProp.js
@@ -1,4 +1,4 @@
-define(['is'], function( is ) {
+define(['is'], function(is) {
   // hasOwnProperty shim by kangax needed for Safari 2.0 support
   var hasOwnProp;
 
@@ -7,13 +7,13 @@ define(['is'], function( is ) {
     /* istanbul ignore else */
     /* we have no way of testing IE 5.5 or safari 2,
      * so just assume the else gets hit */
-    if ( !is(_hasOwnProperty, 'undefined') && !is(_hasOwnProperty.call, 'undefined') ) {
-      hasOwnProp = function (object, property) {
+    if (!is(_hasOwnProperty, 'undefined') && !is(_hasOwnProperty.call, 'undefined')) {
+      hasOwnProp = function(object, property) {
         return _hasOwnProperty.call(object, property);
       };
     }
     else {
-      hasOwnProp = function (object, property) { /* yes, this can give false positives/negatives, but most of the time we don't care about those */
+      hasOwnProp = function(object, property) { /* yes, this can give false positives/negatives, but most of the time we don't care about those */
         return ((property in object) && is(object.constructor.prototype[property], 'undefined'));
       };
     }

--- a/src/injectElementWithStyles.js
+++ b/src/injectElementWithStyles.js
@@ -1,6 +1,6 @@
-define(['ModernizrProto', 'docElement', 'createElement', 'getBody'], function( ModernizrProto, docElement, createElement, getBody ) {
+define(['ModernizrProto', 'docElement', 'createElement', 'getBody'], function(ModernizrProto, docElement, createElement, getBody) {
   // Inject element with style element and some CSS rules
-  function injectElementWithStyles( rule, callback, nodes, testnames ) {
+  function injectElementWithStyles(rule, callback, nodes, testnames) {
     var mod = 'modernizr';
     var style;
     var ret;
@@ -9,10 +9,10 @@ define(['ModernizrProto', 'docElement', 'createElement', 'getBody'], function( M
     var div = createElement('div');
     var body = getBody();
 
-    if ( parseInt(nodes, 10) ) {
+    if (parseInt(nodes, 10)) {
       // In order not to give false positives we create a node for each test
       // This also allows the method to scale for unspecified uses
-      while ( nodes-- ) {
+      while (nodes--) {
         node = createElement('div');
         node.id = testnames ? testnames[nodes] : mod + (nodes + 1);
         div.appendChild(node);
@@ -35,7 +35,7 @@ define(['ModernizrProto', 'docElement', 'createElement', 'getBody'], function( M
     }
     div.id = mod;
 
-    if ( body.fake ) {
+    if (body.fake) {
       //avoid crashing IE8, if background image is used
       body.style.background = '';
       //Safari 5.13/5.1.4 OSX stops loading if ::-webkit-scrollbar is used and scrollbars are visible
@@ -47,7 +47,7 @@ define(['ModernizrProto', 'docElement', 'createElement', 'getBody'], function( M
 
     ret = callback(div, rule);
     // If this is done after page load we don't want to remove the body so check if body exists
-    if ( body.fake ) {
+    if (body.fake) {
       body.parentNode.removeChild(body);
       docElement.style.overflow = docOverflow;
       // Trigger layout so kinetic scrolling isn't disabled in iOS6+

--- a/src/is.js
+++ b/src/is.js
@@ -2,7 +2,7 @@ define(function() {
   /**
    * is returns a boolean for if typeof obj is exactly type.
    */
-  function is( obj, type ) {
+  function is(obj, type) {
     return typeof obj === type;
   }
   return is;

--- a/src/isEventSupported.js
+++ b/src/isEventSupported.js
@@ -1,4 +1,4 @@
-define(['ModernizrProto', 'createElement'], function( ModernizrProto, createElement ) {
+define(['ModernizrProto', 'createElement'], function(ModernizrProto, createElement) {
   // isEventSupported determines if the given element supports the given event
   // kangax.github.com/iseventsupported/
   // github.com/Modernizr/Modernizr/pull/636
@@ -6,7 +6,7 @@ define(['ModernizrProto', 'createElement'], function( ModernizrProto, createElem
   // Known incorrects:
   //   Modernizr.hasEvent("webkitTransitionEnd", elem) // false negative
   //   Modernizr.hasEvent("textInput") // in Webkit. github.com/Modernizr/Modernizr/issues/333
-  var isEventSupported = (function (undefined) {
+  var isEventSupported = (function(undefined) {
 
     // Detect whether event support can be detected via `in`. Test on a DOM element
     // using the "blur" event b/c it should always exist. bit.ly/event-detection
@@ -17,11 +17,11 @@ define(['ModernizrProto', 'createElement'], function( ModernizrProto, createElem
      * @param  {(Object|string|*)=} element    is the element|document|window|tagName to test on
      * @return {boolean}
      */
-    function isEventSupportedInner( eventName, element ) {
+    function isEventSupportedInner(eventName, element) {
 
       var isSupported;
-      if ( !eventName ) { return false; }
-      if ( !element || typeof element === 'string' ) {
+      if (!eventName) { return false; }
+      if (!element || typeof element === 'string') {
         element = createElement(element || 'div');
       }
 
@@ -32,8 +32,8 @@ define(['ModernizrProto', 'createElement'], function( ModernizrProto, createElem
       isSupported = eventName in element;
 
       // Fallback technique for old Firefox - bit.ly/event-detection
-      if ( !isSupported && needsFallback ) {
-        if ( !element.setAttribute ) {
+      if (!isSupported && needsFallback) {
+        if (!element.setAttribute) {
           // Switch to generic element if it lacks `setAttribute`.
           // It could be the `document`, `window`, or something else.
           element = createElement('div');
@@ -42,7 +42,7 @@ define(['ModernizrProto', 'createElement'], function( ModernizrProto, createElem
         element.setAttribute(eventName, '');
         isSupported = typeof element[eventName] === 'function';
 
-        if ( element[eventName] !== undefined ) {
+        if (element[eventName] !== undefined) {
           // If property was created, "remove it" by setting value to `undefined`.
           element[eventName] = undefined;
         }

--- a/src/isSVG.js
+++ b/src/isSVG.js
@@ -1,4 +1,4 @@
-define(['docElement'], function( docElement ) {
+define(['docElement'], function(docElement) {
   var isSVG = docElement.nodeName.toLowerCase() === 'svg';
   return isSVG;
 });

--- a/src/load.js
+++ b/src/load.js
@@ -1,4 +1,4 @@
-define(['ModernizrProto'], function( ModernizrProto ) {
+define(['ModernizrProto'], function(ModernizrProto) {
 
   var err = function() {};
   var warn = function() {};
@@ -6,19 +6,19 @@ define(['ModernizrProto'], function( ModernizrProto ) {
   if (window.console) {
     err = function() {
       var method = console.error ? 'error' : 'log';
-      window.console[method].apply( window.console, Array.prototype.slice.call(arguments) );
+      window.console[method].apply(window.console, Array.prototype.slice.call(arguments));
     };
 
     warn = function() {
       var method = console.warn ? 'warn' : 'log';
-      window.console[method].apply( window.console, Array.prototype.slice.call(arguments) );
+      window.console[method].apply(window.console, Array.prototype.slice.call(arguments));
     };
   }
 
   ModernizrProto.load = function() {
     if ('yepnope' in window) {
       warn('yepnope.js (aka Modernizr.load) is no longer included as part of Modernizr. yepnope appears to be available on the page, so we’ll use it to handle this call to Modernizr.load, but please update your code to use yepnope directly.\n See http://github.com/Modernizr/Modernizr/issues/1182 for more information.');
-      window.yepnope.apply(window, [].slice.call(arguments,0));
+      window.yepnope.apply(window, [].slice.call(arguments, 0));
     } else {
       err('yepnope.js (aka Modernizr.load) is no longer included as part of Modernizr. Get it from http://yepnopejs.com. See http://github.com/Modernizr/Modernizr/issues/1182 for more information.');
     }

--- a/src/mStyle.js
+++ b/src/mStyle.js
@@ -1,4 +1,4 @@
-define(['Modernizr', 'modElem'], function( Modernizr, modElem ) {
+define(['Modernizr', 'modElem'], function(Modernizr, modElem) {
   var mStyle = {
     style : modElem.elem.style
   };

--- a/src/modElem.js
+++ b/src/modElem.js
@@ -1,4 +1,4 @@
-define(['Modernizr', 'createElement'], function( Modernizr, createElement ) {
+define(['Modernizr', 'createElement'], function(Modernizr, createElement) {
   /**
    * Create our "modernizr" element that we do most feature tests on.
    */

--- a/src/mq.js
+++ b/src/mq.js
@@ -1,4 +1,4 @@
-define(['ModernizrProto', 'testMediaQuery'], function( ModernizrProto, testMediaQuery ) {
+define(['ModernizrProto', 'testMediaQuery'], function(ModernizrProto, testMediaQuery) {
   /** Modernizr.mq tests a given media query, live against the current state of the window
    * A few important notes:
         * If a browser does not support media queries at all (eg. oldIE) the mq() will always return false

--- a/src/nativeTestProps.js
+++ b/src/nativeTestProps.js
@@ -1,8 +1,8 @@
-define(['injectElementWithStyles', 'domToCSS'], function ( injectElementWithStyles, domToCSS ) {
+define(['injectElementWithStyles', 'domToCSS'], function(injectElementWithStyles, domToCSS) {
   // Function to allow us to use native feature detection functionality if available.
   // Accepts a list of property names and a single value
   // Returns `undefined` if native detection not available
-  function nativeTestProps ( props, value ) {
+  function nativeTestProps (props, value) {
     var i = props.length;
     // Start with the JS API: http://www.w3.org/TR/css3-conditional/#the-css-interface
     if ('CSS' in window && 'supports' in window.CSS) {
@@ -22,7 +22,7 @@ define(['injectElementWithStyles', 'domToCSS'], function ( injectElementWithStyl
         conditionText.push('(' + domToCSS(props[i]) + ':' + value + ')');
       }
       conditionText = conditionText.join(' or ');
-      return injectElementWithStyles('@supports (' + conditionText + ') { #modernizr { position: absolute; } }', function( node ) {
+      return injectElementWithStyles('@supports (' + conditionText + ') { #modernizr { position: absolute; } }', function(node) {
         return getComputedStyle(node, null).position == 'absolute';
       });
     }

--- a/src/prefixed.js
+++ b/src/prefixed.js
@@ -1,4 +1,4 @@
-define(['ModernizrProto', 'testPropsAll', 'cssToDOM', 'atRule'], function( ModernizrProto, testPropsAll, cssToDOM, atRule ) {
+define(['ModernizrProto', 'testPropsAll', 'cssToDOM', 'atRule'], function(ModernizrProto, testPropsAll, cssToDOM, atRule) {
   // Modernizr.prefixed() returns the prefixed or nonprefixed property name variant of your input
   // Modernizr.prefixed('boxSizing') // 'MozBoxSizing'
 
@@ -14,7 +14,7 @@ define(['ModernizrProto', 'testPropsAll', 'cssToDOM', 'atRule'], function( Moder
   //     },
   //     transEndEventName = transEndEventNames[ Modernizr.prefixed('transition') ];
 
-  var prefixed = ModernizrProto.prefixed = function( prop, obj, elem ) {
+  var prefixed = ModernizrProto.prefixed = function(prop, obj, elem) {
     if (prop.indexOf('@') === 0) {
       return atRule(prop);
     }

--- a/src/prefixedCSS.js
+++ b/src/prefixedCSS.js
@@ -1,4 +1,4 @@
-define(['ModernizrProto', 'prefixed', 'domToCSS'], function( ModernizrProto, prefixed, domToCSS ) {
+define(['ModernizrProto', 'prefixed', 'domToCSS'], function(ModernizrProto, prefixed, domToCSS) {
   // Modernizr.prefixedCSS() is like Modernizr.prefixed(), but returns the result in
   // hyphenated form, e.g.:
   // Modernizr.prefixedCSS('transition') // '-moz-transition'

--- a/src/prefixes.js
+++ b/src/prefixes.js
@@ -1,4 +1,4 @@
-define(['ModernizrProto'], function( ModernizrProto ) {
+define(['ModernizrProto'], function(ModernizrProto) {
   // List of property values to set for css tests. See ticket #21
   var prefixes = (ModernizrProto._config.usePrefixes ? ' -webkit- -moz- -o- -ms- '.split(' ') : []);
 

--- a/src/setClasses.js
+++ b/src/setClasses.js
@@ -1,7 +1,7 @@
-define(['Modernizr', 'docElement', 'isSVG'], function( Modernizr, docElement, isSVG) {
+define(['Modernizr', 'docElement', 'isSVG'], function(Modernizr, docElement, isSVG) {
   // Pass in an and array of class names, e.g.:
   //  ['no-webp', 'borderradius', ...]
-  function setClasses( classes ) {
+  function setClasses(classes) {
     var className = docElement.className;
     var classPrefix = Modernizr._config.classPrefix || '';
 
@@ -12,12 +12,12 @@ define(['Modernizr', 'docElement', 'isSVG'], function( Modernizr, docElement, is
     // Change `no-js` to `js` (we do this independently of the `enableClasses`
     // option)
     // Handle classPrefix on this too
-    if(Modernizr._config.enableJSClass) {
-      var reJS = new RegExp('(^|\\s)'+classPrefix+'no-js(\\s|$)');
-      className = className.replace(reJS, '$1'+classPrefix+'js$2');
+    if (Modernizr._config.enableJSClass) {
+      var reJS = new RegExp('(^|\\s)' + classPrefix + 'no-js(\\s|$)');
+      className = className.replace(reJS, '$1' + classPrefix + 'js$2');
     }
 
-    if(Modernizr._config.enableClasses) {
+    if (Modernizr._config.enableClasses) {
       // Add the new classes
       className += ' ' + classPrefix + classes.join(' ' + classPrefix);
       isSVG ? docElement.className.baseVal = className : docElement.className = className;

--- a/src/setCss.js
+++ b/src/setCss.js
@@ -1,8 +1,8 @@
-define(['Modernizr', 'mStyle'], function( Modernizr, mStyle ) {
+define(['Modernizr', 'mStyle'], function(Modernizr, mStyle) {
   /**
    * setCss applies given styles to the Modernizr DOM node.
    */
-  function setCss( str ) {
+  function setCss(str) {
     mStyle.style.cssText = str;
   }
 

--- a/src/slice.js
+++ b/src/slice.js
@@ -1,4 +1,4 @@
-define(['classes'], function( classes ) {
+define(['classes'], function(classes) {
   var slice = classes.slice;
   return slice;
 });

--- a/src/testAllProps.js
+++ b/src/testAllProps.js
@@ -1,4 +1,4 @@
-define(['ModernizrProto', 'testPropsAll'], function( ModernizrProto, testPropsAll ) {
+define(['ModernizrProto', 'testPropsAll'], function(ModernizrProto, testPropsAll) {
   /**
    * testAllProps determines whether a given CSS property, in some prefixed
    * form, is supported by the browser. It can optionally be given a value; in

--- a/src/testDOMProps.js
+++ b/src/testDOMProps.js
@@ -1,16 +1,18 @@
-define(['is', 'fnBind'], function( is, fnBind ) {
+define(['is', 'fnBind'], function(is, fnBind) {
   /**
    * testDOMProps is a generic DOM property test; if a browser supports
    *   a certain property, it won't return undefined for it.
    */
-  function testDOMProps( props, obj, elem ) {
+  function testDOMProps(props, obj, elem) {
     var item;
 
-    for ( var i in props ) {
-      if ( props[i] in obj ) {
+    for (var i in props) {
+      if (props[i] in obj) {
 
         // return the property name as a string
-        if (elem === false) return props[i];
+        if (elem === false) {
+          return props[i];
+        }
 
         item = obj[props[i]];
 

--- a/src/testMediaQuery.js
+++ b/src/testMediaQuery.js
@@ -1,20 +1,20 @@
-define(['injectElementWithStyles'], function( injectElementWithStyles ) {
+define(['injectElementWithStyles'], function(injectElementWithStyles) {
   // adapted from matchMedia polyfill
   // by Scott Jehl and Paul Irish
   // gist.github.com/786768
-  var testMediaQuery = (function () {
+  var testMediaQuery = (function() {
     var matchMedia = window.matchMedia || window.msMatchMedia;
-    if ( matchMedia ) {
-      return function ( mq ) {
+    if (matchMedia) {
+      return function(mq) {
         var mql = matchMedia(mq);
         return mql && mql.matches || false;
       };
     }
 
-    return function ( mq ) {
+    return function(mq) {
       var bool = false;
 
-      injectElementWithStyles('@media ' + mq + ' { #modernizr { position: absolute; } }', function( node ) {
+      injectElementWithStyles('@media ' + mq + ' { #modernizr { position: absolute; } }', function(node) {
         bool = (window.getComputedStyle ?
                 window.getComputedStyle(node, null) :
                 node.currentStyle)['position'] == 'absolute';

--- a/src/testProp.js
+++ b/src/testProp.js
@@ -1,10 +1,10 @@
-define(['ModernizrProto', 'testProps'], function( ModernizrProto, testProps ) {
+define(['ModernizrProto', 'testProps'], function(ModernizrProto, testProps) {
   // Modernizr.testProp() investigates whether a given style property is recognized
   // Property names can be provided in either camelCase or kebab-case.
   // Modernizr.testProp('pointerEvents')
   // Also accepts optional 2nd arg, of a value to use for native feature detection, e.g.:
   // Modernizr.testProp('pointerEvents', 'none')
-  var testProp = ModernizrProto.testProp = function( prop, value, useValue ) {
+  var testProp = ModernizrProto.testProp = function(prop, value, useValue) {
     return testProps([prop], undefined, value, useValue);
   };
   return testProp;

--- a/src/testProps.js
+++ b/src/testProps.js
@@ -1,4 +1,4 @@
-define(['contains', 'mStyle', 'createElement', 'nativeTestProps', 'is', 'cssToDOM'], function( contains, mStyle, createElement, nativeTestProps, is, cssToDOM) {
+define(['contains', 'mStyle', 'createElement', 'nativeTestProps', 'is', 'cssToDOM'], function(contains, mStyle, createElement, nativeTestProps, is, cssToDOM) {
   // testProps is a generic CSS / DOM property test.
 
   // In testing support for a given CSS property, it's legit to test:
@@ -12,13 +12,13 @@ define(['contains', 'mStyle', 'createElement', 'nativeTestProps', 'is', 'cssToDO
 
   // Property names can be provided in either camelCase or kebab-case.
 
-  function testProps( props, prefixed, value, skipValueTest ) {
+  function testProps(props, prefixed, value, skipValueTest) {
     skipValueTest = is(skipValueTest, 'undefined') ? false : skipValueTest;
 
     // Try native detect first
     if (!is(value, 'undefined')) {
       var result = nativeTestProps(props, value);
-      if(!is(result, 'undefined')) {
+      if (!is(result, 'undefined')) {
         return result;
       }
     }
@@ -33,7 +33,7 @@ define(['contains', 'mStyle', 'createElement', 'nativeTestProps', 'is', 'cssToDO
     // defined for valid tags. Therefore, if `modernizr` does not have one, we
     // fall back to a less used element and hope for the best.
     var elems = ['modernizr', 'tspan'];
-    while ( !mStyle.style ) {
+    while (!mStyle.style) {
       afterInit = true;
       mStyle.modElem = createElement(elems.shift());
       mStyle.style = mStyle.modElem.style;
@@ -48,7 +48,7 @@ define(['contains', 'mStyle', 'createElement', 'nativeTestProps', 'is', 'cssToDO
     }
 
     propsLength = props.length;
-    for ( i = 0; i < propsLength; i++ ) {
+    for (i = 0; i < propsLength; i++) {
       prop = props[i];
       before = mStyle.style[prop];
 
@@ -56,7 +56,7 @@ define(['contains', 'mStyle', 'createElement', 'nativeTestProps', 'is', 'cssToDO
         prop = cssToDOM(prop);
       }
 
-      if ( mStyle.style[prop] !== undefined ) {
+      if (mStyle.style[prop] !== undefined) {
 
         // If value to test has been passed in, do a set-and-check test.
         // 0 (integer) is a valid property value, so check that `value` isn't

--- a/src/testPropsAll.js
+++ b/src/testPropsAll.js
@@ -1,17 +1,17 @@
-define(['ModernizrProto', 'cssomPrefixes', 'is', 'testProps', 'domPrefixes', 'testDOMProps'], function( ModernizrProto, cssomPrefixes, is, testProps, domPrefixes, testDOMProps ) {
+define(['ModernizrProto', 'cssomPrefixes', 'is', 'testProps', 'domPrefixes', 'testDOMProps'], function(ModernizrProto, cssomPrefixes, is, testProps, domPrefixes, testDOMProps) {
   /**
    * testPropsAll tests a list of DOM properties we want to check against.
    *     We specify literally ALL possible (known and/or likely) properties on
    *     the element including the non-vendor prefixed one, for forward-
    *     compatibility.
    */
-  function testPropsAll( prop, prefixed, elem, value, skipValueTest ) {
+  function testPropsAll(prop, prefixed, elem, value, skipValueTest) {
 
     var ucProp = prop.charAt(0).toUpperCase() + prop.slice(1),
     props = (prop + ' ' + cssomPrefixes.join(ucProp + ' ') + ucProp).split(' ');
 
     // did they call .prefixed('boxSizing') or are we just testing a prop?
-    if(is(prefixed, 'string') || is(prefixed, 'undefined')) {
+    if (is(prefixed, 'string') || is(prefixed, 'undefined')) {
       return testProps(props, prefixed, value, skipValueTest);
 
       // otherwise, they called .prefixed('requestAnimationFrame', window[, elem])

--- a/src/testRunner.js
+++ b/src/testRunner.js
@@ -1,4 +1,4 @@
-define(['tests', 'Modernizr', 'classes', 'is'], function( tests, Modernizr, classes, is ) {
+define(['tests', 'Modernizr', 'classes', 'is'], function(tests, Modernizr, classes, is) {
   // Run through all tests and detect their support in the current UA.
   function testRunner() {
     var featureNames;
@@ -9,7 +9,7 @@ define(['tests', 'Modernizr', 'classes', 'is'], function( tests, Modernizr, clas
     var featureName;
     var featureNameSplit;
 
-    for ( var featureIdx in tests ) {
+    for (var featureIdx in tests) {
       featureNames = [];
       feature = tests[featureIdx];
       // run the test, throw the return value into the Modernizr,
@@ -19,7 +19,7 @@ define(['tests', 'Modernizr', 'classes', 'is'], function( tests, Modernizr, clas
       //   If there is no name, it's an 'async' test that is run,
       //   but not directly added to the object. That should
       //   be done with a post-run addTest call.
-      if ( feature.name ) {
+      if (feature.name) {
         featureNames.push(feature.name.toLowerCase());
 
         if (feature.options && feature.options.aliases && feature.options.aliases.length) {

--- a/src/testStyles.js
+++ b/src/testStyles.js
@@ -1,4 +1,4 @@
-define(['ModernizrProto', 'injectElementWithStyles'], function( ModernizrProto, injectElementWithStyles ) {
+define(['ModernizrProto', 'injectElementWithStyles'], function(ModernizrProto, injectElementWithStyles) {
   var testStyles = ModernizrProto.testStyles = injectElementWithStyles;
   return testStyles;
 });

--- a/src/testXhrType.js
+++ b/src/testXhrType.js
@@ -9,7 +9,7 @@ define(function() {
     xhr.open('get', '/', true);
     try {
       xhr.responseType = type;
-    } catch(error) {
+    } catch (error) {
       return false;
     }
     return 'response' in xhr && xhr.responseType == type;


### PR DESCRIPTION
@ryanseddon 
from https://github.com/Modernizr/Modernizr/pull/1551#discussion_r26175879.

I just copied the format from jshint so it will run it in on the same files (and same ignores).

I didn't know what the rules should be (so we can start discussing that now based on the code) so I just picked the google preset as a start (using the jscs autoconfigure option (`jscs --autoconfigure src/ lib/ feature-detects/`)

One option is to use it as a base or just copy the rules from the preset and add/remove as needed. If there isn't a written style guide or another one to follow we can just look at what's the majority.

Another thing would be how to go about fixing the styles after determining rules.
We can use the autofix setting `jscs --auto-fix` (only in master branch) to fix most of the whitespace changes and everything else would be manual. I went ahead and did the autofix changes in a seperate commit so the potential changes of using the google preset can be seen. I can remove the 2nd commit or make a new PR to actually fix the changes later.

And then adding it to the `grunt test` task after all that's fixed? Maybe that should be a separate issue? Right now you can do `grunt jscs` though after an npm install.