### PR TITLE
css/fontdisplay - correct reference to testProp

### DIFF
--- a/feature-detects/css/fontdisplay.js
+++ b/feature-detects/css/fontdisplay.js
@@ -16,6 +16,6 @@
 /* DOC
 Detects support for the `font-display` descriptor, which defines how font files are loaded and displayed by the browser.
 */
-define(['Modernizr'], function(Modernizr, testProp) {
+define(['Modernizr', 'testProp'], function(Modernizr, testProp) {
   Modernizr.addTest('fontDisplay', testProp('font-display'));
 });


### PR DESCRIPTION
There was no reference to `testProp` so it raised an error.