### PR TITLE
Add Font Display detection

### DIFF
--- a/feature-detects/css/fontdisplay.js
+++ b/feature-detects/css/fontdisplay.js
@@ -1,0 +1,30 @@
+/*!
+{
+  "name": "Font Display",
+  "property": "fontdisplay",
+  "notes": [{
+    "name": "W3C CSS Fonts Module Level 4",
+    "href": "https://drafts.csswg.org/css-fonts-4/#font-display-desc"
+  },{
+    "name": "`font-display` for the masses",
+    "href": "https://css-tricks.com/font-display-masses/"
+  }]
+}
+!*/
+/* DOC
+Detects support for the `font-display` descriptor, which defines how font files are loaded and displayed by the browser.
+*/
+define(['Modernizr'], function(Modernizr) {
+  Modernizr.addTest('fontdisplay', function() {
+    try {
+      var e = document.createElement('style');
+      e.textContent = '@font-face { font-display: swap; }';
+      document.documentElement.appendChild(e);
+      var isSupported = e.sheet.cssRules[0].cssText.indexOf('font-display') != -1;
+      e.remove();
+      return isSupported;
+    } catch (e) {
+      return false;
+    }
+  });
+});

--- a/lib/config-all.json
+++ b/lib/config-all.json
@@ -71,6 +71,7 @@
     "css/flexboxlegacy",
     "css/flexboxtweener",
     "css/flexwrap",
+    "css/fontdisplay",
     "css/fontface",
     "css/generatedcontent",
     "css/gradients",


### PR DESCRIPTION
Adding detection as [requested by @paulirish](https://twitter.com/paul_irish/status/920073974654033920). Credits go to [@heyam](https://twitter.com/heycam) for the [detection script itself](https://bugzilla.mozilla.org/show_bug.cgi?id=1296373#c4) and [vijayaraghavanramanan](https://github.com/vijayaraghavanramanan) for raising the issue in the first place.

I added a [demo of the `font-display` feature detection](http://plnkr.co/edit/OoxwMS?p=preview) with a Modernizr build containing the new detection.

I was unclear if and how I should [use the `testStyles` helper like done in `css/fontface.js`](https://github.com/Modernizr/Modernizr/blob/master/feature-detects/css/fontface.js#L39-L45). I'm happy to make changes if needed.