### PR TITLE
Fix false positive in Notifications test for Chrome on Android (fixes #1660)

### DIFF
--- a/feature-detects/notification.js
+++ b/feature-detects/notification.js
@@ -10,7 +10,13 @@
   },{
     "name": "W3C spec",
     "href": "www.w3.org/TR/notifications/"
+  }, {
+    "name": "Changes in Chrome to Notifications API due to Service Worker Push Notifications",
+    "href": "https://developers.google.com/web/updates/2015/05/Notifying-you-of-notificiation-changes"
   }],
+  "knownBugs": [
+    "Possibility of false-positive on Chrome for Android if permissions we're granted for a website prior to Chrome 44."
+  ],
   "polyfills": ["desktop-notify", "html5-notifications"]
 }
 !*/
@@ -18,5 +24,23 @@
 Detects support for the Notifications API
 */
 define(['Modernizr'], function(Modernizr) {
-  Modernizr.addTest('notification', 'Notification' in window && 'permission' in window.Notification && 'requestPermission' in window.Notification);
+  Modernizr.addTest('notification', function() {
+    if (!window.Notification || !window.Notification.requestPermission) {
+      return false;
+    }
+    // if permission is already granted, assume support
+    if (window.Notification.permission === 'granted') {
+      return true;
+    }
+
+    try {
+      new window.Notification('');
+    } catch (e) {
+      if (e.name === 'TypeError') {
+        return false;
+      }
+    }
+
+    return true;
+  });
 });


### PR DESCRIPTION
Please see #1660 for details. Note I don't actually have Chrome for Android to test on. I'm basing the change on this article: https://developers.google.com/web/updates/2015/05/Notifying-you-of-notificiation-changes