### PR TITLE
Issue #2492 inputnumber-l10n test causing unintended scrolls #2492

### DIFF
--- a/feature-detects/forms/inputnumber-l10n.js
+++ b/feature-detects/forms/inputnumber-l10n.js
@@ -31,7 +31,7 @@ define(['Modernizr', 'createElement', 'getBody', 'test/inputtypes', 'test/forms/
 
     body.insertBefore(div, firstChild);
 
-    div.innerHTML = '<input type="number" value="1.0" step="0.1"/>';
+    div.innerHTML = '<input type="number" value="1.0" step="0.1" style="position: fixed;" />';
     var input = div.childNodes[0];
     body.appendChild(div);
 

--- a/feature-detects/forms/inputnumber-l10n.js
+++ b/feature-detects/forms/inputnumber-l10n.js
@@ -31,7 +31,7 @@ define(['Modernizr', 'createElement', 'getBody', 'test/inputtypes', 'test/forms/
 
     body.insertBefore(div, firstChild);
 
-    div.innerHTML = '<input type="number" value="1.0" step="0.1" style="position: fixed;" />';
+    div.innerHTML = '<input type="number" value="1.0" step="0.1" style="position: fixed; top: 0;" />';
     var input = div.childNodes[0];
     body.appendChild(div);
 


### PR DESCRIPTION
Setting the test input position to fixed keeps it in the current viewbox of the browser, avoiding the scrolling during .focus()