### PR TITLE
Pointer Events: remove hand.js polyfill, expand notes/description

### DIFF
--- a/feature-detects/pointerevents.js
+++ b/feature-detects/pointerevents.js
@@ -6,16 +6,21 @@
   "authors": ["Stu Cox"],
   "notes": [
     {
-      "name": "W3C spec",
+      "name": "W3C Pointer Events",
       "href": "https://www.w3.org/TR/pointerevents/"
-    }
-  ],
+    },{
+      "name": "W3C Pointer Events Level 2"
+      "href": "https://www.w3.org/TR/pointerevents2/"
+    },{
+    "name": "MDN documentation",
+    "href": "https://developer.mozilla.org/en-US/docs/Web/API/PointerEvent"
+  }],
   "warnings": ["This property name now refers to W3C DOM PointerEvents: https://github.com/Modernizr/Modernizr/issues/548#issuecomment-12812099"],
-  "polyfills": ["handjs","pep"]
+  "polyfills": ["pep"]
 }
 !*/
 /* DOC
-Detects support for the DOM Pointer Events API, which provides a unified event interface for pointing input devices, as implemented in IE10+.
+Detects support for the DOM Pointer Events API, which provides a unified event interface for pointing input devices, as implemented in IE10+, Edge and Blink.
 */
 define(['Modernizr', 'domPrefixes', 'hasEvent'], function(Modernizr, domPrefixes, hasEvent) {
   // **Test name hijacked!**

--- a/lib/polyfills.json
+++ b/lib/polyfills.json
@@ -414,13 +414,6 @@
     "href": "https://gist.github.com/paulirish/5438650",
     "licenses": ["MIT"]
   },
-  "handjs": {
-    "name": "Hand.js",
-    "authors": ["DeltaKosh"],
-    "href": "http://handjs.codeplex.com/",
-    "notes": ["Implements the Pointer Events API"],
-    "licenses": ["Apache2"]
-  },
   "easyxdm": {
     "name": "easyXDM",
     "authors": ["Sean Kinsey"],


### PR DESCRIPTION
* hand.js is outdated (not modified since 2014, and codeplex is now
obsolete)
* pointer to MDN documentation and PE Level 2
* expand description with regards to browser support (Gecko is currently
experimental)