### PR TITLE
ES8: object

### DIFF
--- a/feature-detects/es8/object.js
+++ b/feature-detects/es8/object.js
@@ -1,0 +1,24 @@
+/*!
+{
+  "name": "ES8 Object",
+  "property": "es8object",
+  "notes": [{
+    "name": "ECMAScript 8 draft specification: Object.entries",
+    "href": "https://www.ecma-international.org/ecma-262/8.0/#sec-object.entries"
+  }, {
+    "name": "ECMAScript 8 draft specification: Object.values",
+    "href": "https://www.ecma-international.org/ecma-262/8.0/#sec-object.values"
+  }],
+  "caniuse": "object-entries,object-values",
+  "authors": ["dabretin"],
+  "warnings": ["ECMAScript 8 is still a only a draft, so this detect may not match the final specification or implementations."],
+  "tags": ["es8"]
+}
+!*/
+/* DOC
+Check if browser implements ECMAScript 8 Object.
+*/
+define(['Modernizr'], function(Modernizr) {
+  Modernizr.addTest('es8object', !!(Object.entries &&
+    Object.values));
+});

--- a/lib/config-all.json
+++ b/lib/config-all.json
@@ -183,6 +183,7 @@
     "es7/array",
     "es7/rest-destructuring",
     "es7/spread-object",
+    "es8/object",
     "event/deviceorientation-motion",
     "event/oninput",
     "eventlistener",


### PR DESCRIPTION
Tests for support of `Object.entries` and `Object.values` from ES8.
These functions are already support in all modern browsers (and very useful for convert `Map` to and from `Object`).