### PR TITLE
Use package.json `files` instead of .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,9 +1,0 @@
-test
-media
-dist
-gh-pages
-appveyor.yml
-Gruntfile.js
-metadata.json
-modernizr.js
-.*

--- a/package.json
+++ b/package.json
@@ -46,6 +46,14 @@
   },
   "main": "./lib/cli",
   "bin": "./bin/modernizr",
+  "files": [
+    "LICENSE",
+    "README.md",
+    "bin/",
+    "feature-detects/",
+    "lib/",
+    "src/"
+  ],
   "repository": {
     "type": "git",
     "url": "git://github.com/Modernizr/Modernizr.git"


### PR DESCRIPTION
It’s easier to explicitly define *what should be published* instead of excluding it.