### PR TITLE
Increase mochaTest timeout to 5s

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -176,7 +176,8 @@ module.exports = function(grunt) {
     mochaTest: {
       test: {
         options: {
-          reporter: 'dot'
+          reporter: 'dot',
+          timeout: 5000
         },
         src: ['<%= env.nodeTests%>']
       }


### PR DESCRIPTION
As the mocha tests on appveyor failed on many pull requests because of timeouts I increased the timeout for the mochaTest to 5 seconds.