### PR TITLE
Backport #1503, fixes #1431 in 2.x

### DIFF
--- a/modernizr.js
+++ b/modernizr.js
@@ -1403,4 +1403,4 @@ window.Modernizr = (function( window, document, undefined ) {
 
     return Modernizr;
 
-})(this, this.document);
+})(window, window.document);


### PR DESCRIPTION
This allows using 2.x in module loaders like Browserify