### PR TITLE
Emoji use backingStorePixelRatio instead of devicePixelRatio

### DIFF
--- a/feature-detects/emoji.js
+++ b/feature-detects/emoji.js
@@ -12,10 +12,16 @@ define(['Modernizr', 'createElement', 'test/canvastext'], function(Modernizr, cr
     if (!Modernizr.canvastext) {
       return false;
     }
-    var pixelRatio = window.devicePixelRatio || 1;
-    var offset = 12 * pixelRatio;
     var node = createElement('canvas');
     var ctx = node.getContext('2d');
+    var backingStoreRatio =
+      ctx.webkitBackingStorePixelRatio ||
+      ctx.mozBackingStorePixelRatio ||
+      ctx.msBackingStorePixelRatio ||
+      ctx.oBackingStorePixelRatio ||
+      ctx.backingStorePixelRatio ||
+      1;
+    var offset = 12 * backingStoreRatio;
     ctx.fillStyle = '#f00';
     ctx.textBaseline = 'top';
     ctx.font = '32px Arial';


### PR DESCRIPTION
While backingStorePixelRatio is deprecated, devicePixelRatio is being used incorrectly in the existing code as the backing store pixel ratio. This code updates the emoji detect to reliably request the same pixel of the canvas regardless of devicePixelRatio (and also supports the rare browser—older Safari—that uses backingStorePixelRatio).

Fixes #2419