### PR TITLE
fix nthchild false negative

### DIFF
--- a/feature-detects/css/nthchild.js
+++ b/feature-detects/css/nthchild.js
@@ -27,15 +27,12 @@ define(['Modernizr', 'testStyles'], function(Modernizr, testStyles) {
   // A Javascript loop then tests if the `<div>`s have the expected width
   // using the modulus operator.
   testStyles('#modernizr div {width:1px} #modernizr div:nth-child(2n) {width:2px;}', function(elem) {
-    Modernizr.addTest('nthchild', function() {
-      var elems = elem.getElementsByTagName('div'),
-      test = true;
+    var elems = elem.getElementsByTagName('div'),
+    correctWidths = true;
 
-      for (var i = 0; i < 5; i++) {
-        test = test && elems[i].offsetWidth === i % 2 + 1;
-      }
-
-      return test;
-    });
+    for (var i = 0; i < 5; i++) {
+      correctWidths = correctWidths && elems[i].offsetWidth === i % 2 + 1;
+    }
+    Modernizr.addTest('nthchild', correctWidths);
   }, 5);
 });

--- a/feature-detects/css/nthchild.js
+++ b/feature-detects/css/nthchild.js
@@ -27,8 +27,8 @@ define(['Modernizr', 'testStyles'], function(Modernizr, testStyles) {
   // A Javascript loop then tests if the `<div>`s have the expected width
   // using the modulus operator.
   testStyles('#modernizr div {width:1px} #modernizr div:nth-child(2n) {width:2px;}', function(elem) {
-    var elems = elem.getElementsByTagName('div'),
-    correctWidths = true;
+    var elems = elem.getElementsByTagName('div');
+    var correctWidths = true;
 
     for (var i = 0; i < 5; i++) {
       correctWidths = correctWidths && elems[i].offsetWidth === i % 2 + 1;


### PR DESCRIPTION
Passing a function in to `Modernizr.addTest` resulted the code being executed *after* `elem` had been removed from the DOM (and so had no layout). I've moved the code to be executed immediately and the just the result  (which I renamed just to make the last line a bit more human readable) passed into `Modernizr.addTest`.

I searched the rest of the css feature-detects and nthchild appears to be the only test with this issue. That said, might be worth adding a little note to the docs about time of execution with `testStyles` and `addTest`.

All tests passed locally before *and* after this fix, but it was a bit beyond me to dive into what's happening with them

fixes #1675