### PR TITLE
Don't include dotfiles in npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -6,3 +6,4 @@ appveyor.yml
 Gruntfile.js
 metadata.json
 modernizr.min.js
+.*


### PR DESCRIPTION
No reason for dotfiles to be included when `npm install`ing.
Running `npm pack`, and extracting before and after, then running [this](http://stackoverflow.com/a/16788549/1850276), shows that these files gets excluded.

```
.editorconfig
.gitattributes
.jshintignore
.jshintrc
.jshintrc
.npmignore
.travis.yml
```