### PR TITLE
ES7 - Array includes

### DIFF
--- a/feature-detects/es7/includes.js
+++ b/feature-detects/es7/includes.js
@@ -1,3 +1,3 @@
 define(['Modernizr', 'is'], function(Modernizr, is) {
-  Modernizr.addTest('contains', is(Array.prototype.includes, 'function'));
+  Modernizr.addTest('includes', is(Array.prototype.includes, 'function'));
 });

--- a/feature-detects/es7/includes.js
+++ b/feature-detects/es7/includes.js
@@ -1,0 +1,3 @@
+define(['Modernizr', 'is'], function(Modernizr, is) {
+  Modernizr.addTest('contains', is(Array.prototype.includes, 'function'));
+});

--- a/lib/config-all.json
+++ b/lib/config-all.json
@@ -177,6 +177,7 @@
     "es6/promises",
     "es6/string",
     "es6/symbol",
+    "es7/includes",
     "event/deviceorientation-motion",
     "event/oninput",
     "eventlistener",


### PR DESCRIPTION
Just a little PR for checking new ES7 array capabilities : `includes`
I'm not familiar of PR so don't hesitate to point me errors I could made.

Ps: This PR is largely inspired of the `es6/contains` code