### PR TITLE
Fix build query not including setclasses when passed as an option

### DIFF
--- a/lib/build-query.js
+++ b/lib/build-query.js
@@ -27,9 +27,6 @@ define(['lodash', 'metadata'], function(_, metadata) {
     // A few of the values have to be massaged in order to match
     // the `value`
     var opts = _.map(config.options, function(opt) {
-      if (opt == 'setClasses') {
-        return 'cssclasses';
-      }
       if (opt.indexOf('html5') === 0) {
         opt = opt.replace('html5', '');
       }

--- a/src/generate.js
+++ b/src/generate.js
@@ -23,9 +23,6 @@ define(['lodash'], function(_) {
     // Some special cases
     var setClasses = _.contains(config.options, 'setClasses');
 
-    // Remove the special cases
-    config.options = _.without(config.options, 'setClasses');
-
     var output = 'require(["ModernizrProto", "Modernizr", "testRunner"';
 
     // Needed named module requires
@@ -38,8 +35,9 @@ define(['lodash'], function(_) {
       config.options = _.without(config.options, 'html5shiv');
     }
 
-    // Load in the rest of the options (they dont return values, so they aren't declared
-    _.forEach(config.options, function(option) {
+    // Load in the rest of the options, excluding special cases
+    // (they dont return values, so they aren't declared)
+    _.forEach(_.without(config.options, 'setClasses'), function(option) {
       output += ', "' + option + '"';
     });
 

--- a/test/browser/src/generate.js
+++ b/test/browser/src/generate.js
@@ -93,6 +93,12 @@ describe('generate', function() {
     window.require = stashedRequire;
   });
 
+  it('does not modify options', function() {
+    var config = {'options': ['setClasses']};
+    generate(config);
+    expect(config['options']).to.eql(['setClasses']);
+  });
+
   after(function() {
     cleanup();
   });

--- a/test/universal/lib/build-hash.js
+++ b/test/universal/lib/build-hash.js
@@ -62,7 +62,7 @@ describe('build-query', function() {
       classPrefix: 'TEST_PREFIX',
       options: ['setClasses']
     });
-    expect(query).to.be('?-cssclasses-dontmin-cssclassprefix:TEST_PREFIX');
+    expect(query).to.be('?-setclasses-dontmin-cssclassprefix:TEST_PREFIX');
   });
 
   it('strips `html5` from the shiv options', function() {


### PR DESCRIPTION
I stumbled upon this when moving from a manually built Modernizr file to a bower installed one. The build URL provided in the file did not include the `setclasses` property, so installing through bower as a tar.gz omitted this feature - despite the fact the original file used it.

This bug can be demonstrated on the current https://modernizr.com/download site itself:

1. Pick your feature detections
2. Ensure "Add CSS classes" is checked
3. Build and view the resulting file
4. Build URL in the header comment is missing `setclasses`

Example following these steps using `inlinesvg` generates this codepen: https://codepen.io/anon/pen/KdLxWb

This is happening as the generate script is directly modifying config to remove the setClasses special case option, which means it no longer exists for the rest of the build process (e.g. build-query) to work with.

Another part of this is even if the property was being set, it is using the wrong label anyway, so would still fail to include the `setClasses` option. This PR fixes that too.

Its usefulness doesn't just lie with copying the build URL for bower, it also makes it more consistently clear what features were intended to be included. Currently, the "bad" URLs work on the site as "Add CSS classes" is checked by default and replaced into the browser history state - shouldn't really depend on that behaviour. 