### PR TITLE
Improve videoautoplay detection

### DIFF
--- a/feature-detects/video/autoplay.js
+++ b/feature-detects/video/autoplay.js
@@ -15,14 +15,26 @@ define(['Modernizr', 'addTest', 'docElement', 'createElement', 'test/video'], fu
 
   Modernizr.addAsyncTest(function() {
     var timeout;
-    var waitTime = 300;
+    var waitTime = 200;
+    var retries = 5;
+    var currentTry = 0;
     var elem = createElement('video');
     var elemStyle = elem.style;
 
     function testAutoplay(arg) {
+      currentTry++;
       clearTimeout(timeout);
+
+      var result = arg && arg.type === 'playing' || elem.currentTime !== 0;
+
+      if (!result && currentTry < retries) {
+        //Detection can be flaky if the browser is slow, so lets retry in a little bit
+        timeout = setTimeout(testAutoplay, waitTime);
+        return;
+      }
+
       elem.removeEventListener('playing', testAutoplay, false);
-      addTest('videoautoplay', arg && arg.type === 'playing' || elem.currentTime !== 0);
+      addTest('videoautoplay', result);
       elem.parentNode.removeChild(elem);
     }
 


### PR DESCRIPTION
videoautoplay detection can be flaky. 300ms is a long enough wait for many sites, however there are plenty of other sites where that number is too low. Rather than simply increasing the wait, this commit tries to address the problem by increasing the wait time to 1000ms while re-checking every 200ms to ensure the quickest result. While this might not be enough for every situation, it should cover many more situations.