### PR TITLE
Updated joi to version 6.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "grunt-mocha": "0.4.13",
     "grunt-mocha-test": "0.12.7",
     "grunt-saucelabs": "8.6.1",
-    "joi": "6.7.1",
+    "joi": "6.8.0",
     "jquery": "1.11.3",
     "json3": "3.3.2",
     "load-grunt-tasks": "0.2.1",
@@ -68,14 +68,30 @@
     "url": "http://modernizr.com/"
   },
   "contributors": [
-    { "name": "Faruk Ates" },
-    { "name": "Paul Irish" },
-    { "name": "Alex Sexton" },
-    { "name": "Ryan Seddon" },
-    { "name": "Alexander Farkas" },
-    { "name": "Patrick Kettner" },
-    { "name": "Stu Cox" },
-    { "name": "Richard Herrera" }
+    {
+      "name": "Faruk Ates"
+    },
+    {
+      "name": "Paul Irish"
+    },
+    {
+      "name": "Alex Sexton"
+    },
+    {
+      "name": "Ryan Seddon"
+    },
+    {
+      "name": "Alexander Farkas"
+    },
+    {
+      "name": "Patrick Kettner"
+    },
+    {
+      "name": "Stu Cox"
+    },
+    {
+      "name": "Richard Herrera"
+    }
   ],
   "license": "MIT"
 }


### PR DESCRIPTION
:rocket:

joi just published version 6.8.0, so that’s now up to date in your `package.json`.

Check that it doesn’t break your code and release the new version of your software safe in the knowledge that it will stay in this working state.

---
The new version differs by 8 commits (ahead by 8, behind by 0).

- [eefc2cc](https://github.com/hapijs/joi/commit/eefc2cc693a843885f776a24328b4a7552dfb281): 6.8.0
- [56ae15d](https://github.com/hapijs/joi/commit/56ae15d310b14b60b51f54d860e1bb1571e26836): Update toc when versioning
- [a9616c4](https://github.com/hapijs/joi/commit/a9616c47d99c7c1f8456cbc0becfd7ebd4694cfc): Merge pull request #728 from hapijs/funcObj
- [9d6013f](https://github.com/hapijs/joi/commit/9d6013ff264186e61e4389721f51a14f1c0a2275): func with keys test
- [dbd4660](https://github.com/hapijs/joi/commit/dbd46603c14325550bfd7c77607cb45fadf17a9f): Allow functions to act as objects. Closes #727
- [7f210bc](https://github.com/hapijs/joi/commit/7f210bc76dfaa55c3ed777141d6b301ecbbf24be): Anchor the regexp (fixes #724)
- [5cf4079](https://github.com/hapijs/joi/commit/5cf407928b57878e4dd2709f8bd9f18720f7b079): Upgrade to lab 6.0.0
- [12a6c39](https://github.com/hapijs/joi/commit/12a6c39b2e02b7289bb1f9d24c5a0bc947c5697e): Add node 4 latest (hapijs/contrib#54)

See the [full diff](https://github.com/hapijs/joi/compare/d4cd8598e1772abba7c4f0e08fc85b4b1af85c7a...eefc2cc693a843885f776a24328b4a7552dfb281).

---
This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>