### PR TITLE
Fix IndexedDB check in Firefox with disabled cookies

### DIFF
--- a/feature-detects/indexeddb.js
+++ b/feature-detects/indexeddb.js
@@ -16,7 +16,12 @@ define(['Modernizr', 'prefixed'], function(Modernizr, prefixed) {
   // - Firefox shipped moz_indexedDB before FF4b9, but since then has been mozIndexedDB
   // For speed, we don't test the legacy (and beta-only) indexedDB
 
-  var indexeddb = prefixed('indexedDB', window);
+  var indexeddb;
+  try {
+    indexeddb = prefixed('indexedDB', window);
+  } catch (e) {
+  }
+
   Modernizr.addTest('indexeddb', !!indexeddb);
 
   if (!!indexeddb) {

--- a/feature-detects/indexeddbblob.js
+++ b/feature-detects/indexeddbblob.js
@@ -15,11 +15,16 @@ define(['Modernizr', 'addTest', 'prefixed', 'test/indexeddb'], function(Moderniz
 
   Modernizr.addAsyncTest(function() {
     /* jshint -W053 */
-    var indexeddb = prefixed('indexedDB', window);
+    var indexeddb;
     var dbname = 'detect-blob-support';
     var supportsBlob = false;
     var request;
     var db;
+
+    try {
+      indexeddb = prefixed('indexedDB', window);
+    } catch (e) {
+    }
 
     if (!(Modernizr.indexeddb && Modernizr.indexeddb.deleteDatabase)) {
       return false;


### PR DESCRIPTION
This PR is a fix for issue https://github.com/Modernizr/Modernizr/issues/1825. According to it FF throws a Security Error during IndexedDB check if cookies are disabled.
Simply wrapped these checks in try/catch.