### PR TITLE
Clean up usage of jshintrc

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -88,22 +88,8 @@
   "smarttabs": true,
 
   "globals": {
-    "_": true,
-    "$": true,
-    "Blob": true,
     "DocumentTouch": true,
     "Modernizr": true,
-    "SVGFEColorMatrixElement": true,
-    "TEST": true,
-    "after": true,
-    "afterEach": true,
-    "before": true,
-    "beforeEach": true,
-    "define": true,
-    "describe": true,
-    "expect": true,
-    "it": true,
-    "requirejs": true,
-    "sinon": true
+    "define": true
   }
 }

--- a/lib/.jshintrc
+++ b/lib/.jshintrc
@@ -1,88 +1,14 @@
 {
+
+  // Import all rules in the root .jshintrc
+  "extends": "../.jshintrc",
   /*
    * ENVIRONMENTS
    * =================
    */
 
   // Define globals exposed by modern browsers.
-  "node": true,
+  "browser": false,
 
-  /*
-   * TABS AND QUOTES
-   * ==================
-   */
-  // Enforce tab width of 2 spaces.
-  "indent": 2,
-
-  // Enforce use of single quotation marks for strings.
-  "quotmark": "single",
-
-  /*
-   * ENFORCING OPTIONS
-   * =================
-   */
-
-  // This option allows you to not put curly braces
-  // around blocks in loops and conditionals.
-  "curly": false,
-
-  // This option allows the use of immediate function
-  // invocations without wrapping them in parentheses.
-  "immed": false,
-
-  // This option prohibits the use of arguments.caller
-  // and arguments.callee. Both .caller and .callee make
-  // quite a few optimizations impossible so they were
-  // deprecated in future versions of JavaScript.
-  "noarg": true,
-
-  // This option suppresses warnings about the use of
-  // assignments in cases where comparisons are expected
-  "boss": true,
-
-  // Allow use of == and != in favor of === and !==.
-  "eqeqeq": false,
-
-  // Suppress warnings about == null comparisons.
-  "eqnull": true,
-
-  // Does not require capitalized names for constructor functions.
-  "newcap": false,
-
-  // Prohibit trailing whitespace.
-  "trailing": true,
-
-  // Prohibit use of explicitly undeclared variables.
-  "undef": true,
-
-  // Warn when variables are defined but never used.
-  "unused": true,
-
-  // This option suppresses warnings about the use of expressions where
-  // normally you would expect to see assignments or function calls.
-  // Most of the time, such code is a typo. However, it is not forbidden
-  // by the spec and that's why this warning is optional.
-  "expr": true,
-
-  // This option suppresses warnings about the use of eval.
-  // The use of eval is discouraged because it can make your code
-  // vulnerable to various injection attacks and it makes it hard for
-  // JavaScript interpreter to do certain optimizations.
-  "evil": true,
-
-  // This option suppresses warnings about comma-first coding style.
-  "laxcomma": true,
-
-  // suppress object dot notation warnings, we know what we're doing
-  "sub": true,
-
-  // This option defines globals that are usually used for logging poor-man's
-  // debugging: console, alert, etc. It is usually a good idea to not ship
-  // them in production because, for example, console.log breaks in legacy
-  // versions of Internet Explorer.
-  "devel": true,
-
-  // This option suppresses warnings about mixed tabs and spaces when the
-  // latter are used for alignment only. The technique is called SmartTabs.
-  "smarttabs": true
+  "globals": null
 }

--- a/test/.jshintrc
+++ b/test/.jshintrc
@@ -1,0 +1,15 @@
+{
+  // Import all rules in the root .jshintrc
+  "extends": "../.jshintrc",
+
+  "mocha": true,
+
+  "jquery": true,
+
+  "globals": {
+    "_": true,
+    "expect": true, // Not included in Mocha
+    "requirejs": true,
+    "sinon": true
+  }
+}


### PR DESCRIPTION
There were only 2 rules different in `lib/.jshintrc` vs the root `.jshintrc`.
I also tried to clean up some globals in tests.

I see you've been really good with comments. Want me to expand on the things in this PR?

EDIT: Annoying diff from GH on comments in "json"-files...