### PR TITLE
Add test for es6 arrow functions

### DIFF
--- a/feature-detects/es6/arrow.js
+++ b/feature-detects/es6/arrow.js
@@ -1,0 +1,22 @@
+/*!
+{
+  "name": "ES6 Arrow Functions",
+  "property": "arrow",
+  "authors": ["Vincent Riemer"],
+  "tags": ["es6"]
+}
+!*/
+/* DOC
+Check if browser implements ECMAScript 6 Arrow Functions per specification.
+*/
+define(['Modernizr'], function(Modernizr) {
+  Modernizr.addTest('arrow', function() {
+    try {
+      /* jshint evil: true */
+      eval('()=>{}');
+    } catch (e) {
+      return false;
+    }
+    return true;
+  });
+});


### PR DESCRIPTION
Following the conventions of the ES6 Generators test, added a new test for the ES6 arrow function syntax. 

I manually tested the code within the try-catch block and it succeeds in the latest Chrome, Firefox, and Edge but fails in the latest Safari which lines up with [this support table](https://kangax.github.io/compat-table/es6/).