### PR TITLE
fix(src/generate): avoid prepending 'test/' to absolute paths

### DIFF
--- a/src/generate.js
+++ b/src/generate.js
@@ -43,7 +43,9 @@ define(['lodash'], function(_) {
 
     // Load in all the detects
     _.forEach(config['feature-detects'], function(detect) {
-      detect = detect.indexOf('test/') === 0 ? detect : 'test/' + detect;
+      if (detect.charAt(0) !== '/' && detect.indexOf('test/') !== 0) {
+        detect = 'test/' + detect;
+      }
       output += ', "' + detect + '"';
     });
 

--- a/test/browser/src/generate.js
+++ b/test/browser/src/generate.js
@@ -56,6 +56,13 @@ describe('generate', function() {
       var output = generate(config);
       expect(output).to.contain('test/fake');
     });
+
+    it('without clobbering absolute path', function() {
+      var config = {'feature-detects': ['/abs/path/to/test.js']};
+      var output = generate(config);
+      expect(output).to.contain('/abs/path/to/test.js');
+      expect(output).to.not.contain('test//abs/path/to/test.js');
+    });
   });
 
   it('adds `setClasses` and `classes` when defined', function() {


### PR DESCRIPTION
If we detect that the user has provided an absolute path, avoid
prepending 'test/' to the path

Resolves #1799 