### PR TITLE
Implement browserify support

### DIFF
--- a/browserify/main.js
+++ b/browserify/main.js
@@ -1,0 +1,33 @@
+var ModernizrProto = require('../src/ModernizrProto');
+var Modernizr = require('../src/Modernizr');
+var testRunner = require('../src/testRunner');
+var setClasses = require('../src/setClasses');
+var classes = require('../src/classes');
+var addTest = require('../src/addTest');
+
+module.exports = Modernizr;
+
+var hasRun = false;
+ModernizrProto.init = function(options) {
+  if (hasRun) return;
+  hasRun = true;
+
+  options = options || {};
+
+  if (options.classPrefix);
+    Modernizr._config.classPrefix = options.classPrefix;
+
+  testRunner();
+
+  ModernizrProto.addTest = addTest;
+  delete ModernizrProto.addAsyncTest;
+
+  if (options.setClasses !== false)
+    setClasses(classes);
+
+  for (var i = 0; i < Modernizr._q.length; i++) {
+    Modernizr._q[i]();
+  }
+
+  return Modernizr;
+};

--- a/browserify/transform.js
+++ b/browserify/transform.js
@@ -1,0 +1,150 @@
+var path = require('path');
+var esprima = require('esprima');
+var estraverse = require('estraverse');
+var escodegen = require('escodegen');
+var btt = require('browserify-transform-tools');
+
+
+module.exports = btt.makeStringTransform(
+    'modernizr-transform'
+  , {}
+  , function(src, options, done) {
+      src = transform(options.file, src);
+      done(null, src);
+    }
+  );
+
+function transform(sourcefile, src) {
+  var ast = esprima.parse(src);
+
+  var tast;
+
+  function leave(node) {
+    var callee = node.callee;
+    if (!(callee &&
+          node.type === 'CallExpression' &&
+          callee.type === 'Identifier' &&
+          callee.name === 'define')
+        )
+      return;
+
+    // define(function() { })
+    if (node.arguments.length === 1 &&
+        node.arguments[0].type === 'FunctionExpression') {
+
+      tast = generateModuleAst(
+          [ ]
+        , node.arguments[0]
+        , sourcefile
+        );
+
+      this.break();
+
+    } else
+
+    // define([ ], function() { })
+    if (node.arguments.length === 2 &&
+        node.arguments[0].type === 'ArrayExpression' &&
+        node.arguments[1].type === 'FunctionExpression') {
+
+      tast = generateModuleAst(
+          node.arguments[0].elements
+        , node.arguments[1]
+        , sourcefile
+        );
+
+      this.break();
+    }
+  }
+
+  estraverse.replace(ast, { leave: leave });
+
+  return escodegen.generate(tast || ast);
+}
+
+
+function generateModuleAst(deps, factory, sourcefile) {
+  for (var dep, i = 0; i < deps.length; i++) {
+    dep = deps[i].value;
+    dep = rewriteDependencyPath(dep, sourcefile);
+    dep = generateRequireAst(dep);
+    deps[i] = dep;
+  }
+
+  var ast =
+    { type: 'Program'
+    , body:
+      [ { 'type': 'ExpressionStatement'
+        , 'expression':
+          { 'type': 'AssignmentExpression'
+          , 'operator': '='
+          , 'left':
+            { 'type': 'MemberExpression'
+            , 'computed': false
+            , 'object':
+              { 'type': 'Identifier'
+              , 'name': 'module'
+              }
+            , 'property':
+              { 'type': 'Identifier'
+              , 'name': 'exports'
+              }
+            }
+          , 'right':
+            { 'type': 'CallExpression'
+            , 'callee': factory
+            , 'arguments': deps
+            }
+          }
+        }
+      ]
+    };
+  return ast;
+}
+
+function rewriteDependencyPath(id, sourcefile) {
+  var dir = sourcefile;
+  var sourcedir;
+  var depth = 0;
+  while (dir !== '/') {
+    dir = path.dirname(dir);
+    sourcedir = path.basename(dir);
+    depth++;
+
+    if (sourcedir === 'feature-detects' || sourcedir === 'src')
+      break;
+  }
+
+  if (sourcedir === 'feature-detects')
+    if (/^test\//.test(id)) {
+      return (new Array(depth)).join('../') + id.substr(5);
+    } else {
+      return (new Array(depth + 1)).join('../') + 'src/' + id;
+    } else
+
+  if (sourcedir === 'src') {
+    if (/^test\//.test(id)) {
+      return '../test/' + id;
+    } else {
+      return './' + id;
+    }
+  }
+
+  throw new Error('Unexpected dependency `' + id + '`');
+}
+
+function generateRequireAst(dep) {
+  var ast =
+    { 'type': 'CallExpression'
+    , 'callee':
+      { 'type': 'Identifier'
+      , 'name': 'require'
+      }
+    , 'arguments':
+      [ { 'type': 'Literal'
+        , 'value': dep
+        }
+      ]
+    };
+  return ast;
+}

--- a/package.json
+++ b/package.json
@@ -6,7 +6,11 @@
     "test": "test"
   },
   "dependencies": {
+    "browserify-transform-tools": "1.5.0",
     "doctrine": "0.7.2",
+    "escodegen": "1.7.1",
+    "esprima": "2.7.0",
+    "estraverse": "4.1.1",
     "file": "0.2.2",
     "find-parent-dir": "0.3.0",
     "lodash": "3.10.1",
@@ -98,5 +102,13 @@
       "url": "https://twitter.com/doctyper"
     }
   ],
-  "license": "MIT"
+  "license": "MIT",
+  "browser": "./browserify/main.js",
+  "browserify": {
+    "transform": [
+      [
+        "./browserify/transform.js"
+      ]
+    ]
+  }
 }


### PR DESCRIPTION
Hi

Here is a working implementation for Browserify without changing anything. It lets you require just the tests you want and the Browserify builder will do it's magic.

Usage example:
```js
require('modernizr/feature-detects/svg/inline') // inlinesvg
require('modernizr/feature-detects/touchevents') // touchevents

const Modernizr = require('modernizr')
Modernizr.init({ classPrefix: 'modernizr-' })

console.log(Moderizr.touchevents)
```

I've created one new methods called `Modernizr.init()`. This method must called before the user starts checking the results of the tests. The reason for this method is that we need a way to configure Modernizr before any tests are run. In most situations, `process.nextTick(Modernizr.init)` will be the best option. 

I was considering a `cleanup` or `finish` method instead of the `init` method and just running `Modernizr._q` there, but that does not solve the configuration problem.