### PR TITLE
Adding feature detection for navigator.connection.effectiveType

### DIFF
--- a/feature-detects/network/connection-effectivetype.js
+++ b/feature-detects/network/connection-effectivetype.js
@@ -1,0 +1,27 @@
+/*!
+{
+  "name": "Connection Effective Type",
+  "notes": [{
+    "name": "MDN documentation",
+    "href": "https://developer.mozilla.org/en-US/docs/Web/API/NetworkInformation/effectiveType"
+  }],
+  "property": "connectioneffectivetype",
+  "builderAliases": ["network_connection"],
+  "tags": ["network"]
+}
+!*/
+/* DOC
+Detects support for determining signal bandwidth via `navigator.connection.effectiveType`
+*/
+define(['Modernizr'], function (Modernizr) {
+  Modernizr.addTest('effectiveType', function () {
+    // polyfill
+    var connection = navigator.connection || { effectiveType: 0 };
+
+    if (connection.effectiveType !== 0) {
+      return true;
+    }
+
+    return false;
+  });
+});

--- a/lib/config-all.json
+++ b/lib/config-all.json
@@ -222,6 +222,7 @@
     "messagechannel",
     "network/beacon",
     "network/connection",
+    "network/connection-effectivetype",
     "network/eventsource",
     "network/fetch",
     "network/xhr-responsetype",


### PR DESCRIPTION
Closes #2378 

Required a workaround to detect navigator.connection or set it to a value if not present. Detects and returns true if value is not zero. Otherwise, returns false.

- Chrome Version 69.0.3497.100 (result: true)
- Firefox Version 62.0.2 (result: false)
- Edge Version 17.17134 (result: false)