### PR TITLE
Passive event listener detection causes error for EdgeHTML 15

### DIFF
--- a/feature-detects/dom/passiveeventlisteners.js
+++ b/feature-detects/dom/passiveeventlisteners.js
@@ -30,7 +30,9 @@ define(['Modernizr'], function(Modernizr) {
           supportsPassiveOption = true;
         }
       });
-      window.addEventListener('test', null, opts);
+      var noop = function () {};
+      window.addEventListener('testPassiveEventSupport', noop, opts);
+      window.removeEventListener('testPassiveEventSupport', noop, opts);
     } catch (e) {}
     return supportsPassiveOption;
   });


### PR DESCRIPTION
This seems to be an issue for Edge because it breaks the DOM standard, but still worth fixing in my opinion.