### PR TITLE
Update multi-column layout polyfill source

### DIFF
--- a/lib/polyfills.json
+++ b/lib/polyfills.json
@@ -95,8 +95,8 @@
   },
   "css3multicolumnjs": {
     "name": "css3-multi-column.js",
-    "authors": ["Cdric Savarese"],
-    "href": "http://www.csscripting.com/css-multi-column/",
+    "authors": ["Betley Whitehorne", "Cdric Savarese"],
+    "href": "https://github.com/BetleyWhitehorne/CSS3MultiColumn",
     "licenses": ["CC-GNU LGPL"],
     "notes": [
       "Supported Properties: column-count, column-width, column-gap, column-rule.",


### PR DESCRIPTION
The original 'css3-multi-column.js’ source referenced in `polyfills.json` appears to be offline. The [multi-column layout entry](https://github.com/Modernizr/Modernizr/wiki/HTML5-Cross-Browser-Polyfills#multi-column-layout-spec) on the HTML5 Cross Browser Polyfills wiki page references an updated version of the script.