### PR TITLE
Improve emoji detection (Fix #1688)

### DIFF
--- a/feature-detects/emoji.js
+++ b/feature-detects/emoji.js
@@ -12,14 +12,13 @@ define(['Modernizr', 'createElement', 'test/canvastext'], function(Modernizr, cr
     if (!Modernizr.canvastext) {
       return false;
     }
-    var pixelRatio = window.devicePixelRatio || 1;
-    var offset = 12 * pixelRatio;
     var node = createElement('canvas');
     var ctx = node.getContext('2d');
     ctx.fillStyle = '#f00';
-    ctx.textBaseline = 'top';
+    ctx.textBaseline = 'middle';
+    ctx.textAlign = 'center';
     ctx.font = '32px Arial';
     ctx.fillText('\ud83d\udc28', 0, 0); // U+1F428 KOALA
-    return ctx.getImageData(offset, offset, 1, 1).data[0] !== 0;
+    return ctx.getImageData(0, 0, 1, 1).data[0] !== 0;
   });
 });


### PR DESCRIPTION
The emoji detection was not always working because the test pixel was outside of the emoji.

I used @maximeg code from #1688 to perform some tests and see where the test pixel was landing:

```
<body>
  <script>
    var docElement = document.documentElement;
    var isSVG = docElement.nodeName.toLowerCase() === 'svg';
    function createElement() {
      if (typeof document.createElement !== 'function') {
        return document.createElement(arguments[0]);
      } else if (isSVG) {
        return document.createElementNS.call(document, 'http://www.w3.org/2000/svg', arguments[0]);
      } else {
        return document.createElement.apply(document, arguments);
      }
    }

    var pixelRatio = window.devicePixelRatio || 1;
    var offset = 12 * pixelRatio;
    var node = createElement('canvas');
    var ctx = node.getContext('2d');

    ctx.fillStyle = '#f00';
    ctx.textBaseline = 'top';
    ctx.font = '32px Arial';
    ctx.fillText('\ud83d\udc28', 0, 0);

    pixel = ctx.getImageData(offset, offset, 1, 1);
    pixel.data[0] = 0;
    pixel.data[1] = 0;
    pixel.data[2] = 255;
    pixel.data[3] = 255;
    ctx.putImageData(pixel, offset, offset);

    var imageDataUri = node.toDataURL('image/png');
    var img = createElement('img');
    img.src=imageDataUri;
    document.body.appendChild(img);
  </script>
</body>
```

Here's what I get on Android 6.0.1:
![screenshot_20170309-164630_01](https://cloud.githubusercontent.com/assets/2705796/23758236/64b45c2c-04e9-11e7-880e-fc8b2e8b849f.png)

This PR implements @Paul-Browne solution and centers the emoji to get rid of the code related to the pixel ratio. Thereby we can use the top-left pixel (actually the central emoji's pixel) which is more likely to be modified.
Here's what we get with this implementation (still on Android 6.0.1):
![screenshot_20170309-164636_01](https://cloud.githubusercontent.com/assets/2705796/23758415/ffa3f4fe-04e9-11e7-9ad7-13c7eeecd65e.png)

|   |Previous code|New code|
|---|---|---|
|Chrome on Android 6.0.1|false :x: |true :white_check_mark:|
|Chrome on Ubuntu 14.04 (the koala emoji is not available)|false :white_check_mark:|false :white_check_mark:|
|Chrome on Ubuntu 16.04 (the koala emoji is available)|true :white_check_mark:|true :white_check_mark:|
|Chrome on macOS Sierra (10.12.3)|true :white_check_mark:|true :white_check_mark:|
|Safari on iPad mini 2 (iOS 10.1.1)|true :white_check_mark:|true :white_check_mark:|
|Safari on iPhone SE (iOS 10.2.1)|true :white_check_mark:|true :white_check_mark:|
|Safari on iPhone 6 (iOS 10.1.1)|true :white_check_mark:|true :white_check_mark:|