### PR TITLE
Updated grunt-contrib-jade to version 0.15.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "grunt-contrib-clean": "0.4.1",
     "grunt-contrib-connect": "0.5.0",
     "grunt-contrib-copy": "0.8.1",
-    "grunt-contrib-jade": "0.14.1",
+    "grunt-contrib-jade": "0.15.0",
     "grunt-contrib-jshint": "0.11.3",
     "grunt-coveralls": "1.0.0",
     "grunt-env": "0.4.4",


### PR DESCRIPTION
:rocket:

One of your dependencies has just updated, so this PR bumps the corresponding version number in your `package.json`.

You can now check that the dependency update doesn't break your code, and then release the new version of your software safe in the knowledge that it will stay in this working state, regardless of _when_ your users do `$ npm install`.

Have a good day!

---

This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>