### PR TITLE
Make Flash Test element invisible to prevent flickering

### DIFF
--- a/feature-detects/flash.js
+++ b/feature-detects/flash.js
@@ -66,6 +66,7 @@ define(['Modernizr', 'createElement', 'docElement', 'addTest', 'getBody', 'isSVG
       var inline_style;
 
       embed.type = 'application/x-shockwave-flash';
+      embed.setAttribute('style', 'display: none;');
 
       // Need to do this in the body (fake or otherwise) otherwise IE8 complains
       body.appendChild(embed);


### PR DESCRIPTION
Hi There!

We had a problem that the element that is attached to the body to detect flash was visible if the page has a background that is not white.

Cheers!