### PR TITLE
Fix "elem.parentNode is null" with Flashblock

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -46,7 +46,7 @@
       "error",
       "single"
     ],
-    "curly": "off",
+    "curly": "error",
     "wrap-iife": "off",
     "no-caller": "error",
     "no-cond-assign": [

--- a/feature-detects/video/autoplay.js
+++ b/feature-detects/video/autoplay.js
@@ -35,7 +35,12 @@ define(['Modernizr', 'addTest', 'docElement', 'createElement', 'test/video'], fu
 
       elem.removeEventListener('playing', testAutoplay, false);
       addTest('videoautoplay', result);
-      elem.parentNode.removeChild(elem);
+
+      // Cleanup, but don't assume elem is still in the page -
+      // an extension (eg Flashblock) may already have removed it.
+      if (elem.parentNode) {
+        elem.parentNode.removeChild(elem);
+      }
     }
 
     //skip the test if video itself, or the autoplay


### PR DESCRIPTION
The Flashblock Firefox extension seems to take the questionable approach of removing `video` nodes immediately as they're inserted into the page, which causes an "elem.parentNode is null" error.  What do you think to this fix?