### PR TITLE
attach body once before appending embed

### DIFF
--- a/feature-detects/flash.js
+++ b/feature-detects/flash.js
@@ -68,12 +68,12 @@ define(['Modernizr', 'createElement', 'docElement', 'addTest', 'getBody', 'isSVG
       embed.type = 'application/x-shockwave-flash';
 
       // Need to do this in the body (fake or otherwise) otherwise IE8 complains
+      attachBody(body);
       body.appendChild(embed);
 
       // Pan doesn't exist in the embed if its IE (its on the ActiveXObjeect)
       // so this check is for all other browsers.
       if (!('Pan' in embed) && !activex) {
-        attachBody(body);
         runTest('blocked', embed);
         removeFakeBody(body);
         return;
@@ -83,7 +83,6 @@ define(['Modernizr', 'createElement', 'docElement', 'addTest', 'getBody', 'isSVG
         // if we used a fake body originally, we need to restart this test, since
         // we haven't been attached to the DOM, and therefore none of the blockers
         // have had time to work.
-        attachBody(body);
         if (!docElement.contains(body)) {
           body = document.body || body;
           embed = createElement('embed');


### PR DESCRIPTION
When (fake) body is not attached before appending embed, detection will falsely report that blocking is active. The attachment only needs to be done once, as body will still be attached if previous check is inconclusive.
