### PR TITLE
Add support for ShadowRoot DOM api feature detect

### DIFF
--- a/feature-detects/dom/shadowroot.js
+++ b/feature-detects/dom/shadowroot.js
@@ -1,0 +1,20 @@
+/*!
+{
+  "name": "Shadow DOM API",
+  "property": "shadowroot",
+  "caniuse": "shadowdomv1",
+  "notes": [{
+    "name": "MDN Docs",
+    "href": "https://developer.mozilla.org/en-US/docs/Web/API/ShadowRoot"
+  }],
+  "authors": ["Kevin Coyle (@kevin-coyle-unipro)", "Pascal Lim (@pascalim)"],
+  "tags": ["dom"]
+}
+!*/
+
+/* DOC
+Detects support for the Shadow DOM API.
+*/
+define(['Modernizr', 'createElement'], function (Modernizr, createElement) {
+  Modernizr.addTest('shadowroot', 'attachShadow' in createElement('div'));
+});

--- a/feature-detects/dom/shadowrootlegacy.js
+++ b/feature-detects/dom/shadowrootlegacy.js
@@ -1,0 +1,20 @@
+/*!
+{
+  "name": "Shadow DOM API (Legacy)",
+  "property": "shadowrootlegacy",
+  "caniuse": "shadowdom",
+  "notes": [{
+    "name": "MDN Docs",
+    "href": "https://developer.mozilla.org/en-US/docs/Web/API/Element/createShadowRoot"
+  }],
+  "authors": ["Kevin Coyle (@kevin-coyle-unipro)", "Pascal Lim (@pascalim)"],
+  "tags": ["dom"]
+}
+!*/
+
+/* DOC
+Detects support for the Shadow DOM API. (Legacy)
+*/
+define(['Modernizr', 'createElement'], function (Modernizr, createElement) {
+  Modernizr.addTest('shadowrootlegacy', 'createShadowRoot' in createElement('div'));
+});

--- a/lib/config-all.json
+++ b/lib/config-all.json
@@ -142,6 +142,8 @@
     "dom/microdata",
     "dom/mutationObserver",
     "dom/passiveeventlisteners",
+    "dom/shadowroot",
+    "dom/shadowrootlegacy",
     "elem/bdi",
     "elem/datalist",
     "elem/details",


### PR DESCRIPTION
Add support for ShadowRoot DOM api feature detect through `shadowroot` and `shadowroot-legacy` tests