### PR TITLE
Increase mocha test timeout

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -176,7 +176,8 @@ module.exports = function(grunt) {
     mochaTest: {
       test: {
         options: {
-          reporter: 'dot'
+          reporter: 'dot',
+          timeout: 5000
         },
         src: ['<%= env.nodeTests%>']
       }

--- a/feature-detects/websockets.js
+++ b/feature-detects/websockets.js
@@ -25,5 +25,11 @@
 }
 !*/
 define(['Modernizr'], function(Modernizr) {
-  Modernizr.addTest('websockets', 'WebSocket' in window && window.WebSocket.CLOSING === 2);
+  var supports;
+  try {
+    supports = 'WebSocket' in window && window.WebSocket.CLOSING === 2;
+  } catch (e) {
+    supports = false;
+  }
+  Modernizr.addTest('websockets', supports);
 });


### PR DESCRIPTION
As the mocha tests on appveyor failed on many pull requests because of timeouts I increased the timeout for the `mochaTest` to 5 seconds.