### PR TITLE
IndexedDB: Fix InvalidStateError and UnknownError in Firefox

### DIFF
--- a/feature-detects/indexeddb.js
+++ b/feature-detects/indexeddb.js
@@ -31,9 +31,10 @@ define(['Modernizr', 'prefixed', 'addTest'], function(Modernizr, prefixed, addTe
       var testDBName = 'modernizr-' + Math.random();
       var req = indexeddb.open(testDBName);
 
-      req.onerror = function() {
-        if (req.error && req.error.name === 'InvalidStateError') {
+      req.onerror = function(event) {
+        if (req.error && (req.error.name === 'InvalidStateError' || req.error.name === 'UnknownError')) {
           addTest('indexeddb', false);
+          event.preventDefault();
         } else {
           addTest('indexeddb', true);
           detectDeleteDatabase(indexeddb, testDBName);


### PR DESCRIPTION
In Firefox, the method "IDBFactory.open()" can raise an asynchronous error that can only be supressed by calling "event.preventDefault()". See https://github.com/Modernizr/Modernizr/pull/2315.

https://bugzilla.mozilla.org/show_bug.cgi?id=1331103#c3

https://stackoverflow.com/q/13972385