### PR TITLE
Add avif detection

### DIFF
--- a/feature-detects/img/avif.js
+++ b/feature-detects/img/avif.js
@@ -6,6 +6,7 @@
   "caniuse": "avif",
   "tags": ["image"],
   "authors": ["Markel Ferro (@MarkelFe)"],
+  "polyfills": ["avifjs"],
   "notes": [{
     "name": "Avif Spec",
     "href": "https://aomediacodec.github.io/av1-avif/"

--- a/feature-detects/img/avif.js
+++ b/feature-detects/img/avif.js
@@ -1,0 +1,29 @@
+/*!
+{
+  "name": "AVIF",
+  "async": true,
+  "property": "avif",
+  "caniuse": "avif",
+  "tags": ["image"],
+  "authors": ["Markel Ferro (@MarkelFe)"],
+  "notes": [{
+    "name": "Avif Spec",
+    "href": "https://aomediacodec.github.io/av1-avif/"
+  }]
+}
+!*/
+/* DOC
+Test for AVIF support
+*/
+define(['Modernizr', 'addTest'], function(Modernizr, addTest) {
+
+    Modernizr.addAsyncTest(function() {
+      var image = new Image();
+  
+      image.onload = image.onerror = function() {
+        addTest('avif', image.width === 1);
+      };
+  
+      image.src = 'data:image/avif;base64,AAAAIGZ0eXBhdmlmAAAAAGF2aWZtaWYxbWlhZk1BMUIAAAEcbWV0YQAAAAAAAABIaGRscgAAAAAAAAAAcGljdAAAAAAAAAAAAAAAAGNhdmlmIC0gaHR0cHM6Ly9naXRodWIuY29tL2xpbmstdS9jYXZpZgAAAAAeaWxvYwAAAAAEQAABAAEAAAAAAUQAAQAAABcAAAAqaWluZgEAAAAAAAABAAAAGmluZmUCAAAAAAEAAGF2MDFJbWFnZQAAAAAOcGl0bQAAAAAAAQAAAHJpcHJwAAAAUmlwY28AAAAQcGFzcAAAAAEAAAABAAAAFGlzcGUAAAAAAAAAAQAAAAEAAAAQcGl4aQAAAAADCAgIAAAAFmF2MUOBAAwACggYAAYICGgIIAAAABhpcG1hAAAAAAAAAAEAAQUBAoMDhAAAAB9tZGF0CggYAAYICGgIIBoFHiAAAEQiBACwDoA=';
+    });
+  });

--- a/lib/config-all.json
+++ b/lib/config-all.json
@@ -213,6 +213,7 @@
     "iframe/seamless",
     "iframe/srcdoc",
     "img/apng",
+    "img/avif",
     "img/crossorigin",
     "img/jpeg2000",
     "img/jpegxr",

--- a/lib/polyfills.json
+++ b/lib/polyfills.json
@@ -780,5 +780,11 @@
     "authors": ["Tom Van Cutsem"],
     "href": "https://github.com/tvcutsem/harmony-reflect",
     "licenses": ["Apache2"]
+  },
+  "avifjs": {
+    "name": "Avif.js",
+    "authors": ["Kagami"],
+    "href": "https://github.com/Kagami/avif.js",
+    "licenses": ["CC0"]
   }
 }

--- a/test/browser/integration/caniuse.js
+++ b/test/browser/integration/caniuse.js
@@ -21,6 +21,7 @@ window.caniusecb = function(caniuse) {
       applicationcache: 'offline-apps',
       atobbtoa: 'atob-btoa',
       audio: 'audio',
+      avif: 'avif',
       backdropfilter: 'css-backdrop-filter',
       backgroundblendmode: 'css-backgroundblendmode',
       blobconstructor: 'blobbuilder',


### PR DESCRIPTION
Based on the jpeg2000 test I've added avif detection. 

However, it is a draft pull request for a simple reason: [there is no browser](https://caniuse.com/#feat=avif) to test if it works correctly 😅. I will mark it ready for review whenever there is a browser that supports avif, developments are already being made in [Firefox](https://bugzilla.mozilla.org/show_bug.cgi?id=1625363) and [Chrome](https://chromium-review.googlesource.com/c/chromium/src/+/2101317). At least the false works correctly in Firefox 75 and Brave (Chrome 81). 

Also, I finally learnt how to add tests :)