### PR TITLE
Add av1 and h265 codec detection

### DIFF
--- a/feature-detects/video.js
+++ b/feature-detects/video.js
@@ -18,7 +18,7 @@
 /* DOC
 Detects support for the video element, as well as testing what types of content it supports.
 
-Subproperties are provided to describe support for `ogg`, `h264` and `webm` formats, e.g.:
+Subproperties are provided to describe support for `ogg`, `h264`, `h265`, `webm`, `vp9`, `hls` and `av1` formats, e.g.:
 
 ```javascript
 Modernizr.video         // true

--- a/feature-detects/video.js
+++ b/feature-detects/video.js
@@ -54,9 +54,11 @@ define(['Modernizr', 'createElement'], function(Modernizr, createElement) {
 
         // Without QuickTime, this value will be `undefined`. github.com/Modernizr/Modernizr/issues/546
         Modernizr.addTest('video.h264', elem.canPlayType('video/mp4; codecs="avc1.42E01E"').replace(/^no$/, ''));
+        Modernizr.addTest('video.h265', elem.canPlayType('video/mp4; codecs="hev1"').replace(/^no$/, ''));
         Modernizr.addTest('video.webm', elem.canPlayType('video/webm; codecs="vp8, vorbis"').replace(/^no$/, ''));
         Modernizr.addTest('video.vp9', elem.canPlayType('video/webm; codecs="vp9"').replace(/^no$/, ''));
         Modernizr.addTest('video.hls', elem.canPlayType('application/x-mpegURL; codecs="avc1.42E01E"').replace(/^no$/, ''));
+        Modernizr.addTest('video.av1', elem.canPlayType('video/mp4; codecs="av01"').replace(/^no$/, ''));
       }
     } catch (e) {}
   })();


### PR DESCRIPTION
**Similar pull requests**: #2457 (mine)
Closes #2231 

**Changes**:
- Add av1 codec detection
- Add x265 codec detection
- Added some missing subproperties to the description on the web

**Comments**:
No new tests needed to be created as the test scripted already check for all existing codecs. I've tested with Firefox 75 and Edge 18 (with and without [hevc extensions](https://www.microsoft.com/en-us/p/hevc-video-extensions-from-device-manufacturer/9n4wgh0z6vhq?activetab=pivot:overviewtab) installed) in gh-pages and they match [caniuse](https://caniuse.com/#feat=av1). Furthermore `npm test` shows 2 new tests passed.