### PR TITLE
Set classes for inputtypes (#2130)

### DIFF
--- a/feature-detects/inputtypes.js
+++ b/feature-detects/inputtypes.js
@@ -102,6 +102,9 @@ define(['Modernizr', 'inputElem', 'docElement'], function(Modernizr, inputElem, 
       }
 
       inputs[ props[i] ] = !!bool;
+
+      // Allow Modernizr run setClasses, e.g.
+      Modernizr.addTest('inputtypes-' + props[i], !!bool);
     }
     return inputs;
   })(inputtypes);

--- a/test/browser/integration/classes.js
+++ b/test/browser/integration/classes.js
@@ -27,7 +27,7 @@ describe('classes', function() {
               name = name.replace('-', '');
               expect(Modernizr[name]).to.be(result);
             } else {
-              name = name.split('-');
+              name = name.split(/-(.+)/); // split at first occurence of '-'
               expect(Modernizr[name[0]]).to.not.be(undefined);
               expect(!!Modernizr[name[0]][name[1]]).to.equal(result);
             }


### PR DESCRIPTION
This change will make sure that `setClasses` works for every `inputtypes` test.
Fixes #2130