### PR TITLE
block direct usage of getComputedStyle, as it causes problems in certain sitautions in firefox

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -65,6 +65,7 @@
       "last"
     ],
     "dot-notation": "off",
-    "valid-jsdoc": "error"
+    "valid-jsdoc": "error",
+    "no-global-getComputedStyle": "error"
   }
 }

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -65,7 +65,10 @@ module.exports = function(grunt) {
         '!test/coverage/**/*.js',
         '!test/js/lib/**/*.js',
         '!src/html5shiv.js'
-      ]
+      ],
+      options: {
+        rulePaths: ['test/eslint/rules']
+      }
     },
     clean: {
       dist: [

--- a/feature-detects/css/vhunit.js
+++ b/feature-detects/css/vhunit.js
@@ -14,12 +14,10 @@
   }]
 }
 !*/
-define(['Modernizr', 'testStyles'], function(Modernizr, testStyles) {
+define(['Modernizr', 'testStyles', 'computedStyle'], function(Modernizr, testStyles, computedStyle) {
   testStyles('#modernizr { height: 50vh; }', function(elem) {
     var height = parseInt(window.innerHeight / 2, 10);
-    var compStyle = parseInt((window.getComputedStyle ?
-                              getComputedStyle(elem, null) :
-                              elem.currentStyle).height, 10);
+    var compStyle = parseInt(computedStyle(elem, null, 'height'), 10);
     Modernizr.addTest('cssvhunit', compStyle == height);
   });
 });

--- a/feature-detects/css/vmaxunit.js
+++ b/feature-detects/css/vmaxunit.js
@@ -14,7 +14,7 @@
   }]
 }
 !*/
