### PR TITLE
Add link to temporary new webpage

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 ##### Modernizr is a JavaScript library that detects HTML5 and CSS3 features in the user’s browser.
 
 - [Website](https://modernizr.com) unfortunatly out-of-date
-- [**Updated Website**](https://new.modernizr.com) updated with the latest modernizr version (currently 3.8.0)
+- [**Updated Website**](https://new.modernizr.com) updated with the latest modernizr version (currently 3.9.1)
 - [Documentation](https://modernizr.com/docs/)
 - [Integration tests](https://modernizr.github.io/Modernizr/test/integration.html)
 - [Unit tests](https://modernizr.github.io/Modernizr/test/unit.html)

--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@
 
 ##### Modernizr is a JavaScript library that detects HTML5 and CSS3 features in the user’s browser.
 
-- [Website](https://modernizr.com)
+- [Website](https://modernizr.com) unfortunatly out-of-date
+- [**Updated Website**](https://new.modernizr.com) updated with the latest modernizr version (currently 3.8.0)
 - [Documentation](https://modernizr.com/docs/)
 - [Integration tests](https://modernizr.github.io/Modernizr/test/integration.html)
 - [Unit tests](https://modernizr.github.io/Modernizr/test/unit.html)


### PR DESCRIPTION
I managed to deploy an updated version of the webpage to new.modernizr.com since @patrickkettner doesnt seem to have time (or doesnt get any email anymore) for updating the old one. Maybe this gets the train rolling again...

Any idea on how to go onward with the page would be highly appreciated...

Fixes https://github.com/Modernizr/modernizr-neue/issues/140 and https://github.com/Modernizr/modernizr-neue/issues/141