### PR TITLE
Add test for CSS custom properties.

### DIFF
--- a/feature-detects/css/custom-properties.js
+++ b/feature-detects/css/custom-properties.js
@@ -1,0 +1,19 @@
+/*!
+{
+  "name": "CSS Custom Properties",
+  "property": "csscustomproperties",
+  "caniuse": "css-variables",
+  "authors": ["Kruithne"],
+  "tags": ["css"],
+  "notes": [{
+    "name": "MDN",
+    "href": "https://developer.mozilla.org/en-US/docs/Web/CSS/--*"
+  }, {
+    "name": "WC3",
+    "href": "https://www.w3.org/TR/css-variables/"
+  }]
+}
+!*/
+define(['Modernizr', 'testAllProps'], function(Modernizr, testAllProps) {
+  Modernizr.addTest('csscustomproperties', testAllProps('--a', 0));
+});


### PR DESCRIPTION
MDN ref: https://developer.mozilla.org/en-US/docs/Web/CSS/--*
WC3 ref: https://www.w3.org/TR/css-variables/

Apologies if this is already supported somewhere, I checked around but could find no mention of this feature reference as neither custom CSS properties or variables.