### PR TITLE
add WindowBase64 API detection (window.atob && window.btoa)

### DIFF
--- a/feature-detects/window/atob-btoa.js
+++ b/feature-detects/window/atob-btoa.js
@@ -1,0 +1,25 @@
+/*!
+{
+  "name": "Base 64 encoding/decoding",
+  "property": ["atob-btoa"],
+  "caniuse" : "atob-btoa",
+  "tags": ["atob", "base64", "WindowBase64", "btoa"],
+  "authors": ["Christian Ulbrich"],
+  "notes": [{
+    "name": "WindowBase64",
+    "href": "http://www.w3.org/TR/html5/webappapis.html#windowbase64"
+  }, {
+    "name": "MDN documentation",
+    "href": "https://developer.mozilla.org/en-US/docs/Web/API/WindowBase64/atob"
+  }],
+  "polyfills": ["base64js"]
+}
+!*/
+/* DOC
+
+Detects support for WindowBase64 API (window.atob && window.btoa).
+
+*/
+define(['Modernizr'], function(Modernizr) {
+  Modernizr.addTest('atob-btoa', 'atob' in window && 'btoa' in window);
+});

--- a/lib/polyfills.json
+++ b/lib/polyfills.json
@@ -745,5 +745,11 @@
     "href": "https://github.com/github/fetch",
     "licenses": ["MIT"],
     "name": "window.fetch polyfill"
+  },
+  "base64js": {
+    "authors": ["David Chambers"],
+    "href": "https://github.com/davidchambers/Base64.js",
+    "licenses": ["Apache2", "WTFPL"],
+    "name": "window.atob and window.btoa polyfill"
   }
 }


### PR DESCRIPTION
I needed support for detecting, whether window.atob and window.btoa are present (basically to apply a polyfill for <IE10). I also updated the polyfill info using the suggestion from https://github.com/Modernizr/Modernizr/wiki/HTML5-Cross-Browser-Polyfills#base64-windowatob-and-windowbtoa