### PR TITLE
Check for >=6 as chrome rounds down value when page is zoomed

### DIFF
--- a/feature-detects/css/generatedcontent.js
+++ b/feature-detects/css/generatedcontent.js
@@ -18,6 +18,7 @@
 !*/
 define(['Modernizr', 'testStyles'], function(Modernizr, testStyles) {
   testStyles('#modernizr{font:0/0 a}#modernizr:after{content:":)";visibility:hidden;font:7px/1 a}', function(node) {
-    Modernizr.addTest('generatedcontent', node.offsetHeight >= 7);
+    // See bug report on why this value is 6 crbug.com/608142
+    Modernizr.addTest('generatedcontent', node.offsetHeight >= 6);
   });
 });


### PR DESCRIPTION
Fixes #1935.

When zoomed >125% in chrome the injected div returns a rounded down height of 6. 

Need help to make this is still returning correct results for other browsers.