### PR TITLE
simplification of the src-set/sizes tests

### DIFF
--- a/feature-detects/img/sizes.js
+++ b/feature-detects/img/sizes.js
@@ -16,6 +16,6 @@
 /* DOC
 Test for the `sizes` attribute on images
 */
-define(['Modernizr', 'createElement'], function(Modernizr, createElement) {
-  Modernizr.addTest('sizes', 'sizes' in createElement('img'));
+define(['Modernizr'], function(Modernizr) {
+  Modernizr.addTest('sizes', 'sizes' in new Image());
 });

--- a/feature-detects/img/srcset.js
+++ b/feature-detects/img/srcset.js
@@ -15,6 +15,6 @@
 /* DOC
 Test for the srcset attribute of images
 */
-define(['Modernizr', 'createElement'], function(Modernizr, createElement) {
-  Modernizr.addTest('srcset', 'srcset' in createElement('img'));
+define(['Modernizr'], function(Modernizr) {
+  Modernizr.addTest('srcset', 'srcset' in new Image());
 });


### PR DESCRIPTION
It's simpler and reduces the number of dependencies