### PR TITLE
Add video crossOrigin detect

### DIFF
--- a/feature-detects/video/crossorigin.js
+++ b/feature-detects/video/crossorigin.js
@@ -1,0 +1,18 @@
+/*!
+{
+  "name": "Video crossOrigin",
+  "property": "videocrossorigin",
+  "caniuse": "cors",
+  "authors": ["Florian Mailliet"],
+  "notes": [{
+    "name": "MDN documentation",
+    "href": "https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_settings_attributes"
+  }]
+}
+!*/
+/* DOC
+Detects support for the crossOrigin attribute on video tag
+*/
+define(['Modernizr', 'createElement'], function(Modernizr, createElement) {
+    Modernizr.addTest('videocrossorigin', 'crossOrigin' in createElement('video'));
+});

--- a/lib/config-all.json
+++ b/lib/config-all.json
@@ -244,6 +244,7 @@
     "test/elem/bdi",
     "test/img/crossorigin",
     "test/ligatures",
+    "test/video/crossorigin",
     "textarea/maxlength",
     "touchevents",
     "typed-arrays",


### PR DESCRIPTION
Detects support for the crossOrigin attribute on video tag
https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_settings_attributes