### PR TITLE
Fix detecting unprefixed gradients

### DIFF
--- a/feature-detects/css/gradients.js
+++ b/feature-detects/css/gradients.js
@@ -30,7 +30,7 @@ define(['Modernizr', 'prefixes', 'createElement'], function(Modernizr, prefixes,
     var angle;
 
     for (var i = 0, len = prefixes.length - 1; i < len; i++) {
-      angle = (i == 0 ? 'to ' : '') + 'left top';
+      angle = (i === 0 ? 'to ' : '') + 'left top';
       css += str1 + prefixes[i] + 'linear-gradient(' + angle + ', #9f9, white);';
     }
 

--- a/feature-detects/css/gradients.js
+++ b/feature-detects/css/gradients.js
@@ -30,8 +30,8 @@ define(['Modernizr', 'prefixes', 'createElement'], function(Modernizr, prefixes,
     var angle;
 
     for (var i = 0, len = prefixes.length - 1; i < len; i++) {
-      angle = (i === 0 ? 'to ' : '') + 'left top';
-      css += str1 + prefixes[i] + 'linear-gradient(' + angle + ', #9f9, white);';
+      angle = (i === 0 ? 'to ' : '');
+      css += str1 + prefixes[i] + 'linear-gradient(' + angle + 'left top, #9f9, white);';
     }
 
     if (Modernizr._config.usePrefixes) {

--- a/feature-detects/css/gradients.js
+++ b/feature-detects/css/gradients.js
@@ -26,10 +26,14 @@ define(['Modernizr', 'prefixes', 'createElement'], function(Modernizr, prefixes,
 
     var str1 = 'background-image:';
     var str2 = 'gradient(linear,left top,right bottom,from(#9f9),to(white));';
-    var str3 = 'linear-gradient(left top,#9f9, white);';
+    var css = '';
+    var angle;
 
-    // standard syntax             // trailing 'background-image:'
-    var css = str1 + prefixes.join(str3 + str1).slice(0, -str1.length);
+    for (var i = 0, len = prefixes.length - 1; i < len; i++) {
+      angle = (i == 0 ? 'to ' : '') + 'left top';
+      css += str1 + prefixes[i] + 'linear-gradient(' + angle + ', #9f9, white);';
+    }
+
     if (Modernizr._config.usePrefixes) {
     // legacy webkit syntax (FIXME: remove when syntax not in use anymore)
       css += str1 + '-webkit-' + str2;


### PR DESCRIPTION
Use the "to" keyword when detecting the unprefixed version of CSS gradients.  This should fix #1621.