### PR TITLE
Include built modernizr in npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,6 +1,5 @@
 test
 media
-dist
 gh-pages
 appveyor.yml
 Gruntfile.js

--- a/package.json
+++ b/package.json
@@ -38,10 +38,12 @@
     "proxyquire": "1.7.2"
   },
   "scripts": {
+    "prepublish": "grunt build",
     "test": "grunt test --stack"
   },
   "main": "./lib/cli",
   "bin": "./bin/modernizr",
+  "browser": "dist/modernizr-build",
   "repository": {
     "type": "git",
     "url": "git://github.com/Modernizr/Modernizr.git"


### PR DESCRIPTION
Also add browser field to allow requiring it.

This allows me to just do `import 'modernizr'` in a webpack application (probably browserify as well), and get the built file. This way I don't have to keep moderizr in my source code, or do any configuration