### PR TITLE
remove grunt-suacelabs from the gh pages build to stop large file emails

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,9 @@ before_script:
   - if [ "${TRAVIS_NODE_VERSION}" = "0.12" ] && [ "${TRAVIS_REPO_SLUG}" = "modernizr-savage/Modernizr" ]; then export BROWSER_COVERAGE=true; fi
 after_success:
   - |
+      # Remove grunt-saucelabs since we don't use it on GH Pages, and it complains
+      # about large files in the repo from this module
+      npm uninstall --force grunt-saucelabs
       # Automatically update the content from the `gh-pages` branch
       $(npm bin)/update-branch --commands "grunt copy:gh-pages" \
                                --commit-message "Hey server, this content is for you! [skip ci]" \


### PR DESCRIPTION
should stop us from getting an email every time we merge a commit