### PR TITLE
Fixes an issue with AVG Secure browser throwing exceptions

### DIFF
--- a/feature-detects/canvas/todataurl.js
+++ b/feature-detects/canvas/todataurl.js
@@ -15,10 +15,24 @@ define(['Modernizr', 'createElement', 'test/canvas'], function(Modernizr, create
   var canvas = createElement('canvas');
 
   Modernizr.addTest('todataurljpeg', function() {
-    return !!Modernizr.canvas && canvas.toDataURL('image/jpeg').indexOf('data:image/jpeg') === 0;
+    var supports = false;
+
+    // AVG secure browser with 'Anti-Fingerprinting' turned on throws an exception when using an "invalid" toDataUrl
+    try {
+      supports = !!Modernizr.canvas && canvas.toDataURL('image/jpeg').indexOf('data:image/jpeg') === 0;
+    } catch (e) {}
+
+    return supports;
   });
   Modernizr.addTest('todataurlpng', function() {
-    return !!Modernizr.canvas && canvas.toDataURL('image/png').indexOf('data:image/png') === 0;
+    var supports = false;
+
+    // AVG secure browser with 'Anti-Fingerprinting' turned on throws an exception when using an "invalid" toDataUrl
+    try {
+      supports = !!Modernizr.canvas && canvas.toDataURL('image/png').indexOf('data:image/png') === 0;
+    } catch (e) {}
+
+    return supports;
   });
   Modernizr.addTest('todataurlwebp', function() {
     var supports = false;


### PR DESCRIPTION
When using either the AVG or AVAST Secure Browser, if you turn "Anti-Fingerprinting" on, it will throw exceptions when attempting to use the result of .toDataURL() from a canvas. This causes 'test/canvas/todataurl' (feature-detects/canvas/todataurl.js) to fail which breaks Modernizr.

The solution is to wrap the test in a try/catch, just like you were already doing for todataurlwebp for firefox anti-fingerprinting but also for todataurlpng and todataurljpeg.
