### PR TITLE
ES7 array test (includes method)

### DIFF
--- a/feature-detects/es7/array.js
+++ b/feature-detects/es7/array.js
@@ -14,7 +14,7 @@
 /* DOC
 Check if browser implements ECMAScript 7 Array per specification.
 */
-define(["Modernizr"], function(Modernizr) {
-	Modernizr.addTest("es7array", !!(Array.prototype &&
+define(['Modernizr'], function(Modernizr) {
+	Modernizr.addTest('es7array', !!(Array.prototype &&
 		Array.prototype.includes));
 });

--- a/feature-detects/es7/array.js
+++ b/feature-detects/es7/array.js
@@ -1,0 +1,20 @@
+/*!
+{
+  "name": "ES7 Array",
+  "property": "es7array",
+  "notes": [{
+    "name": "official ECMAScript 7 array draft specification",
+    "href": "https://tc39.es/ecma262/#sec-array.prototype.includes"
+  }],
+  "authors": ["dabretin"],
+  "warnings": ["ECMAScript 7 is still a only a draft, so this detect may not match the final specification or implementations."],
+  "tags": ["es7"]
+}
+!*/
+/* DOC
+Check if browser implements ECMAScript 7 Array per specification.
+*/
+define(["Modernizr"], function(Modernizr) {
+	Modernizr.addTest("es7array", !!(Array.prototype &&
+		Array.prototype.includes));
+});

--- a/feature-detects/es7/array.js
+++ b/feature-detects/es7/array.js
@@ -15,6 +15,6 @@
 Check if browser implements ECMAScript 7 Array per specification.
 */
 define(['Modernizr'], function(Modernizr) {
-	Modernizr.addTest('es7array', !!(Array.prototype &&
-		Array.prototype.includes));
+  Modernizr.addTest('es7array', !!(Array.prototype &&
+    Array.prototype.includes));
 });

--- a/lib/config-all.json
+++ b/lib/config-all.json
@@ -177,6 +177,7 @@
     "es6/promises",
     "es6/string",
     "es6/symbol",
+    "es7/array",
     "event/deviceorientation-motion",
     "event/oninput",
     "eventlistener",


### PR DESCRIPTION
Fixes #2376 

I hope this one will be ok :)
ES7 introduce a new method (includes) for array. This PR check the presence of this method on the array prototype.

PS: widely inspired of es6/array