### PR TITLE
Add backdropfilter test

### DIFF
--- a/feature-detects/css/backdropfilter.js
+++ b/feature-detects/css/backdropfilter.js
@@ -1,0 +1,10 @@
+/*!
+{
+  "name": "Backdrop Filter",
+  "property": "backdropfilter",
+  "tags": ["css"],
+}
+!*/
+define(['Modernizr', 'testAllProps'], function(Modernizr, testAllProps) {
+  Modernizr.addTest('backdropfilter', testAllProps('backdropFilter'));
+});

--- a/lib/config-all.json
+++ b/lib/config-all.json
@@ -41,6 +41,7 @@
     "css/all",
     "css/animations",
     "css/appearance",
+    "css/backdropfilter",
     "css/backgroundblendmode",
     "css/backgroundcliptext",
     "css/backgroundposition-shorthand",


### PR DESCRIPTION
Browsers are introducing support for the backdrop-filter CSS prop (in
WebKit Nightlies; arriving prefixed in iOS9 Safari; committed to Blink
this morning), so here's a simple test for it