### PR TITLE
Add semicolons to avoid unicode feature-detect generating typos

### DIFF
--- a/feature-detects/unicode.js
+++ b/feature-detects/unicode.js
@@ -26,8 +26,8 @@ define(['Modernizr', 'createElement', 'testStyles', 'isSVG'], function(Modernizr
 
     testStyles('#modernizr{font-family:Arial,sans;font-size:300em;}', function(node) {
 
-      missingGlyph.innerHTML = isSVG ? '\u5987' : '&#5987';
-      star.innerHTML = isSVG ? '\u2606' : '&#9734';
+      missingGlyph.innerHTML = isSVG ? '\u5987' : '&#5987;';
+      star.innerHTML = isSVG ? '\u2606' : '&#9734;';
 
       node.appendChild(missingGlyph);
       node.appendChild(star);


### PR DESCRIPTION
The unicode feature-detect seems to introduce html typos (two html-entities without their trailing semicolons), which caused non-validating code for me.  This PR fixes that.