### PR TITLE
improve grammar in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -11,7 +11,7 @@ Modernizr tests which native CSS3 and HTML5 features are available in the curren
 
 Often times people want to know when an asynchronous test is done so they can allow their application to react to it.
 In the past, you've had to rely on watching properties or `<html>` classes. Only events on **asynchronous** tests are
-supported. Synchronous tests should be handled synchronously to improve speed and to maintain consistency.
+supported. Synchronous tests should be handled synchronously to improve speed and maintain consistency.
 
 The new API looks like this:
 


### PR DESCRIPTION
I took out an unnecessary "to" in readme. I primarily made this change to practice forking and making pull requests. Feel free to ignore this.