### PR TITLE
Add caniuse mappings

### DIFF
--- a/feature-detects/ambientlight.js
+++ b/feature-detects/ambientlight.js
@@ -2,6 +2,7 @@
 {
   "name": "Ambient Light Events",
   "property": "ambientlight",
+  "caniuse": "ambient-light",
   "notes": [{
     "name": "W3C Spec",
     "href": "https://www.w3.org/TR/ambient-light/"

--- a/feature-detects/audio.js
+++ b/feature-detects/audio.js
@@ -2,6 +2,7 @@
 {
   "name": "HTML5 Audio Element",
   "property": "audio",
+  "caniuse": "audio",
   "tags": ["html5", "audio", "media"],
   "notes": [{
     "name": "MDN Docs",

--- a/feature-detects/css/backgroundposition-shorthand.js
+++ b/feature-detects/css/backgroundposition-shorthand.js
@@ -2,6 +2,7 @@
 {
   "name": "Background Position Shorthand",
   "property": "bgpositionshorthand",
+  "caniuse": "css-background-offsets",
   "tags": ["css"],
   "builderAliases": ["css_backgroundposition_shorthand"],
   "notes": [{

--- a/feature-detects/css/chunit.js
+++ b/feature-detects/css/chunit.js
@@ -3,6 +3,7 @@
   "name": "CSS Font ch Units",
   "authors": ["Ron Waldon (@jokeyrhyme)"],
   "property": "csschunit",
+  "caniuse": "rem",
   "tags": ["css"],
   "notes": [{
     "name": "W3C Spec",

--- a/feature-detects/css/chunit.js
+++ b/feature-detects/css/chunit.js
@@ -3,7 +3,7 @@
   "name": "CSS Font ch Units",
   "authors": ["Ron Waldon (@jokeyrhyme)"],
   "property": "csschunit",
-  "caniuse": "rem",
+  "caniuse": "ch-unit",
   "tags": ["css"],
   "notes": [{
     "name": "W3C Spec",

--- a/feature-detects/css/exunit.js
+++ b/feature-detects/css/exunit.js
@@ -3,6 +3,7 @@
   "name": "CSS Font ex Units",
   "authors": ["Ron Waldon (@jokeyrhyme)"],
   "property": "cssexunit",
+  "caniuse": "rem",
   "tags": ["css"],
   "notes": [{
     "name": "W3C Spec",

--- a/feature-detects/css/exunit.js
+++ b/feature-detects/css/exunit.js
@@ -3,7 +3,7 @@
   "name": "CSS Font ex Units",
   "authors": ["Ron Waldon (@jokeyrhyme)"],
   "property": "cssexunit",
-  "caniuse": "rem",
+  "caniuse": "mdn-css_types_length_ex",
   "tags": ["css"],
   "notes": [{
     "name": "W3C Spec",

--- a/feature-detects/css/scrollsnappoints.js
+++ b/feature-detects/css/scrollsnappoints.js
@@ -2,6 +2,7 @@
 {
   "name": "Scroll Snap Points",
   "property": "scrollsnappoints",
+  "caniuse": "css-snappoints",
   "notes": [{
     "name": "Setting native-like scrolling offsets in CSS with Scrolling Snap Points",
     "href": "http://generatedcontent.org/post/66817675443/setting-native-like-scrolling-offsets-in-css-with"

--- a/feature-detects/css/textalignlast.js
+++ b/feature-detects/css/textalignlast.js
@@ -2,6 +2,7 @@
 {
   "name": "CSS text-align-last",
   "property": "textalignlast",
+  "caniuse": "css-text-align-last",
   "tags": ["css"],
   "knownBugs": ["IE does not support the 'start' or 'end' values."],
   "notes": [{

--- a/feature-detects/css/will-change.js
+++ b/feature-detects/css/will-change.js
@@ -2,6 +2,7 @@
 {
   "name": "will-change",
   "property": "willchange",
+  "caniuse": "will-change",
   "notes": [{
     "name": "W3C Spec",
     "href": "https://drafts.csswg.org/css-will-change/"

--- a/feature-detects/custom-elements.js
+++ b/feature-detects/custom-elements.js
@@ -2,6 +2,7 @@
 {
   "name": "Custom Elements API",
   "property": "customelements",
+  "caniuse": "custom-elementsv1",
   "tags": ["customelements"],
   "polyfills": ["customelements"],
   "notes": [{

--- a/feature-detects/dom/passiveeventlisteners.js
+++ b/feature-detects/dom/passiveeventlisteners.js
@@ -1,6 +1,7 @@
 /*!
 {
   "property": "passiveeventlisteners",
+  "caniuse": "passive-event-listener",
   "tags": ["dom"],
   "authors": ["Rick Byers"],
   "name": "Passive event listeners",

--- a/feature-detects/elem/template.js
+++ b/feature-detects/elem/template.js
@@ -2,6 +2,7 @@
 {
   "name": "Template Tag",
   "property": "template",
+  "caniuse": "template",
   "tags": ["elem"],
   "notes": [{
     "name": "HTML5Rocks Article",

--- a/feature-detects/eventlistener.js
+++ b/feature-detects/eventlistener.js
@@ -2,6 +2,7 @@
 {
   "name": "Event Listener",
   "property": "eventlistener",
+  "caniuse": "addeventlistener",
   "authors": ["Andrew Betts (@triblondon)"],
   "notes": [{
     "name": "W3C Spec",

--- a/feature-detects/gamepad.js
+++ b/feature-detects/gamepad.js
@@ -2,6 +2,7 @@
 {
   "name": "GamePad API",
   "property": "gamepads",
+  "caniuse": "gamepad",
   "authors": ["Eric Bidelman"],
   "tags": ["media"],
   "notes": [{

--- a/feature-detects/iframe/sandbox.js
+++ b/feature-detects/iframe/sandbox.js
@@ -2,6 +2,7 @@
 {
   "name": "iframe[sandbox] Attribute",
   "property": "sandbox",
+  "caniuse": "iframe-sandbox",
   "tags": ["iframe"],
   "builderAliases": ["iframe_sandbox"],
   "notes": [

--- a/feature-detects/iframe/srcdoc.js
+++ b/feature-detects/iframe/srcdoc.js
@@ -2,6 +2,7 @@
 {
   "name": "iframe[srcdoc] Attribute",
   "property": "srcdoc",
+  "caniuse": "iframe-srcdoc",
   "tags": ["iframe"],
   "builderAliases": ["iframe_srcdoc"],
   "notes": [{

--- a/feature-detects/img/apng.js
+++ b/feature-detects/img/apng.js
@@ -3,6 +3,7 @@
   "name": "Animated PNG",
   "async": true,
   "property": "apng",
+  "caniuse": "apng",
   "tags": ["image"],
   "builderAliases": ["img_apng"],
   "notes": [{

--- a/feature-detects/img/jpeg2000.js
+++ b/feature-detects/img/jpeg2000.js
@@ -4,6 +4,7 @@
   "async": true,
   "aliases": ["jpeg-2000", "jpg2"],
   "property": "jpeg2000",
+  "caniuse": "jpeg2000",
   "tags": ["image"],
   "authors": ["@eric_wvgg"],
   "notes": [{

--- a/feature-detects/img/webp.js
+++ b/feature-detects/img/webp.js
@@ -3,6 +3,7 @@
   "name": "Webp",
   "async": true,
   "property": "webp",
+  "caniuse": "webp",
   "tags": ["image"],
   "builderAliases": ["img_webp"],
   "authors": ["Krister Kari", "@amandeep", "Rich Bradshaw", "Ryan Seddon", "Paul Irish"],

--- a/feature-detects/inputsearchevent.js
+++ b/feature-detects/inputsearchevent.js
@@ -2,7 +2,6 @@
 {
   "name": "input[search] search event",
   "property": "inputsearchevent",
-  "caniuse": "input-search",
   "tags": ["input","search"],
   "authors": ["Calvin Webster"],
   "notes": [{

--- a/feature-detects/inputsearchevent.js
+++ b/feature-detects/inputsearchevent.js
@@ -2,6 +2,7 @@
 {
   "name": "input[search] search event",
   "property": "inputsearchevent",
+  "caniuse": "input-search",
   "tags": ["input","search"],
   "authors": ["Calvin Webster"],
   "notes": [{

--- a/feature-detects/intl.js
+++ b/feature-detects/intl.js
@@ -2,6 +2,7 @@
 {
   "name": "Internationalization API",
   "property": "intl",
+  "caniuse": "internationalization",
   "notes": [{
     "name": "MDN Docs",
     "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl"

--- a/feature-detects/network/beacon.js
+++ b/feature-detects/network/beacon.js
@@ -9,6 +9,7 @@
     "href": "https://w3c.github.io/beacon/"
   }],
   "property": "beacon",
+  "caniuse": "beacon",
   "tags": ["beacon", "network"],
   "authors": ["Cătălin Mariș"]
 }

--- a/feature-detects/network/xhr2.js
+++ b/feature-detects/network/xhr2.js
@@ -2,6 +2,7 @@
 {
   "name": "XML HTTP Request Level 2 XHR2",
   "property": "xhr2",
+  "caniuse": "xhr2",
   "tags": ["network"],
   "builderAliases": ["network_xhr2"],
   "notes": [{

--- a/feature-detects/pointerevents.js
+++ b/feature-detects/pointerevents.js
@@ -2,6 +2,7 @@
 {
   "name": "DOM Pointer Events API",
   "property": "pointerevents",
+  "caniuse": "pointer-events",
   "tags": ["input"],
   "authors": ["Stu Cox"],
   "notes": [{

--- a/feature-detects/pointerevents.js
+++ b/feature-detects/pointerevents.js
@@ -2,7 +2,7 @@
 {
   "name": "DOM Pointer Events API",
   "property": "pointerevents",
-  "caniuse": "pointer-events",
+  "caniuse": "pointer",
   "tags": ["input"],
   "authors": ["Stu Cox"],
   "notes": [{

--- a/feature-detects/serviceworker.js
+++ b/feature-detects/serviceworker.js
@@ -2,6 +2,7 @@
 {
   "name": "ServiceWorker API",
   "property": "serviceworker",
+  "caniuse": "serviceworkers",
   "notes": [{
     "name": "ServiceWorkers Explained",
     "href": "https://github.com/slightlyoff/ServiceWorker/blob/master/explainer.md"

--- a/feature-detects/speech/speech-recognition.js
+++ b/feature-detects/speech/speech-recognition.js
@@ -1,6 +1,7 @@
 /*!
 {
   "property": "speechrecognition",
+  "caniuse": "speech-recognition",
   "tags": ["input", "speech"],
   "authors": ["Cătălin Mariș"],
   "name": "Speech Recognition API",

--- a/feature-detects/speech/speech-synthesis.js
+++ b/feature-detects/speech/speech-synthesis.js
@@ -1,6 +1,7 @@
 /*!
 {
   "property": "speechsynthesis",
+  "caniuse": "speech-synthesis",
   "tags": ["input", "speech"],
   "authors": ["Cătălin Mariș"],
   "name": "Speech Synthesis API",

--- a/feature-detects/url/urlsearchparams.js
+++ b/feature-detects/url/urlsearchparams.js
@@ -1,6 +1,7 @@
 /*!
 {
   "property": "urlsearchparams",
+  "caniuse": "urlsearchparams",
   "tags": ["querystring", "url"],
   "authors": ["Cătălin Mariș"],
   "name": "URLSearchParams API",

--- a/feature-detects/vibration.js
+++ b/feature-detects/vibration.js
@@ -2,6 +2,7 @@
 {
   "name": "Vibration API",
   "property": "vibrate",
+  "caniuse": "vibration",
   "notes": [{
     "name": "MDN Docs",
     "href": "https://developer.mozilla.org/en/DOM/window.navigator.mozVibrate"

--- a/feature-detects/webrtc/peerconnection.js
+++ b/feature-detects/webrtc/peerconnection.js
@@ -2,6 +2,7 @@
 {
   "name": "RTC Peer Connection",
   "property": "peerconnection",
+  "caniuse": "rtcpeerconnection",
   "tags": ["webrtc"],
   "authors": ["Ankur Oberoi"],
   "notes": [{


### PR DESCRIPTION
Add the mappings that @PavMel pointed out in #2519, so this would then close #2519

I only have doubts with [csschunit](https://github.com/Modernizr/Modernizr/pull/2535/files#diff-72a64464df4b2f8f4c8f5eb394d5a740) and [cssexunit](https://github.com/Modernizr/Modernizr/pull/2535/files#diff-94016d36369d08fc37d795f62ff398a6) in which the rem page of caniuse is used, but as far as I know they are not the same.

Co-Authored-By: PavMel <pavmel@users.noreply.github.com>