### PR TITLE
Improve name of hairline test

### DIFF
--- a/feature-detects/css/hairline.js
+++ b/feature-detects/css/hairline.js
@@ -1,5 +1,5 @@
 /*! {
-  "name": "hairline",
+  "name": "CSS Hairline",
   "property": "hairline",
   "tags": ["css"],
   "authors": ["strarsis"],


### PR DESCRIPTION
Improve the name of hairline test ('hairline' -> 'CSS Hairline') -
 named liked the other Modernizr CSS tests.