### PR TITLE
Fix localizednumber test. Overwrite the existing value rather than appending text

### DIFF
--- a/feature-detects/forms/inputnumber-l10n.js
+++ b/feature-detects/forms/inputnumber-l10n.js
@@ -36,6 +36,7 @@ define(['Modernizr', 'createElement', 'docElement', 'getBody', 'test/inputtypes'
     root.appendChild(el);
     input.focus();
     try {
+      document.execCommand('SelectAll', false); // Overwrite current input value, rather than appending text
       document.execCommand('InsertText', false, '1,1');
     } catch (e) { // prevent warnings in IE
     }


### PR DESCRIPTION
This test was always returning false even when the browser and OS were in a Spanish locale. 

You can see this for yourself by changing Chrome's default language to Spanish, and loading the [Modernizr test page](http://modernizr.github.io/Modernizr/test/).

The initial value of the input box is `1,0` - when we `document.execCommand('InsertText', false, '1,1')` it was prepending to the start of the input value resulting in `111,0`.

By executing `document.execCommand('SelectAll', false)` first, we ensure we overwrite the current input value, and the test passes.
