### PR TITLE
Prefixed returns a bound constructor

### DIFF
--- a/feature-detects/webrtc/datachannel.js
+++ b/feature-detects/webrtc/datachannel.js
@@ -11,24 +11,17 @@
 /* DOC
 Detect for the RTCDataChannel API that allows for transfer data directly from one peer to another
 */
-define(['Modernizr', 'prefixed', 'domPrefixes', 'test/webrtc/peerconnection'], function(Modernizr, prefixed, domPrefixes) {
-
+define(['Modernizr', 'prefixed'], function(Modernizr, prefixed) {
   Modernizr.addTest('datachannel', function() {
-    if (!Modernizr.peerconnection) {
+    /* Return the property because otherwise we get a bound constructor. */
+    var prop = prefixed('RTCPeerConnection', window, false);
+    if (prop) {
+      var peerConnection = new window[prop]({
+        iceServers: [{url: 'stun:0'}],
+      });
+      return 'createDataChannel' in peerConnection;
+    } else {
       return false;
     }
-    for (var i = 0, l = domPrefixes.length; i < l; i++) {
-      var PeerConnectionConstructor = window[domPrefixes[i] + 'RTCPeerConnection'];
-
-      if (PeerConnectionConstructor) {
-        var peerConnection = new PeerConnectionConstructor({
-          'iceServers': [{'url': 'stun:0'}]
-        });
-
-        return 'createDataChannel' in peerConnection;
-      }
-
-    }
-    return false;
   });
 });

--- a/src/prefixed.js
+++ b/src/prefixed.js
@@ -35,7 +35,7 @@ define(['ModernizrProto', 'testPropsAll', 'cssToDOM', 'atRule'], function(Modern
    * ```js
    * var rAF = prefixed('requestAnimationFrame', window);
    *
-   * raf(function() {
+   * rAF(function() {
    *  renderFunction();
    * })
    * ```
@@ -46,7 +46,7 @@ define(['ModernizrProto', 'testPropsAll', 'cssToDOM', 'atRule'], function(Modern
    * ```js
    * var rAFProp = prefixed('requestAnimationFrame', window, false);
    *
-   * rafProp === 'WebkitRequestAnimationFrame' // in older webkit
+   * rAFProp === 'WebkitRequestAnimationFrame' // in older webkit
    * ```
    *
    * One common use case for prefixed is if you're trying to determine which transition


### PR DESCRIPTION
In testDOMProps.js, this doesn't always seem like the best thing to do,

```
// let's bind a function
if (is(item, 'function')) {
  // bind to obj unless overriden
  return fnBind(item, elem || obj);
}
```