### PR TITLE
Feature detect: CSS Transforms Level 2. Fixes #1625.

### DIFF
--- a/feature-detects/css/transformslevel2.js
+++ b/feature-detects/css/transformslevel2.js
@@ -1,0 +1,17 @@
+/*!
+{
+  "name": "CSS Transforms Level 2",
+  "property": "csstransformslevel2",
+  "authors": ["rupl"],
+  "tags": ["css"],
+  "notes": [{
+    "name": "CSSWG Draft Spec",
+    "href": "https://drafts.csswg.org/css-transforms-2/"
+  }]
+}
+!*/
+define(['Modernizr', 'testAllProps'], function(Modernizr, testAllProps) {
+  Modernizr.addTest('csstransformslevel2', function() {
+    return testAllProps('translate', '45px', true);
+  });
+});

--- a/lib/config-all.json
+++ b/lib/config-all.json
@@ -103,6 +103,7 @@
     "css/textalignlast",
     "css/textshadow",
     "css/transforms",
+    "css/transformslevel2",
     "css/transforms3d",
     "css/transformstylepreserve3d",
     "css/transitions",


### PR DESCRIPTION
The shorthand transform properties landed in Chrome 53 behind the experimental flag.

There's no caniuse entry yet, but I [submitted a test for inclusion](http://codepen.io/rupl/pen/kkpYyG).

Spec: https://drafts.csswg.org/css-transforms-2/
