### PR TITLE
Update href for cupcakejs sessionStorage polyfill.

### DIFF
--- a/lib/polyfills.json
+++ b/lib/polyfills.json
@@ -443,7 +443,7 @@
   "cupcake": {
     "name": "CupCake.js",
     "authors": ["Rivindu Perera"],
-    "href": "http://www.rivindu.com/p/cupcakejs.html",
+    "href": "https://github.com/rivindu/cupcakejs",
     "licenses": ["MIT"]
   },
   "storagepolyfill": {


### PR DESCRIPTION
Looks like http://www.rivindu.com/ was taken over by spam. Updating the link for cupcakejs to Rivindu's [GitHub page](https://github.com/rivindu/cupcakejs).