### PR TITLE
Fix Modernizr.localizednumber moves head below body

### DIFF
--- a/feature-detects/audio.js
+++ b/feature-detects/audio.js
@@ -42,7 +42,7 @@ define(['Modernizr', 'createElement'], function(Modernizr, createElement) {
         bool.m4a  = (elem.canPlayType('audio/x-m4a;')            ||
                      elem.canPlayType('audio/aac;'))             .replace(/^no$/, '');
       }
-    } catch (e) { }
+    } catch (e) {}
 
     return bool;
   });

--- a/feature-detects/css/hyphens.js
+++ b/feature-detects/css/hyphens.js
@@ -69,9 +69,10 @@ define(['Modernizr', 'prefixes', 'createElement', 'testAllProps', 'addTest'], fu
           divStyle.cssText = 'position:absolute;top:0;left:0;width:5em;text-align:justify;text-justify:newspaper;' +
             prefixes.join('hyphens:auto; ');
 
+          /* results */
           result = (span.offsetHeight !== spanHeight || span.offsetWidth !== spanWidth);
 
-          /* results and cleanup */
+          /* cleanup */
           document.body.removeChild(div);
           div.removeChild(span);
 

--- a/feature-detects/forms/inputnumber-l10n.js
+++ b/feature-detects/forms/inputnumber-l10n.js
@@ -24,16 +24,16 @@ define(['Modernizr', 'createElement', 'docElement', 'getBody', 'test/inputtypes'
     /* we rely on checkValidity later, so bomb out early if we don't have it */
     if (!Modernizr.formvalidation) { return false; }
 
-    var div = createElement('div');
-    var result;
     var body = getBody();
+    var div = createElement('div');
+    var firstChild = body.firstElementChild || body.firstChild;
+    var result;
 
-    var root = (function() {
-      return docElement.insertBefore(body, docElement.firstElementChild || docElement.firstChild);
-    }());
+    body.insertBefore(div, firstChild);
+
     div.innerHTML = '<input type="number" value="1.0" step="0.1"/>';
     var input = div.childNodes[0];
-    root.appendChild(div);
+    body.appendChild(div);
 
     input.focus();
     try {
@@ -45,9 +45,9 @@ define(['Modernizr', 'createElement', 'docElement', 'getBody', 'test/inputtypes'
     result = input.type === 'number' && input.valueAsNumber === 1.1 && input.checkValidity();
 
     /* cleanup */
-    root.removeChild(div);
+    body.removeChild(div);
     if (body.fake) {
-      root.parentNode.removeChild(root);
+      body.parentNode.removeChild(body);
     }
 
     return result;

--- a/feature-detects/forms/inputnumber-l10n.js
+++ b/feature-detects/forms/inputnumber-l10n.js
@@ -19,33 +19,38 @@ Detects whether input type="number" is capable of receiving and displaying local
 */
 define(['Modernizr', 'createElement', 'docElement', 'getBody', 'test/inputtypes', 'test/forms/validation'], function(Modernizr, createElement, docElement, getBody) {
   Modernizr.addTest('localizednumber', function() {
-    // this extends our testing of input[type=number], so bomb out if that's missing
+    /* this extends our testing of input[type=number], so bomb out if that's missing */
     if (!Modernizr.inputtypes.number) { return false; }
-    // we rely on checkValidity later, so bomb out early if we don't have it
+    /* we rely on checkValidity later, so bomb out early if we don't have it */
     if (!Modernizr.formvalidation) { return false; }
 
-    var el = createElement('div');
-    var diff;
+    var div = createElement('div');
+    var result;
     var body = getBody();
 
     var root = (function() {
       return docElement.insertBefore(body, docElement.firstElementChild || docElement.firstChild);
     }());
-    el.innerHTML = '<input type="number" value="1.0" step="0.1"/>';
-    var input = el.childNodes[0];
-    root.appendChild(el);
+    div.innerHTML = '<input type="number" value="1.0" step="0.1"/>';
+    var input = div.childNodes[0];
+    root.appendChild(div);
+
     input.focus();
     try {
       document.execCommand('SelectAll', false); // Overwrite current input value, rather than appending text
       document.execCommand('InsertText', false, '1,1');
-    } catch (e) { // prevent warnings in IE
-    }
-    diff = input.type === 'number' && input.valueAsNumber === 1.1 && input.checkValidity();
-    root.removeChild(el);
+    } catch (e) {} // prevent warnings in IE
+
+    /* results */
+    result = input.type === 'number' && input.valueAsNumber === 1.1 && input.checkValidity();
+
+    /* cleanup */
+    root.removeChild(div);
     if (body.fake) {
       root.parentNode.removeChild(root);
     }
-    return diff;
+
+    return result;
   });
 
 });

--- a/feature-detects/forms/inputnumber-l10n.js
+++ b/feature-detects/forms/inputnumber-l10n.js
@@ -17,7 +17,7 @@
 /* DOC
 Detects whether input type="number" is capable of receiving and displaying localized numbers, e.g. with comma separator.
 */
-define(['Modernizr', 'createElement', 'docElement', 'getBody', 'test/inputtypes', 'test/forms/validation'], function(Modernizr, createElement, docElement, getBody) {
+define(['Modernizr', 'createElement', 'getBody', 'test/inputtypes', 'test/forms/validation'], function(Modernizr, createElement, getBody) {
   Modernizr.addTest('localizednumber', function() {
     /* this extends our testing of input[type=number], so bomb out if that's missing */
     if (!Modernizr.inputtypes.number) { return false; }

--- a/src/hasEvent.js
+++ b/src/hasEvent.js
@@ -1,4 +1,4 @@
-define(['ModernizrProto', 'createElement'], function(ModernizrProto, createElement) {
+define(['ModernizrProto', 'createElement', 'docElement'], function(ModernizrProto, createElement, docElement) {
   /**
    * Modernizr.hasEvent() detects support for a given event
    *
@@ -30,7 +30,7 @@ define(['ModernizrProto', 'createElement'], function(ModernizrProto, createEleme
 
     // Detect whether event support can be detected via `in`. Test on a DOM element
     // using the "blur" event b/c it should always exist. bit.ly/event-detection
-    var needsFallback = !('onblur' in document.documentElement);
+    var needsFallback = !('onblur' in docElement);
 
     function inner(eventName, element) {
 


### PR DESCRIPTION
Fixes #1836 by using a IMO more sane method of adding and removing the test-div. Code was inspired from the hyphen.js test.