### PR TITLE
Safari 9 fix for sizes detection

### DIFF
--- a/feature-detects/img/sizes.js
+++ b/feature-detects/img/sizes.js
@@ -29,7 +29,7 @@ define(['Modernizr', 'createElement', 'addTest'], function(Modernizr, createElem
       width2 = 'data:image/gif;base64,R0lGODlhAgABAPAAAP///wAAACH5BAAAAAAALAAAAAACAAEAAAICBAoAOw==';
       width1 = 'data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==';
 
-      test = function(){
+      test = function() {
         addTest('sizes', image.width == 2);
       };
 

--- a/feature-detects/img/sizes.js
+++ b/feature-detects/img/sizes.js
@@ -1,6 +1,7 @@
 /*!
 {
   "name": "sizes attribute",
+  "async": true,
   "property": "sizes",
   "tags": ["image"],
   "authors": ["Mat Marquis"],
@@ -16,6 +17,30 @@
 /* DOC
 Test for the `sizes` attribute on images
 */
-define(['Modernizr', 'createElement'], function(Modernizr, createElement) {
-  Modernizr.addTest('sizes', 'sizes' in createElement('img'));
+define(['Modernizr', 'createElement', 'addTest'], function(Modernizr, createElement, addTest) {
+  Modernizr.addAsyncTest(function() {
+    var width1, width2, test;
+    var image = createElement('img');
+    // in a perfect world this would be the test...
+    var isSizes = 'sizes' in image;
+
+    // ... but we need to deal with Safari 9...
+    if (!isSizes && ('srcset' in  image)) {
+      width2 = 'data:image/gif;base64,R0lGODlhAgABAPAAAP///wAAACH5BAAAAAAALAAAAAACAAEAAAICBAoAOw==';
+      width1 = 'data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==';
+
+      test = function(){
+        addTest('sizes', image.width == 2);
+      };
+
+      image.onload = test;
+      image.onerror = test;
+      image.setAttribute('sizes', '9px');
+
+      image.srcset = width1 + ' 1w,' + width2 + ' 8w';
+      image.src = width1;
+    } else {
+      addTest('sizes', isSizes);
+    }
+  });
 });


### PR DESCRIPTION
This fixes #1721. This fix is only async in Safari (8, 9 and maybe 10) and Edge (12).