### PR TITLE
Prevent request loop on Opera Mini servers

### DIFF
--- a/feature-detects/forms/validation.js
+++ b/feature-detects/forms/validation.js
@@ -30,8 +30,9 @@ define(['Modernizr', 'createElement', 'docElement', 'testStyles'], function(Mode
 
     // Prevent form from being submitted
     form.addEventListener('submit', function(e) {
-      //Opera does not validate form, if submit is prevented
-      if (!window.opera) {
+      // Old Presto based Opera does not validate form, if submit is prevented
+      // although Opera Mini servers use newer Presto.
+      if (!window.opera || window.operamini) {
         e.preventDefault();
       }
       e.stopPropagation();


### PR DESCRIPTION
Opera Mini servers use newer Presto engine code than
old Opera desktop. This prevents request loop between
Mini server and web server serving page with Modernizr
tests.