### PR TITLE
Adds support for autoplay on iOS 10

### DIFF
--- a/feature-detects/video/autoplay.js
+++ b/feature-detects/video/autoplay.js
@@ -68,6 +68,7 @@ define(['Modernizr', 'addTest', 'docElement', 'createElement', 'test/video'], fu
     }
 
     elem.setAttribute('autoplay', '');
+    elem.setAttribute('playsinline', '');
     elem.style.cssText = 'display:none';
     docElement.appendChild(elem);
     // wait for the next tick to add the listener, otherwise the element may


### PR DESCRIPTION
In iOS 10, the [WebKit team have relaxed their policies on autoplaying
video](https://webkit.org/blog/6784/new-video-policies-for-ios/).

Video can now autoplay on iOS if it does not featured an audio track,
or is muted. And on iPhone devices, will autoplay inline with the
`playsinline` attribute.

This adds the `playsinline` attribute to the videoautoplay test.

This may be better suited to it’s own test, as it could result in in an autoplaying video, without the addition of the attribute required to make the video autoplay on some devices.