-define(['Modernizr', 'docElement', 'testStyles', 'roundedEquals'], function(Modernizr, docElement, testStyles, roundedEquals) {
+define(['Modernizr', 'docElement', 'testStyles', 'roundedEquals', 'computedStyle'], function(Modernizr, docElement, testStyles, roundedEquals, computedStyle) {
   testStyles('#modernizr1{width: 50vmax}#modernizr2{width:50px;height:50px;overflow:scroll}#modernizr3{position:fixed;top:0;left:0;bottom:0;right:0}', function(node) {
     var elem = node.childNodes[2];
     var scroller = node.childNodes[1];
@@ -24,9 +24,7 @@ define(['Modernizr', 'docElement', 'testStyles', 'roundedEquals'], function(Mode
     var one_vw = fullSizeElem.clientWidth / 100;
     var one_vh = fullSizeElem.clientHeight / 100;
     var expectedWidth = parseInt(Math.max(one_vw, one_vh) * 50, 10);
-    var compWidth = parseInt((window.getComputedStyle ?
-                          getComputedStyle(elem, null) :
-                          elem.currentStyle).width, 10);
+    var compWidth = parseInt(computedStyle(elem, null, 'width'), 10);
 
     Modernizr.addTest('cssvmaxunit', roundedEquals(expectedWidth, compWidth) || roundedEquals(expectedWidth, compWidth - scrollbarWidth));
   }, 3);

--- a/feature-detects/css/vminunit.js
+++ b/feature-detects/css/vminunit.js
@@ -14,7 +14,7 @@
   }]
 }
 !*/
-define(['Modernizr', 'docElement', 'testStyles', 'roundedEquals'], function(Modernizr, docElement, testStyles, roundedEquals) {
+define(['Modernizr', 'docElement', 'testStyles', 'roundedEquals', 'computedStyle'], function(Modernizr, docElement, testStyles, roundedEquals, computedStyle) {
   testStyles('#modernizr1{width: 50vm;width:50vmin}#modernizr2{width:50px;height:50px;overflow:scroll}#modernizr3{position:fixed;top:0;left:0;bottom:0;right:0}', function(node) {
     var elem = node.childNodes[2];
     var scroller = node.childNodes[1];
@@ -24,9 +24,7 @@ define(['Modernizr', 'docElement', 'testStyles', 'roundedEquals'], function(Mode
     var one_vw = fullSizeElem.clientWidth / 100;
     var one_vh = fullSizeElem.clientHeight / 100;
     var expectedWidth = parseInt(Math.min(one_vw, one_vh) * 50, 10);
-    var compWidth = parseInt((window.getComputedStyle ?
-                          getComputedStyle(elem, null) :
-                          elem.currentStyle).width, 10);
+    var compWidth = parseInt(computedStyle(elem, null, 'width'), 10);
 
     Modernizr.addTest('cssvminunit', roundedEquals(expectedWidth, compWidth) || roundedEquals(expectedWidth, compWidth - scrollbarWidth));
   }, 3);

--- a/feature-detects/css/vwunit.js
+++ b/feature-detects/css/vwunit.js
@@ -14,12 +14,10 @@
   }]
 }
 !*/
-define(['Modernizr', 'testStyles'], function(Modernizr, testStyles) {
+define(['Modernizr', 'testStyles', 'computedStyle'], function(Modernizr, testStyles, computedStyle) {
   testStyles('#modernizr { width: 50vw; }', function(elem) {
     var width = parseInt(window.innerWidth / 2, 10);
-    var compStyle = parseInt((window.getComputedStyle ?
-                              getComputedStyle(elem, null) :
-                              elem.currentStyle).width, 10);
+    var compStyle = parseInt(computedStyle(elem, null, 'width'), 10);
 
     Modernizr.addTest('cssvwunit', compStyle == width);
   });

--- a/feature-detects/elem/bdi.js
+++ b/feature-detects/elem/bdi.js
@@ -11,7 +11,7 @@
 /* DOC
 Detect support for the bdi element, a way to have text that is isolated from its possibly bidirectional surroundings
 */
-define(['Modernizr', 'createElement', 'docElement'], function(Modernizr, createElement, docElement) {
+define(['Modernizr', 'createElement', 'docElement', 'computedStyle'], function(Modernizr, createElement, docElement, computedStyle) {
   Modernizr.addTest('bdi', function() {
     var div = createElement('div');
     var bdi = createElement('bdi');
@@ -21,9 +21,7 @@ define(['Modernizr', 'createElement', 'docElement'], function(Modernizr, createE
 
     docElement.appendChild(div);
 
-    var supports = ((window.getComputedStyle ?
-          getComputedStyle(bdi, null) :
-          bdi.currentStyle).direction === 'rtl');
+    var supports = computedStyle(bdi, null, 'direction') === 'rtl';
 
     docElement.removeChild(div);
 

--- a/src/computedStyle.js
+++ b/src/computedStyle.js
@@ -1,0 +1,39 @@
+define(function() {
+
+  /**
+   * wrapper around getComputedStyle, to fix issues with Firefox returning null when
+   * called inside of a hidden iframe
+   *
+   * @access private
+   * @function computedStyle
+   * @param {HTMLElement|SVGElement} - The element we want to find the computed styles of
+   * @param {string|null} [pseudoSelector]- An optional pseudo element selector (e.g. :before), of null if none
+   * @returns {CSSStyleDeclaration}
+   */
+
+  function computedStyle(elem, pseudo, prop) {
+    var result;
+
+    if ('getComputedStyle' in window) {
+      result = getComputedStyle.call(window, elem, pseudo);
+      var console = window.console;
+
+      if (result !== null) {
+        if (prop) {
+          result = result.getPropertyValue(prop);
+        }
+      } else {
+        if (console) {
+          var method = console.error ? 'error' : 'log';
+          console[method].call(console, 'getComputedStyle returning null, its possible modernizr test results are inaccurate');
+        }
+      }
+    } else {
+      result = !pseudo && elem.currentStyle && elem.currentStyle[prop];
+    }
+
+    return result;
+  }
+
+  return computedStyle;
+});

--- a/src/nativeTestProps.js
+++ b/src/nativeTestProps.js
@@ -1,4 +1,4 @@
-define(['injectElementWithStyles', 'domToCSS'], function(injectElementWithStyles, domToCSS) {
+define(['injectElementWithStyles', 'domToCSS', 'computedStyle'], function(injectElementWithStyles, domToCSS, computedStyle) {
   /**
    * nativeTestProps allows for us to use native feature detection functionality if available.
    * some prefixed form, or false, in the case of an unsupported rule
@@ -33,7 +33,7 @@ define(['injectElementWithStyles', 'domToCSS'], function(injectElementWithStyles
       }
       conditionText = conditionText.join(' or ');
       return injectElementWithStyles('@supports (' + conditionText + ') { #modernizr { position: absolute; } }', function(node) {
-        return getComputedStyle(node, null).position == 'absolute';
+        return computedStyle(node, null, 'position') == 'absolute';
       });
     }
     return undefined;

--- a/test/eslint/rules/no-global-getComputedStyle.js
+++ b/test/eslint/rules/no-global-getComputedStyle.js
@@ -1,0 +1,29 @@
+/**
+ * @fileoverview Rule to disallow the use of getComputedStyle
+ * @author Patrick Kettner
+ */
+
+'use strict';
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = {
+  meta: {
+    docs: {
+      description: 'disallow use of getComputedStyle without checking if it is null first',
+      category: 'Possible Errors',
+      recommended: false
+    }
+  },
+  create: function(context) {
+    return {
+      CallExpression: function (node) {
+        if (node.callee.name === 'getComputedStyle') {
+          context.report(node, 'Do not use getComputedStyle, import and use the "computedStyle" helper');
+        }
+      }
+    };
+  }
+};


### PR DESCRIPTION
fixes #1443

(well, supersedes it. but supersedes #1443 doesn't autoclose the issue)