### PR TITLE
Add an alternative check to detect opus codec support

### DIFF
--- a/feature-detects/audio.js
+++ b/feature-detects/audio.js
@@ -30,9 +30,10 @@ define(['Modernizr', 'createElement'], function(Modernizr, createElement) {
     try {
       if (bool = !!elem.canPlayType) {
         bool      = new Boolean(bool);
-        bool.ogg  = elem.canPlayType('audio/ogg; codecs="vorbis"').replace(/^no$/, '');
-        bool.mp3  = elem.canPlayType('audio/mpeg; codecs="mp3"')  .replace(/^no$/, '');
-        bool.opus  = elem.canPlayType('audio/ogg; codecs="opus"') .replace(/^no$/, '');
+        bool.ogg  = elem.canPlayType('audio/ogg; codecs="vorbis"') .replace(/^no$/, '');
+        bool.mp3  = elem.canPlayType('audio/mpeg; codecs="mp3"')   .replace(/^no$/, '');
+        bool.opus  = elem.canPlayType('audio/ogg; codecs="opus"')  ||
+                     elem.canPlayType('audio/webm; codecs="opus"') .replace(/^no$/, '');
 
         // Mimetypes accepted:
         //   developer.mozilla.org/En/Media_formats_supported_by_the_audio_and_video_elements


### PR DESCRIPTION
on mobile (android 5.1.1 / chrome 45), the opus audio codec is supported but `elem.canPlayType('audio/ogg; codecs="opus"')` will return an empty string and  `elem.canPlayType('audio/webm; codecs="opus"')` will return `probably`.