### PR TITLE
History API unavailable for URLs with 'file:' protocol

### DIFF
--- a/feature-detects/history.js
+++ b/feature-detects/history.js
@@ -37,6 +37,6 @@ define(['Modernizr'], function(Modernizr) {
     }
 
     // Return the regular check
-    return (window.history && 'pushState' in window.history);
+    return (window.history && 'pushState' in window.history && location.protocol !== 'file:');
   });
 });


### PR DESCRIPTION
Browsers that usually support the History API will disable it when the current URL is served off the filesystem with the `file:` protocol.

By including this protocol check, this becomes a more accurate test for apps running in Cordova/PhoneGap/similar, as HTML files in these scenarios are served locally off the device filesystem (so with `location.protocol === 'file:'`). Although the browser used by the Cordova app may support the history API, it doesn't with the `file:` protocol.