### PR TITLE
bin/modernizr --options is broken

### DIFF
--- a/bin/modernizr
+++ b/bin/modernizr
@@ -124,7 +124,7 @@ if (argv.o || argv.f) {
         if (_.isUndefined(obj)) {
           throw new Error('invalid key value name - ' + prop);
         } else {
-          return obj.amdPath || obj.name;
+          return obj.amdPath || obj.property;
         }
       });
   };


### PR DESCRIPTION
PR to fix the broken `options` flag in `bin/modernizr` :

```
(master) ~/data/Modernizr$ bin/modernizr --options atRule --dest ./modernizr-custom.js
{ [Error: Error: ENOENT, no such file or directory '/Users/jon301/data/Modernizr/lib/../src/Modernizr.atRule().js'
In module tree:
    modernizr-init

    at Error (native)
]
  originalError:
   { [Error: ENOENT, no such file or directory '/Users/jon301/data/Modernizr/lib/../src/Modernizr.atRule().js']
     errno: -2,
     code: 'ENOENT',
     path: '/Users/jon301/data/Modernizr/lib/../src/Modernizr.atRule().js',
     syscall: 'open',
     fileName: '/Users/jon301/data/Modernizr/lib/../src/Modernizr.atRule().js',
     moduleTree: [ 'modernizr-init' ] } }
```