### PR TITLE
Add open code of conduct statement

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -7,6 +7,9 @@
 
 Modernizr tests which native CSS3 and HTML5 features are available in the current UA and makes the results available to you in two ways: as properties on a global `Modernizr` object, and as classes on the `<html>` element. This information allows you to progressively enhance your pages with a granular level of control over the experience.
 
+This project adheres to the [Open Code of Conduct][code-of-conduct]. By participating, you are expected to honor this code.
+[code-of-conduct]: http://todogroup.org/opencodeofconduct/#Modernizr/conduct@modernizr.com
+
 ## New Asynchronous Event Listeners
 
 Often times people want to know when an asynchronous test is done so they can allow their application to react to it.


### PR DESCRIPTION
This fixes #1615 and links off to the open code of conduct template. We'll need to configure the email address conduct[at]modernizr.com @KuraFire @patrickkettner who has access to do this?