### PR TITLE
[Modernizr]: Support to disable openDatabase driver for testing

### DIFF
--- a/feature-detects/storage/websqldatabase.js
+++ b/feature-detects/storage/websqldatabase.js
@@ -9,5 +9,12 @@
 define(['Modernizr'], function(Modernizr) {
   // Chrome incognito mode used to throw an exception when using openDatabase
   // It doesn't anymore.
-  Modernizr.addTest('websqldatabase', 'openDatabase' in window);
+  Modernizr.addTest('websqldatabase', function() {
+    if (window.openDatabase === null) {
+      return false;
+    }
+    else {
+      return 'openDatabase' in window;
+    }
+  });
 });


### PR DESCRIPTION
Providing support to test if openDatabase driver is virtually removed.
In some cases users would like to test what if openDatabase driver doesn't support by setting openDatabase to null. In this case the test application/method will fail to use openDatabase driver and Modernizr must behave same.

Signed-off-by: ossdev07 <ossdev@puresoftware.com>