### PR TITLE
Repair detect regions

### DIFF
--- a/feature-detects/css/regions.js
+++ b/feature-detects/css/regions.js
@@ -12,7 +12,7 @@
   }]
 }
 !*/
-define(['Modernizr', 'createElement', 'docElement', 'isSVG'], function(Modernizr, createElement, docElement, isSVG) {
+define(['Modernizr', 'createElement', 'docElement', 'isSVG', 'prefixed'], function(Modernizr, createElement, docElement, isSVG, prefixed) {
   // We start with a CSS parser test then we check page geometry to see if it's affected by regions
   // Later we might be able to retire the second part, as WebKit builds with the false positives die out
 
@@ -26,8 +26,8 @@ define(['Modernizr', 'createElement', 'docElement', 'isSVG'], function(Modernizr
 
     /* Get the 'flowFrom' property name available in the browser. Either default or vendor prefixed.
        If the property name can't be found we'll get Boolean 'false' and fail quickly */
-    var flowFromProperty = Modernizr.prefixed('flowFrom');
-    var flowIntoProperty = Modernizr.prefixed('flowInto');
+    var flowFromProperty = prefixed('flowFrom');
+    var flowIntoProperty = prefixed('flowInto');
     var result = false;
 
     if (!flowFromProperty || !flowIntoProperty) {


### PR DESCRIPTION
Detect regions is broken badly. It invokes an undefined property
causing failure to run _any_ detects. The cause is a missing
dependency.

Fixes this by including the missing dependency. Also updates the
references to the free variable style, the correct pattern
in the AMD module architecture.

Fixes #2079
