### PR TITLE
Remove blacklisting of old Android from fontface.js. Closes #1851

### DIFF
--- a/feature-detects/css/fontface.js
+++ b/feature-detects/css/fontface.js
@@ -29,11 +29,9 @@
 define(['Modernizr', 'testStyles'], function(Modernizr, testStyles) {
   var blacklist = (function() {
     var ua = navigator.userAgent;
-    var wkvers = ua.match(/applewebkit\/([0-9]+)/gi) && parseFloat(RegExp.$1);
     var webos = ua.match(/w(eb)?osbrowser/gi);
     var wppre8 = ua.match(/windows phone/gi) && ua.match(/iemobile\/([0-9])+/gi) && parseFloat(RegExp.$1) >= 9;
-    var oldandroid = wkvers < 533 && ua.match(/android/gi);
-    return webos || oldandroid || wppre8;
+    return webos || wppre8;
   }());
   if (blacklist) {
     Modernizr.addTest('fontface', false);


### PR DESCRIPTION
Usage of pre-2.2 Android versions has fallen below 0.1% [(source)](https://developer.android.com/about/dashboards/index.html), so @font-face is practically guaranteed to work on Android. The blacklisting was catching all versions of Firefox for Android.
