### PR TITLE
Ensure elem.parentNode exists before remove its child

### DIFF
--- a/feature-detects/audio/preload.js
+++ b/feature-detects/audio/preload.js
@@ -23,7 +23,11 @@ define(['Modernizr', 'addTest', 'docElement', 'createElement', 'test/audio'], fu
       var result = event !== undefined && event.type === 'loadeddata' ? true : false; //need to check if event is not undefined here in case function is evoked from timeout (no parameters)
       elem.removeEventListener('loadeddata', testpreload, false);
       addTest('audiopreload', result);
-      elem.parentNode.removeChild(elem);
+      // Cleanup, but don't assume elem is still in the page -
+      // an extension (eg Flashblock) may already have removed it.
+      if (elem.parentNode) {
+        elem.parentNode.removeChild(elem);
+      }
     }
 
     //skip the test if audio itself, or the preload


### PR DESCRIPTION
Based on feature-detects/video/autoplay.js, ensure that elem is still present.
Linked to issue https://github.com/Modernizr/Modernizr/issues/1196 I believe.

We had all errors regarding this reported only on Chrome 57.0.2987, under Windows 7. I wasn't able to reproduce, as I couldn't figure out how to get this specific version of Chrome :(