### PR TITLE
Update CSS custom properties check to be more robust

### DIFF
--- a/feature-detects/css/customproperties.js
+++ b/feature-detects/css/customproperties.js
@@ -16,5 +16,5 @@
 !*/
 define(['Modernizr'], function(Modernizr) {
   var supportsFn = (window.CSS && window.CSS.supports.bind(window.CSS)) || (window.supportsCSS);
-  Modernizr.addTest('customproperties', !!supportsFn && supportsFn('--f:0'));
+  Modernizr.addTest('customproperties', !!supportsFn && (supportsFn('--f:0') || supportsFn('--f', 0)));
 });


### PR DESCRIPTION
Allows for different browser implementations of the CSS.supports method for custom properties by checking for either a condition, or a property and value set.

Fixes #2383.