### PR TITLE
Fix rgba/hsla false negative in browsers that alias them to rgb/hsl

### DIFF
--- a/feature-detects/css/hsla.js
+++ b/feature-detects/css/hsla.js
@@ -10,6 +10,6 @@ define(['Modernizr', 'createElement', 'contains'], function(Modernizr, createEle
   Modernizr.addTest('hsla', function() {
     var style = createElement('a').style;
     style.cssText = 'background-color:hsla(120,40%,100%,.5)';
-    return contains(style.backgroundColor, 'rgba') || contains(style.backgroundColor, 'hsla');
+    return contains(style.backgroundColor, 'rgb') || contains(style.backgroundColor, 'hsl');
   });
 });

--- a/feature-detects/css/rgba.js
+++ b/feature-detects/css/rgba.js
@@ -15,6 +15,6 @@ define(['Modernizr', 'createElement'], function(Modernizr, createElement) {
     var style = createElement('a').style;
     style.cssText = 'background-color:rgba(150,255,150,.5)';
 
-    return ('' + style.backgroundColor).indexOf('rgba') > -1;
+    return ('' + style.backgroundColor).indexOf('rgb') > -1;
   });
 });


### PR DESCRIPTION
Fixes incompatibility with the newly-released Firefox 52. I decided to do nothing about the pre-existing inconsistent (non-)use of `contains`.