### PR TITLE
Fix bug when using modernizr in Safari with plugin ClickToFlash

### DIFF
--- a/feature-detects/flash.js
+++ b/feature-detects/flash.js
@@ -26,7 +26,7 @@ define(['Modernizr', 'createElement', 'docElement', 'addTest', 'getBody'], funct
         bool.blocked = (result === 'blocked');
       }
       addTest('flash', function() { return bool; });
-      if (embed && body.contains(embed)) {
+      if (embed && embed.parentNode === body) {
         body.removeChild(embed);
       }
     };


### PR DESCRIPTION
'Embed' element is not always direct child of body. This causes error when using modernizr in Safari with enabled plugin ClickToFlash.
This fix works fine for me but maybe problem is deeper (I can't understand how embed becomes not a direct child of body)