### PR TITLE
Add CSS Grid test for old & new syntaxes

### DIFF
--- a/feature-detects/css/cssgrid.js
+++ b/feature-detects/css/cssgrid.js
@@ -2,18 +2,19 @@
 {
   "name": "CSS Grid (old & new)",
   "property": ["cssgrid", "cssgridlegacy"],
+  "authors": ["Faruk Ates"],
   "tags": ["css"],
   "notes": [{
     "name": "The new, standardized CSS Grid",
     "href": "https://www.w3.org/TR/css3-grid-layout/"
   }, {
-    "name": "The _old_ CSS Grid",
+    "name": "The _old_ CSS Grid (legacy)",
     "href": "https://www.w3.org/TR/2011/WD-css3-grid-layout-20110407/"
-  }],
-  "warnings": ["`grid-columns` is only in the old syntax, `grid-column` exists in both and so `grid-template-rows` is used for the new syntax."]
+  }]
 }
 !*/
 define(['Modernizr', 'testAllProps'], function(Modernizr, testAllProps) {
+  // `grid-columns` is only in the old syntax, `grid-column` exists in both and so `grid-template-rows` is used for the new syntax.
   Modernizr.addTest('cssgridlegacy', testAllProps('grid-columns', '10px', true));
   Modernizr.addTest('cssgrid', testAllProps('grid-template-rows', 'none', true));
 });

--- a/feature-detects/css/cssgrid.js
+++ b/feature-detects/css/cssgrid.js
@@ -1,0 +1,19 @@
+/*!
+{
+  "name": "CSS Grid (old & new)",
+  "property": ["cssgrid", "cssgridlegacy"],
+  "tags": ["css"],
+  "notes": [{
+    "name": "The new, standardized CSS Grid",
+    "href": "https://www.w3.org/TR/css3-grid-layout/"
+  }, {
+    "name": "The _old_ CSS Grid",
+    "href": "https://www.w3.org/TR/2011/WD-css3-grid-layout-20110407/"
+  }]
+  "warnings": ["`grid-columns` is only in the old syntax, `grid-column` exists in both and so `grid-template-rows` is used for the new syntax."]
+}
+!*/
+define(['Modernizr', 'testAllProps'], function(Modernizr, testAllProps) {
+  Modernizr.addTest('cssgridlegacy', testAllProps('grid-columns', '10px', true));
+  Modernizr.addTest('cssgrid', testAllProps('grid-template-rows', 'none', true));
+});

--- a/feature-detects/css/cssgrid.js
+++ b/feature-detects/css/cssgrid.js
@@ -9,7 +9,7 @@
   }, {
     "name": "The _old_ CSS Grid",
     "href": "https://www.w3.org/TR/2011/WD-css3-grid-layout-20110407/"
-  }]
+  }],
   "warnings": ["`grid-columns` is only in the old syntax, `grid-column` exists in both and so `grid-template-rows` is used for the new syntax."]
 }
 !*/

--- a/lib/config-all.json
+++ b/lib/config-all.json
@@ -59,6 +59,7 @@
     "css/checked",
     "css/chunit",
     "css/columns",
+    "css/cssgrid",
     "css/cubicbezierrange",
     "css/displayrunin",
     "css/displaytable",


### PR DESCRIPTION
While CSS Grid gets rolled out, it’s useful to have a way to target
IE11 which does not support @supports() but does support old CSS Grid
syntax, as does the new IE14.