### PR TITLE
Make form-validation output valid code

### DIFF
--- a/feature-detects/forms/validation.js
+++ b/feature-detects/forms/validation.js
@@ -41,7 +41,7 @@ define(['Modernizr', 'createElement', 'docElement', 'testStyles'], function(Mode
     // Calling form.submit() doesn't trigger interactive validation,
     // use a submit button instead
     //older opera browsers need a name attribute
-    form.innerHTML = '<input name="modTest" required><button></button>';
+    form.innerHTML = '<input name="modTest" required="required" /><button></button>';
 
     testStyles('#modernizr form{position:absolute;top:-99999em}', function(node) {
       node.appendChild(form);


### PR DESCRIPTION
The form-validation code generates html5 code which doesn't validate as xhtml5 (namely,  a missing close-tag and an attribute with no value). This PR fixes that. If you prefer the brevity of vanilla html5 and don't want to cater to the "also valid xml" camp, then feel free to just close this PR (and I will keep it as a custom change for my use, and make a mental note not to submit PRs for any similar changes I might discover in future).