### PR TITLE
Fix websockets test for some Panasonic SmartTVs

### DIFF
--- a/feature-detects/websockets.js
+++ b/feature-detects/websockets.js
@@ -25,5 +25,9 @@
 }
 !*/
 define(['Modernizr'], function(Modernizr) {
-  Modernizr.addTest('websockets', 'WebSocket' in window && window.WebSocket.CLOSING === 2);
+  var supports = false;
+  try {
+    supports = 'WebSocket' in window && window.WebSocket.CLOSING === 2;
+  } catch (e) {}
+  Modernizr.addTest('websockets', supports);
 });


### PR DESCRIPTION
SmartTV browsers from 2012 Panasonic TVs crash otherwise.
It seems they didn't integrate `window.WebSocket` fully.