### PR TITLE
Fix for input-formtarget detection

### DIFF
--- a/feature-detects/input/formtarget.js
+++ b/feature-detects/input/formtarget.js
@@ -19,5 +19,5 @@
 Detect support for the formtarget attribute on form inputs, which overrides the form target attribute
 */
 define(['Modernizr', 'createElement'], function(Modernizr, createElement) {
-  Modernizr.addTest('inputformtarget', !!('formtarget' in createElement('input')), {aliases: ['input-formtarget']});
+  Modernizr.addTest('inputformtarget', !!('formTarget' in createElement('input')), {aliases: ['input-formtarget']});
 });


### PR DESCRIPTION
Fix for input-formtarget detection. "T" in target must be uppercase, like formEnctype and formAction already are.