### PR TITLE
Remove ancient (and expensive) logic for verifying CSS transform support

### DIFF
--- a/feature-detects/css/transforms3d.js
+++ b/feature-detects/css/transforms3d.js
@@ -9,37 +9,8 @@
   ]
 }
 !*/
-define(['Modernizr', 'testAllProps', 'testStyles', 'docElement', 'test/css/supports'], function(Modernizr, testAllProps, testStyles, docElement) {
+define(['Modernizr', 'testAllProps', 'test/css/supports'], function(Modernizr, testAllProps) {
   Modernizr.addTest('csstransforms3d', function() {
-    var ret = !!testAllProps('perspective', '1px', true);
-    var usePrefix = Modernizr._config.usePrefixes;
-
-    // Webkit's 3D transforms are passed off to the browser's own graphics renderer.
-    //   It works fine in Safari on Leopard and Snow Leopard, but not in Chrome in
-    //   some conditions. As a result, Webkit typically recognizes the syntax but
-    //   will sometimes throw a false positive, thus we must do a more thorough check:
-    if (ret && (!usePrefix || 'webkitPerspective' in docElement.style)) {
-      var mq;
-      var defaultStyle = '#modernizr{width:0;height:0}';
-      // Use CSS Conditional Rules if available
-      if (Modernizr.supports) {
-        mq = '@supports (perspective: 1px)';
-      } else {
-        // Otherwise, Webkit allows this media query to succeed only if the feature is enabled.
-        // `@media (transform-3d),(-webkit-transform-3d){ ... }`
-        mq = '@media (transform-3d)';
-        if (usePrefix) {
-          mq += ',(-webkit-transform-3d)';
-        }
-      }
-
-      mq += '{#modernizr{width:7px;height:18px;margin:0;padding:0;border:0}}';
-
-      testStyles(defaultStyle + mq, function(elem) {
-        ret = elem.offsetWidth === 7 && elem.offsetHeight === 18;
-      });
-    }
-
-    return ret;
+    return !!testAllProps('perspective', '1px', true);
   });
 });


### PR DESCRIPTION
This code was added in 2009 via [1] to work around a false-positive in WebKit.
Per [2] both Safari and Chrome have supported transforms since 2009 and 2011
respectively, and current global usage of earlier versions of those products
is negligible. Also note that this code originally attempted to limit itself
to WebKit, but the prefixed properties it detects have since been standardized
and implemented in all browsers.

This code is responsible for significant slowdowns (in the tens of tens of
milliseconds) when loading CNN.

[1] https://github.com/Modernizr/Modernizr/issues/15
[2] https://caniuse.com/#search=perspective