### PR TITLE
Fixed csshypens detection on FireFox and Safari.

### DIFF
--- a/feature-detects/css/hyphens.js
+++ b/feature-detects/css/hyphens.js
@@ -52,19 +52,22 @@ define(['Modernizr', 'prefixes', 'createElement', 'testAllProps', 'addTest'], fu
           var result = false;
           var firstChild = document.body.firstElementChild || document.body.firstChild;
 
+          /* Hyphenation is only applied when language is explicitly set and when respective dictionary
+           * is available. See https://developer.mozilla.org/en-US/docs/Web/CSS/hyphens for details. */
+          div.lang = 'en';
           div.appendChild(span);
           span.innerHTML = 'Bacon ipsum dolor sit amet jerky velit in culpa hamburger et. Laborum dolor proident, enim dolore duis commodo et strip steak. Salami anim et, veniam consectetur dolore qui tenderloin jowl velit sirloin. Et ad culpa, fatback cillum jowl ball tip ham hock nulla short ribs pariatur aute. Pig pancetta ham bresaola, ut boudin nostrud commodo flank esse cow tongue culpa. Pork belly bresaola enim pig, ea consectetur nisi. Fugiat officia turkey, ea cow jowl pariatur ullamco proident do laborum velit sausage. Magna biltong sint tri-tip commodo sed bacon, esse proident aliquip. Ullamco ham sint fugiat, velit in enim sed mollit nulla cow ut adipisicing nostrud consectetur. Proident dolore beef ribs, laborum nostrud meatball ea laboris rump cupidatat labore culpa. Shankle minim beef, velit sint cupidatat fugiat tenderloin pig et ball tip. Ut cow fatback salami, bacon ball tip et in shank strip steak bresaola. In ut pork belly sed mollit tri-tip magna culpa veniam, short ribs qui in andouille ham consequat. Dolore bacon t-bone, velit short ribs enim strip steak nulla. Voluptate labore ut, biltong swine irure jerky. Cupidatat excepteur aliquip salami dolore. Ball tip strip steak in pork dolor. Ad in esse biltong. Dolore tenderloin exercitation ad pork loin t-bone, dolore in chicken ball tip qui pig. Ut culpa tongue, sint ribeye dolore ex shank voluptate hamburger. Jowl et tempor, boudin pork chop labore ham hock drumstick consectetur tri-tip elit swine meatball chicken ground round. Proident shankle mollit dolore. Shoulder ut duis t-bone quis reprehenderit. Meatloaf dolore minim strip steak, laboris ea aute bacon beef ribs elit shank in veniam drumstick qui. Ex laboris meatball cow tongue pork belly. Ea ball tip reprehenderit pig, sed fatback boudin dolore flank aliquip laboris eu quis. Beef ribs duis beef, cow corned beef adipisicing commodo nisi deserunt exercitation. Cillum dolor t-bone spare ribs, ham hock est sirloin. Brisket irure meatloaf in, boudin pork belly sirloin ball tip. Sirloin sint irure nisi nostrud aliqua. Nostrud nulla aute, enim officia culpa ham hock. Aliqua reprehenderit dolore sunt nostrud sausage, ea boudin pork loin ut t-bone ham tempor. Tri-tip et pancetta drumstick laborum. Ham hock magna do nostrud in proident. Ex ground round fatback, venison non ribeye in.';
 
           document.body.insertBefore(div, firstChild);
 
           /* get size of unhyphenated text */
-          divStyle.cssText = 'position:absolute;top:0;left:0;width:5em;text-align:justify;text-justification:newspaper;';
+          divStyle.cssText = 'position:absolute;top:0;left:0;width:5em;text-align:justify;text-justify:newspaper;';
           spanHeight = span.offsetHeight;
           spanWidth = span.offsetWidth;
 
           /* compare size with hyphenated text */
           divStyle.cssText = 'position:absolute;top:0;left:0;width:5em;text-align:justify;' +
-            'text-justification:newspaper;' +
+            'text-justify:newspaper;' +
             prefixes.join('hyphens:auto; ');
 
           result = (span.offsetHeight !== spanHeight || span.offsetWidth !== spanWidth);

--- a/feature-detects/css/hyphens.js
+++ b/feature-detects/css/hyphens.js
@@ -61,13 +61,13 @@ define(['Modernizr', 'prefixes', 'createElement', 'testAllProps', 'addTest'], fu
           document.body.insertBefore(div, firstChild);
 
           /* get size of unhyphenated text */
-          divStyle.cssText = 'position:absolute;top:0;left:0;width:5em;text-align:justify;text-justify:newspaper;';
+          divStyle.cssText = 'position:absolute;top:0;left:0;width:5em;text-align:justify;text-justification:newspaper;';
           spanHeight = span.offsetHeight;
           spanWidth = span.offsetWidth;
 
           /* compare size with hyphenated text */
           divStyle.cssText = 'position:absolute;top:0;left:0;width:5em;text-align:justify;' +
-            'text-justify:newspaper;' +
+            'text-justification:newspaper;' +
             prefixes.join('hyphens:auto; ');
 
           result = (span.offsetHeight !== spanHeight || span.offsetWidth !== spanWidth);


### PR DESCRIPTION
# `csshyphens` detection fix for FF and Safari
This is a split version of #1428 as requested by @rejas.

- ~~There was seemingly a typo in CSS property name (`text-justification` instead of correct [`text-justify`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-justify))~~ Addressed in #2339.
- The hyphenation doesn't take effect unless the `lang` attribute is explicitly set, for this reason it was erroneously detected as not supported on FF and Safari, whereas it **is** actually supported.
