### PR TITLE
Specifiy codec name when check support of mp3

### DIFF
--- a/feature-detects/audio.js
+++ b/feature-detects/audio.js
@@ -31,7 +31,7 @@ define(['Modernizr', 'createElement'], function(Modernizr, createElement) {
       if (bool = !!elem.canPlayType) {
         bool      = new Boolean(bool);
         bool.ogg  = elem.canPlayType('audio/ogg; codecs="vorbis"').replace(/^no$/, '');
-        bool.mp3  = elem.canPlayType('audio/mpeg;')               .replace(/^no$/, '');
+        bool.mp3  = elem.canPlayType('audio/mpeg; codecs="mp3"')  .replace(/^no$/, '');
         bool.opus  = elem.canPlayType('audio/ogg; codecs="opus"') .replace(/^no$/, '');
 
         // Mimetypes accepted:


### PR DESCRIPTION
Firefox return `maybe` for `audio/mpeg` and `probably` for `audio/mpeg; codec="mp3"` (Firefox 42 OSX 10.10.5)