### PR TITLE
Add CLI version lower case -v alias

### DIFF
--- a/bin/modernizr
+++ b/bin/modernizr
@@ -12,7 +12,7 @@ var yargs = require('yargs')
     describe: 'Print Help'
   })
   .options('V', {
-    alias: 'version',
+    alias: ['v', 'version'],
     describe: 'Print the version and exit'
   })
   .options('f', {


### PR DESCRIPTION
Most of CLI tools that are known to Modernizr
use lower case options. Let's mention only:
npm -v, node -v, bower -v, brew -v, git -v.
For some reason Modernizr CLI uses uppercase
-V option. This commit provides lower case alias
for now, so uppercase option can be phased out
in the future safely.

The tests:
```
>> 719 passed! (4.38s)
Done, without errors.
```

Before this change the well know `-v` was not supported:
```
modernizr -v
config file, inline features, or options required.
```
After this change the `-v` will work:
```
modernizr -v
Modernizr v3.0.0
```
The usage help will output:
```
modernizr -h
Options:
  -h, --help         Print Help                                                                                      
  -V, -v, --version  Print the version and exit 
```

Thanks!