### PR TITLE
[BUGFIX] Prevent viewport jumping when using CSS Hyphens (#1781)

### DIFF
--- a/feature-detects/css/hyphens.js
+++ b/feature-detects/css/hyphens.js
@@ -147,6 +147,10 @@ define(['Modernizr', 'prefixes', 'createElement', 'testAllProps', 'addTest'], fu
           var textrange;
           var firstChild = document.body.firstElementChild || document.body.firstChild;
 
+          /* Make the elements fixed to prevent that the browser's viewport will jump to the top  */
+          dummy.style.cssText = 'position:fixed;top:0;';
+          div.style.cssText = 'position:fixed;top:0;';
+
           div.innerHTML = testword + delimiter + testword;
 
           document.body.insertBefore(div, firstChild);


### PR DESCRIPTION
Positioned the created elements fixed to the top, to prevent any
jumping when (re-)loading the page.
When those elements weren't positioned fixed, they will be rendered at
the top of the document. In the test it's required to reset the
selection by focusing to a dummy input element thus triggering the
jump of the browser's viewport.

Successfully tested in the following browsers
* Chrome 68.0.3440.106 on MacOS 10.13.5
* Firefox 45.0.1 on MacOS 10.13.5
* Firefox 57.0.4 on MacOS 10.13.5
* Firefox 61.0.2 on MacOS 10.13.5
* Safari 11.1.1 (13605.2.8) on MacOS 10.13.5

* Chrome 68.0.3440.106 on Windows 10 Pro Build 1803
* Firefox 61.0.2 on Windows 10 Pro Build 1803
* Internet Explorer 11.228.17134.0 on Windows 10 Pro Build 1803
* Edge 42.17134.1.0 on Windows 10 Pro Build 1803

* Firefox 61.0.2 on Windows 7 Build 7600
* Internet Explorer 8.0.7600.16385 on Windows 7 Build 7600

* Firefox 61.0.1 on Linux Mint 19 Tara

Resolves #1781