### PR TITLE
Use `roundedEquals` to test vw and vh units

### DIFF
--- a/feature-detects/css/vhunit.js
+++ b/feature-detects/css/vhunit.js
@@ -14,10 +14,11 @@
   }]
 }
 !*/
-define(['Modernizr', 'testStyles', 'computedStyle'], function(Modernizr, testStyles, computedStyle) {
+define(['Modernizr', 'testStyles', 'computedStyle', 'roundedEquals'], function(Modernizr, testStyles, computedStyle, roundedEquals) {
   testStyles('#modernizr { height: 50vh; }', function(elem) {
     var height = parseInt(window.innerHeight / 2, 10);
     var compStyle = parseInt(computedStyle(elem, null, 'height'), 10);
-    Modernizr.addTest('cssvhunit', compStyle == height);
+
+    Modernizr.addTest('cssvhunit', roundedEquals(compStyle, height));
   });
 });

--- a/feature-detects/css/vwunit.js
+++ b/feature-detects/css/vwunit.js
@@ -14,11 +14,11 @@
   }]
 }
 !*/
-define(['Modernizr', 'testStyles', 'computedStyle'], function(Modernizr, testStyles, computedStyle) {
+define(['Modernizr', 'testStyles', 'computedStyle', 'roundedEquals'], function(Modernizr, testStyles, computedStyle, roundedEquals) {
   testStyles('#modernizr { width: 50vw; }', function(elem) {
     var width = parseInt(window.innerWidth / 2, 10);
     var compStyle = parseInt(computedStyle(elem, null, 'width'), 10);
 
-    Modernizr.addTest('cssvwunit', compStyle == width);
+    Modernizr.addTest('cssvwunit', roundedEquals(compStyle, width));
   });
 });


### PR DESCRIPTION
This PR is intended to replace #1570, which has gone very stale and isn't automatically mergeable. From that PR:

> This fixes #1569 by assuming window.innerHeight, window.innerWidth may be rounded normally, floored, ceiled, etc by the browser. This test still fails in Safari when you're zoomed in, but it did before, and I have not been able to find away around it since Safari's vw/vh units stay the same as you zoom in.

See that thread for further discussion.