### PR TITLE
create a requireConfig instance per build call. fixes #1832

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -8,8 +8,8 @@ var inBrowser = typeof define == 'function' && typeof define.amd == 'object';
 var _extend = function(a, b) {
   for (var prop in b) {
     var supplied = b[prop];
-    if (typeof supplied === 'object') {
-      a[prop] == a[prop] || {};
+    if (Object.prototype.toString.call(supplied) === '[object Object]') {
+      a[prop] = a[prop] || {};
       _extend(a[prop], supplied);
     } else {
       a[prop] = b[prop];
@@ -17,8 +17,7 @@ var _extend = function(a, b) {
   }
 };
 
-
-var requireConfig = {
+var baseRequireConfig = {
   optimize: 'none',
   generateSourceMaps: false,
   optimizeCss: 'none',
@@ -41,26 +40,29 @@ var requireConfig = {
 
       contents = contents.replace(/\}\);\s*?$/, '');
 
-      if (!contents.match(/Modernizr\.add(Async)?Test\(/)) {
-        // remove last return statement and trailing })
-        contents = contents.replace(/return.*[^return]*$/, '');
-      }
-    } else if ((/require\([^\{]*?\{/).test(contents)) {
-      contents = contents.replace(/require[^\{]+\{/, '');
-      contents = contents.replace(/\}\);\s*$/, '');
+    if (!contents.match(/Modernizr\.add(Async)?Test\(/)) {
+      // remove last return statement and trailing })
+      contents = contents.replace(/return.*[^return]*$/, '');
     }
-
-    contents = contents.replace(/return addTest;/, '');
-
-    return contents;
+  } else if ((/require\([^\{]*?\{/).test(contents)) {
+    contents = contents.replace(/require[^\{]+\{/, '');
+    contents = contents.replace(/\}\);\s*$/, '');
   }
+
+  contents = contents.replace(/return addTest;/, '');
+
+  return contents;
+}
 };
 
 function build(generate, generateBanner, pkg) {
   return function build(config, cb) {
+    var requireConfig = {};
+    var banner;
     config = config || {};
     cb = cb || function noop() {};
-    var banner;
+
+    _extend(requireConfig, baseRequireConfig);
 
     requireConfig.rawText = {
       'modernizr-init': generate(config)
@@ -106,8 +108,8 @@ if (inBrowser) {
   var suppliedConfig = self._modernizrConfig;
   var metadataUrl = 'i/js/metadata.json';
   var packageUrl = 'i/js/modernizr-git/package.json';
-  requireConfig.baseUrl = '/i/js/modernizr-git/src';
-  requireConfig.paths = {
+  baseRequireConfig.baseUrl = '/i/js/modernizr-git/src';
+  baseRequireConfig.paths = {
     text: '/i/js/requirejs-plugins/lib/text',
     lib: '/i/js/modernizr-git/lib',
     json: '/i/js/requirejs-plugins/src/json',
@@ -118,7 +120,7 @@ if (inBrowser) {
   if (suppliedConfig) {
     metadataUrl = suppliedConfig.metadataUrl || metadataUrl;
     packageUrl = suppliedConfig.packageUrl || packageUrl;
-    _extend(requireConfig, suppliedConfig);
+    _extend(baseRequireConfig, suppliedConfig);
   }
 
   if (self._modernizrMetadata) {
@@ -135,15 +137,15 @@ if (inBrowser) {
   requirejs.define('metadata', [], function() {return metadata;});
   requirejs.define('package', function() {return pkg;});
 
-  requireConfig.baseUrl = __dirname + '/../src';
-  requireConfig.paths = {
+  baseRequireConfig.baseUrl = __dirname + '/../src';
+  baseRequireConfig.paths = {
     lodash: __dirname + '/../node_modules/lodash/index',
     test: __dirname + '/../feature-detects',
     lib: __dirname
   };
 }
 
-requirejs.config(requireConfig);
+requirejs.config(baseRequireConfig);
 
 if (inBrowser) {
   define('build', ['generate', 'lib/generate-banner', 'package'], build);


### PR DESCRIPTION
(pasting a [stackoverflow answer I wrote](http://stackoverflow.com/questions/34773567/very-unusual-scope-behaviour-when-i-call-modernizr-build-in-node-js/34779470#34779470), to not have to repeat myself) 

the build command is basically a large requirejs configuration function, all powered by a large config object. There is some basic things that are true, always, that are established at the top of the function
```js
{
  optimize: 'none',
  generateSourceMaps: false,
  optimizeCss: 'none',
  useStrict: true,
  include: ['modernizr-init'],
  fileExclusionRegExp: /^(.git|node_modules|modulizr|media|test)$/,
  wrap: {
    start: '\n;(function(window, document, undefined){',
    end: '})(window, document);'
  }
}
```

Then, since Modernizr works in both the browser and in node without changes, there needs to be a way for it to know if it should be loading its dependencies via the filesystem or via http. So we add some more options like basePath inside of a environment check

```js
if (inBrowser) {
  baseRequireConfig.baseUrl = '/i/js/modernizr-git/src';
} else {
  baseRequireConfig.baseUrl = __dirname + '/../src';  
}
```

At this point, the config object gets passed into requirejs.config, which wires up require and allows us to start calling build.

Finally, after all of that has been created, we have a build function that also ends up modifying the config object yet again for build specific settings (the actual detects in your build, regex to strip out some AMD crud, etc).

So here is a super simplified pseudocode version of what is ended up happening
```js
var config = {
  name: 'modernizr'
}

if (inBrowser) {
  config.env = 'browser';
} else {
  config.env = 'node';    
}

requirejs.config(config);

module.exports = function(config, callback) {
  config.out = function (output) {
    //code to strip out AMD ceremony, add classPrefix, version, etc

    callback(output)
  }

  requirejs.optimize(config)
}
```
spot the problem?

Since we are touching the .out method of the config object (whose scope is the entire module, and therefore its context is saved between build() calls) right before we run the asynchronous require.optimize function, the callback you were passing was rewriting the .out method every time build is called.