### PR TITLE
Feature detect for text-decoration styling

### DIFF
--- a/feature-detects/css/textdecorationstyling.js
+++ b/feature-detects/css/textdecorationstyling.js
@@ -1,0 +1,19 @@
+/*!
+{
+  "name": "CSS text-decoration styling",
+  "property": "textdecorationstyling",
+  "caniuse": "text-decoration styling",
+  "tags": ["css"],
+  "notes": [{
+    "name" : "w3c explanation of individual text-decoration properties",
+    "href": "https://www.w3.org/TR/css-text-decor-3/#line-decoration"
+  }]
+}
+!*/
+/* DOC
+Detects whether or not text-decoration styling 
+ (i.e. defining color, position and type of text decorations) is possible.
+*/
+define(['Modernizr', 'testAllProps'], function(Modernizr, testAllProps) {
+  Modernizr.addTest('textdecorationstyling', testAllProps('text-decoration-color'));
+});

--- a/lib/config-all.json
+++ b/lib/config-all.json
@@ -103,6 +103,7 @@
     "css/supports",
     "css/target",
     "css/textalignlast",
+    "css/textdecorationstyling",
     "css/textshadow",
     "css/transforms",
     "css/transformslevel2",


### PR DESCRIPTION
Adding a feature detect for text-decoration styling. It is based on text-decoration-color – if this property is enabled in the browser (or isn't), it is very likely that the other text-decoration properties (text-decoration-style, text-decoration-line, text-decoration-skip, text-decoration) follow suit. 