### PR TITLE
Downgrades npm to 4.3.0 on appveyor.yml to fix the builds on node 0.10 and 0.12

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,7 @@ environment:
 # Get the latest stable version of Node 0.STABLE.latest
 install:
   - ps: Update-NodeJsInstallation (Get-NodeJsLatestBuild $env:nodejs_version)
-  - npm install -g npm@5.0.4
+  - npm install -g npm@4.3.0
   - set PATH=%APPDATA%\npm;%PATH%
   - npm install
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,7 @@ environment:
 # Get the latest stable version of Node 0.STABLE.latest
 install:
   - ps: Update-NodeJsInstallation (Get-NodeJsLatestBuild $env:nodejs_version)
-  - npm install -g npm@latest
+  - npm install -g npm@5.0.4
   - set PATH=%APPDATA%\npm;%PATH%
   - npm install
 


### PR DESCRIPTION
# What does this PR do:

* Downgrades npm to 4.3.0 since newer versions stop supporting node versions such as 0.10 and 0.12.

One question though, does the project still needs to support these old versions of node?