### PR TITLE
Hosted tests in modernizr.github.io failed these two tests due to 404s

### DIFF
--- a/test/browser/integration/iframe.js
+++ b/test/browser/integration/iframe.js
@@ -29,7 +29,7 @@ describe('iframe context', function() {
   });
 
   it('is able to be loaded in an iframe', function(done) {
-      iframeWindow.$.getScript('http://localhost:9999/dist/modernizr-build.js')
+      iframeWindow.$.getScript('../dist/modernizr-build.js')
         .done(function(build, status) {
           expect(status).to.equal('success');
           expect(iframeWindow.Modernizr).to.not.be(undefined);

--- a/test/img/integration.svg
+++ b/test/img/integration.svg
@@ -1,7 +1,7 @@
 <svg width="180" height="88" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
 
     <script>window.onerror = window.parent.document.getElementById('svgContext').onerror</script>
-    <script xlink:href="/dist/modernizr-build.js"></script>
+    <script xlink:href="../../dist/modernizr-build.js"></script>
     <script> if (window.Modernizr) {window.parent.document.getElementById('svgContext').onsuccess(window.Modernizr)}</script>
 
     <path fill="none" d="M-1-1h1172v90H-1z" />


### PR DESCRIPTION
The iframe and svg tests failed on http://modernizr.github.io/Modernizr/test/ due not looking in the right path for the `dist/modernizr-build.js`. 

Since `copy:gh-pages` preserves the dist folder in `gh-pages` branch we can alter the path and it'll be fine for PR, local and host tests.