### PR TITLE
Remove duplicate img/jpeg2000 feature-detects entry

### DIFF
--- a/lib/config-all.json
+++ b/lib/config-all.json
@@ -181,7 +181,6 @@
     "iframe/srcdoc",
     "img/apng",
     "img/jpeg2000",
-    "img/jpeg2000",
     "img/jpegxr",
     "img/sizes",
     "img/srcset",


### PR DESCRIPTION
This PR removes a duplicate `img/jpeg2000` entry from the `feature-detects` array within the `lib/config-all.json` file.