### PR TITLE
Replace text-justification -> text-justify

### DIFF
--- a/feature-detects/css/hyphens.js
+++ b/feature-detects/css/hyphens.js
@@ -58,13 +58,12 @@ define(['Modernizr', 'prefixes', 'createElement', 'testAllProps', 'addTest'], fu
           document.body.insertBefore(div, firstChild);
 
           /* get size of unhyphenated text */
-          divStyle.cssText = 'position:absolute;top:0;left:0;width:5em;text-align:justify;text-justification:newspaper;';
+          divStyle.cssText = 'position:absolute;top:0;left:0;width:5em;text-align:justify;text-justify:newspaper;';
           spanHeight = span.offsetHeight;
           spanWidth = span.offsetWidth;
 
           /* compare size with hyphenated text */
-          divStyle.cssText = 'position:absolute;top:0;left:0;width:5em;text-align:justify;' +
-            'text-justification:newspaper;' +
+          divStyle.cssText = 'position:absolute;top:0;left:0;width:5em;text-align:justify;text-justify:newspaper;' +
             prefixes.join('hyphens:auto; ');
 
           result = (span.offsetHeight !== spanHeight || span.offsetWidth !== spanWidth);


### PR DESCRIPTION
Fixes https://github.com/Modernizr/Modernizr/issues/2261 
text-justification is an unknown css property, should be text-justify. ('newspaper' value is only supported in IE (https://msdn.microsoft.com/en-us/ie/ms531172(v=vs.94)))