### PR TITLE
ES6/Rest parameters

### DIFF
--- a/feature-detects/es6/restParameters.js
+++ b/feature-detects/es6/restParameters.js
@@ -1,0 +1,11 @@
+define(['Modernizr'], function(Modernizr) {
+  Modernizr.addTest('restParameters', function() {
+    try {
+      // eslint-disable-next-line
+      eval('var { ...rest } = { a:1}');
+    } catch (e) {
+      return false;
+    }
+    return true;
+  });
+});

--- a/lib/config-all.json
+++ b/lib/config-all.json
@@ -177,6 +177,7 @@
     "es6/promises",
     "es6/string",
     "es6/symbol",
+    "es6/restParameters",
     "event/deviceorientation-motion",
     "event/oninput",
     "eventlistener",


### PR DESCRIPTION
I didn't find any detection of rest parameters and I think it's very important because it could break script load if not supported...
So another try of PR :)

PS: widely inspired of `es6/arrow`