### PR TITLE
Additional WebView check added to fileinput test

### DIFF
--- a/feature-detects/forms/fileinput.js
+++ b/feature-detects/forms/fileinput.js
@@ -10,11 +10,13 @@
 /* DOC
 Detects whether input type="file" is available on the platform
 
-E.g. iOS < 6 and some android version don't support this
+E.g. iOS < 6, some android versions and embedded Chrome WebViews don't support this
 */
 define(['Modernizr', 'createElement'], function(Modernizr, createElement) {
   Modernizr.addTest('fileinput', function() {
-    if (navigator.userAgent.match(/(Android (1.0|1.1|1.5|1.6|2.0|2.1))|(Windows Phone (OS 7|8.0))|(XBLWP)|(ZuneWP)|(w(eb)?OSBrowser)|(webOS)|(Kindle\/(1.0|2.0|2.5|3.0))/)) {
+    var ua = navigator.userAgent;
+    if (ua.match(/(Android (1.0|1.1|1.5|1.6|2.0|2.1))|(Windows Phone (OS 7|8.0))|(XBLWP)|(ZuneWP)|(w(eb)?OSBrowser)|(webOS)|(Kindle\/(1.0|2.0|2.5|3.0))/) ||
+        ua.match(/\swv\).+(chrome)\/([\w\.]+)/i)) {
       return false;
     }
     var elem = createElement('input');


### PR DESCRIPTION
Issue: #2366 

Chrome WebViews may return a true result from the "fileinput" test, even though the file input HTML5 element is not supported in WebViews (as described [here](https://developer.chrome.com/multidevice/webview/overview#does_the_new_webview_have_feature_parity_with_chrome_for_android_)).

Added an extra UA condition that looks for specific values indicating the browser is operating from a WebView. Note: this pull request only covers Android Lollipop+ as described [here](https://developer.chrome.com/multidevice/user-agent#webview_user_agent).

RegEx string taken from [here](https://github.com/faisalman/ua-parser-js/blob/a56c990ec32f105219570d398f3398f9373b5a75/src/ua-parser.js).
