### PR TITLE
Add test for the `URLSearchParams` API

### DIFF
--- a/feature-detects/url/urlsearchparams.js
+++ b/feature-detects/url/urlsearchparams.js
@@ -1,0 +1,27 @@
+/*!
+{
+  "async": false,
+  "authors": ["Cătălin Mariș"],
+  "name": "URLSearchParams API",
+  "notes": [
+    {
+      "name": "WHATWG specification",
+      "href": "https://url.spec.whatwg.org/#interface-urlsearchparams"
+    },
+    {
+      "name": "MDN documentation",
+      "href": "https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams"
+    }
+  ],
+  "property": "urlsearchparams",
+  "tags": ["querystring", "url"]
+}
+!*/
+
+/* DOC
+Detects support for an API that provides utility methods for working with the query string of a URL.
+*/
+
+define(['Modernizr'], function(Modernizr) {
+  Modernizr.addTest('urlsearchparams', 'URLSearchParams' in window);
+});

--- a/lib/config-all.json
+++ b/lib/config-all.json
@@ -252,6 +252,7 @@
     "url/bloburls",
     "url/data-uri",
     "url/parser",
+    "url/urlsearchparams",
     "userdata",
     "vibration",
     "video",


### PR DESCRIPTION
Links:

  * [Test page](http://jsbin.com/havelavopa/edit?output)
  * [WHATWG specification](https://url.spec.whatwg.org/#interface-urlsearchparams)
  * [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams)
