### PR TITLE
Add Av1 codec detection

### DIFF
--- a/feature-detects/video.js
+++ b/feature-detects/video.js
@@ -52,6 +52,8 @@ define(['Modernizr', 'createElement'], function(Modernizr, createElement) {
         bool.vp9 = elem.canPlayType('video/webm; codecs="vp9"').replace(/^no$/, '');
 
         bool.hls = elem.canPlayType('application/x-mpegURL; codecs="avc1.42E01E"').replace(/^no$/, '');
+        
+        bool.av1 = elem.canPlayType('video/mp4; codecs="av01"').replace(/^no$/, '');
       }
     } catch (e) {}
 


### PR DESCRIPTION
Completely not tested AV1 detection code.

Possible problems:
- AV1 can be contained by a lot of containers .mkv `video/x-matroska`, webm `video/webm`, .mp4 `video/mp4` and not sure if any other, research is required. Right now is only being tested for .mp4.
- AV1.1 could be a problem, not completely sure.

It simply needs some research and testing 🙃 