### PR TITLE
Fix testProps so it works on strict XHTML browsers

### DIFF
--- a/src/testProps.js
+++ b/src/testProps.js
@@ -32,8 +32,9 @@ define(['contains', 'mStyle', 'createElement', 'nativeTestProps', 'is', 'cssToDO
     // inside of an SVG element, in certain browsers, the `style` element is only
     // defined for valid tags. Therefore, if `modernizr` does not have one, we
     // fall back to a less used element and hope for the best.
-    var elems = ['modernizr', 'tspan'];
-    while (!mStyle.style) {
+    // for strict XHTML browsers the hardly used samp element is used
+    var elems = ['modernizr', 'tspan', 'samp'];
+    while (!mStyle.style && elems.length) {
       afterInit = true;
       mStyle.modElem = createElement(elems.shift());
       mStyle.style = mStyle.modElem.style;


### PR DESCRIPTION
Without `elems.length` it will be an endless loop if the browser can't create the element.
For strict XHTML browsers I added the hardly used element `samp` to test the style. Samsung SmartTVs from 2011 end up otherwise in the endless loop.