### PR TITLE
Add metadata documentation

### DIFF
--- a/HOW_TO_WRITE_FEATURE_DETECTS.md
+++ b/HOW_TO_WRITE_FEATURE_DETECTS.md
@@ -1,10 +1,3 @@
-# How to Write Feature Detects
-The scope of this file is to help you to create new feature detects or edit existing ones. Here you will find details and guidelines that will help you understand how
-Modernizr works.
-
-#### Table of contents
-[Metadata](#metadata)
-
 ## Metadata
 At the top of every feature detect in Modernizr there is a JSON fragment that represents the metadata of the test. This data is used, for example, to build the webpage.
 This is an example of this schema (it does not represent a real test): 

--- a/HOW_TO_WRITE_FEATURE_DETECTS.md
+++ b/HOW_TO_WRITE_FEATURE_DETECTS.md
@@ -39,17 +39,17 @@ Here it would go a description of the feature test. You can use **markdown** her
 > Metadata does no need to appear in a set order, however, it is common to see `name` and `property` at the top while `notes` at the bottom.
 
 ### Item description
-|                  | Necesity |                      Description                     |                                       Notes                                      |
-|------------------|:--------:|:----------------------------------------------------:|:--------------------------------------------------------------------------------:|
-| `name`           | required |             Name of the feature detection            |                                                                                  |
-| `property`       | required | The property name established in `Modernizr.addTest` |                   It must be lowercase, without any punctuation                  |
-| `tags`           | optional |    A group that encapsulates many feature detects    |                                                                                  |
-| `caniuse`        | optional |      A conversion table of caniuse and Modernizr     |      Consider adding it to [caniuse.js](test/browser/integration/caniuse.js)     |
-| `authors`        | optional |          List of contributors of the script          |                                                                                  |
-| `builderAliases` | optional |     Used by CI and the web when tests are renamed    |                         Should not be needed in new tests                        |
-| `polyfills`      | optional |     Available polyfills for not working versions     | Any polyfill listed needs to be included in [polyfills.json](lib/polyfills.json) |
-| `aliases`        | optional |   Used if a feature has more than a canonical name   |                             Legacy only - do not use                             |
-| `async`          | optional |       If the test supports async functionality       |                                 Defaults to false                                |
-| `warnings`       | optional |        Notes to the developer using the script       |                          Don't mistake it for knownBugs                          |
-| `knownBugs`      | optional |  Bugs known of the test (e.g.: doesn't work in IE6)  |                                                                                  |
-| `notes`          | optional |                  Links to resources                  |                                                                                  |
+|                  | Necessity |                      Description                     |                                       Notes                                      |
+|------------------|:---------:|:----------------------------------------------------:|:--------------------------------------------------------------------------------:|
+| `name`           |  required |             Name of the feature detection            |                                                                                  |
+| `property`       |  required | The property name established in `Modernizr.addTest` |                   It must be lowercase, without any punctuation                  |
+| `tags`           |  optional |    A group that encapsulates many feature detects    |                                                                                  |
+| `caniuse`        |  optional |      A conversion table of caniuse and Modernizr     |      Consider adding it to [caniuse.js](test/browser/integration/caniuse.js)     |
+| `authors`        |  optional |          List of contributors of the script          |                                                                                  |
+| `builderAliases` |  optional |     Used by CI and the web when tests are renamed    |                         Should not be needed in new tests                        |
+| `polyfills`      |  optional |     Available polyfills for not working versions     | Any polyfill listed needs to be included in [polyfills.json](lib/polyfills.json) |
+| `aliases`        |  optional |   Used if a feature has more than a canonical name   |                             Legacy only - do not use                             |
+| `async`          |  optional |       If the test supports async functionality       |                                 Defaults to false                                |
+| `warnings`       |  optional |        Notes to the developer using the script       |                          Don't mistake it for knownBugs                          |
+| `knownBugs`      |  optional |  Bugs known of the test (e.g.: doesn't work in IE6)  |                                                                                  |
+| `notes`          |  optional |                  Links to resources                  |                                                                                  |

--- a/HOW_TO_WRITE_FEATURE_DETECTS.md
+++ b/HOW_TO_WRITE_FEATURE_DETECTS.md
@@ -1,3 +1,10 @@
+# How to Write Feature Detects
+The scope of this file is to help you to create new feature detects or edit existing ones. Here you will find details and guidelines that will help you understand how
+Modernizr works.
+
+#### Table of contents
+[Metadata](#metadata)
+
 ## Metadata
 At the top of every feature detect in Modernizr there is a JSON fragment that represents the metadata of the test. This data is used, for example, to build the webpage.
 This is an example of this schema (it does not represent a real test): 

--- a/HOW_TO_WRITE_FEATURE_DETECTS.md
+++ b/HOW_TO_WRITE_FEATURE_DETECTS.md
@@ -1,7 +1,7 @@
-# Metadata
+## Metadata
 At the top of every feature detect in Modernizr there is a JSON fragment that represents the metadata of the test. This data is used, for example, to build the webpage.
 This is an example of this schema (it does not represent a real test): 
-## Schema
+### Schema
 ```json
 /*!
 {
@@ -31,7 +31,7 @@ Here it would go a description of the feature test. You can use **markdown** her
 ```
 > There is no set order in which they must appear, but it is common to see `name` and `property` at the top while `notes` at the bottom.
 
-## Item description
+### Item description
 |                  | Necesity |                      Description                     |                                       Notes                                      |
 |------------------|:--------:|:----------------------------------------------------:|:--------------------------------------------------------------------------------:|
 | `name`           | required |             Name of the feature detection            |                                                                                  |

--- a/HOW_TO_WRITE_FEATURE_DETECTS.md
+++ b/HOW_TO_WRITE_FEATURE_DETECTS.md
@@ -6,19 +6,19 @@ Modernizr works.
 [Metadata](#metadata)
 
 ## Metadata
-At the top of every feature detect in Modernizr there is a JSON fragment that represents the metadata of the test. This data is used, for example, to build the webpage.
-This is an example of this schema (it does not represent a real test): 
+A JSON fragment at the top of every feature detect in Modernizr represents the metadata of the test. This data is used, for example, to build the webpage.
 ### Schema
+The following code represents an example of the schema (it does not represent a real test):
 ```json
 /*!
 {
   "name": "JPEG 2000",
   "property": "jpeg2000",
-  "tags": ["media", "attribute"],
+  "tags": ["media", "image"],
   "caniuse": "jpeg2000",
   "authors": ["Markel Ferro (@MarkelFe)", "@rejas", "Brandom Aaron"],
-  "builderAliases": ["a_download"],
-  "polyfills": ["xaudiojs"],
+  "builderAliases": ["jpeg2"],
+  "polyfills": ["jpeg2000js"],
   "aliases": ["jpeg-2000", "jpg2"],
   "async": true,
   "warnings": ["These tests currently require document.body to be present"],
@@ -36,7 +36,7 @@ This is an example of this schema (it does not represent a real test):
 Here it would go a description of the feature test. You can use **markdown** here :)
 */
 ```
-> There is no set order in which they must appear, but it is common to see `name` and `property` at the top while `notes` at the bottom.
+> Metadata does no need to appear in a set order, however, it is common to see `name` and `property` at the top while `notes` at the bottom.
 
 ### Item description
 |                  | Necesity |                      Description                     |                                       Notes                                      |

--- a/metadata.md
+++ b/metadata.md
@@ -38,7 +38,7 @@ Here it would go a description of the feature test. You can use **markdown** her
 | `property`       | required | The property name established in `Modernizr.addTest` |                   It must be lowercase, without any punctuation                  |
 | `tags`           | optional |    A group that encapsulates many feature detects    |                                                                                  |
 | `caniuse`        | optional |      A conversion table of caniuse and Modernizr     |      Consider adding it to [caniuse.js](test/browser/integration/caniuse.js)     |
-| `authors`        | optional |          List of contributors of the script          |                     There are a couple of ways to express it                     |
+| `authors`        | optional |          List of contributors of the script          |                                                                                  |
 | `builderAliases` | optional |     Used by CI and the web when tests are renamed    |                         Should not be needed in new tests                        |
 | `polyfills`      | optional |     Available polyfills for not working versions     | Any polyfill listed needs to be included in [polyfills.json](lib/polyfills.json) |
 | `aliases`        | optional |   Used if a feature has more than a canonical name   |                             Legacy only - do not use                             |

--- a/metadata.md
+++ b/metadata.md
@@ -39,7 +39,7 @@ Here it would go a description of the feature test. You can use **markdown** her
 | `tags`           | optional |    A group that encapsulates many feature detects    |                                                           |
 | `caniuse`        | optional |      A conversion table of caniuse and Modernizr     | Consider adding it to test/browser/integration/caniuse.js |
 | `authors`        | optional |          List of contributors of the script          |          There are a couple of ways to express it         |
-| `builderAliases` | optional |                                                      |                                                           |
+| `builderAliases` | optional |     Used by CI and the web when tests are renamed    |                                                           |
 | `polyfills`      | optional |     Available polyfills for not working versions     |               Add them in lib/polyfills.json              |
 | `aliases`        | optional |         Other names that the feature goes by         |                                                           |
 | `async`          | optional |       If the test supports async functionality       |                     Defaults to false                     |

--- a/metadata.md
+++ b/metadata.md
@@ -32,17 +32,17 @@ Here it would go a description of the feature test. You can use **markdown** her
 > There is no set order in which they must appear, but it is common to see `name` and `property` at the top while `notes` at the bottom.
 
 ## Item description
-|                  | Necesity |                      Description                     |                        Notes                       |
-|------------------|:--------:|:----------------------------------------------------:|:--------------------------------------------------:|
-| `name`           | required |             Name of the feature detection            |                                                    |
-| `property`       | required | The property name established in `Modernizr.addTest` | Preferably just lowercase, without any punctuation |
-| `tags`           | optional |                                                      |                                                    |
-| `caniuse`        | optional |                                                      |                                                    |
-| `authors`        | optional |          List of contributors of the script          |      There are a couple of ways to express it      |
-| `builderAliases` | optional |                                                      |                                                    |
-| `polyfills`      | optional |     Available polyfills for not working versions     |           Add them in lib/polyfills.json           |
-| `aliases`        | optional |         Other names that the feature goes by         |                   Used for search                  |
-| `async`          | optional |       If the test supports async functionality       |                  Defaults to false                 |
-| `warnings`       | optional |        Notes to the developer using the script       |           Don't mistake it for knownBugs           |
-| `knownBugs`      | optional |  Bugs known of the test (e.g.: doesn't work in IE6)  |                                                    |
-| `notes`          | optional |                  Links to resources                  |                                                    |
+|                  | Necesity |                      Description                     |                           Notes                           |
+|------------------|:--------:|:----------------------------------------------------:|:---------------------------------------------------------:|
+| `name`           | required |             Name of the feature detection            |                                                           |
+| `property`       | required | The property name established in `Modernizr.addTest` |     Preferably just lowercase, without any punctuation    |
+| `tags`           | optional |    A group that encapsulates many feature detects    |                                                           |
+| `caniuse`        | optional |      A conversion table of caniuse and Modernizr     | Consider adding it to test/browser/integration/caniuse.js |
+| `authors`        | optional |          List of contributors of the script          |          There are a couple of ways to express it         |
+| `builderAliases` | optional |                                                      |                                                           |
+| `polyfills`      | optional |     Available polyfills for not working versions     |               Add them in lib/polyfills.json              |
+| `aliases`        | optional |         Other names that the feature goes by         |                                                           |
+| `async`          | optional |       If the test supports async functionality       |                     Defaults to false                     |
+| `warnings`       | optional |        Notes to the developer using the script       |               Don't mistake it for knownBugs              |
+| `knownBugs`      | optional |  Bugs known of the test (e.g.: doesn't work in IE6)  |                                                           |
+| `notes`          | optional |                  Links to resources                  |                                                           |

--- a/metadata.md
+++ b/metadata.md
@@ -1,6 +1,6 @@
 # Metadata
-At the top of every feature detect in Modernizr there is a JSON fragment that represents the metadata of the test. This data is used to build the webpage, for example.
-This is an example of this schema and does not represent a real test: 
+At the top of every feature detect in Modernizr there is a JSON fragment that represents the metadata of the test. This data is used, for example, to build the webpage.
+This is an example of this schema (it does not represent a real test): 
 ## Schema
 ```json
 /*!
@@ -32,17 +32,17 @@ Here it would go a description of the feature test. You can use **markdown** her
 > There is no set order in which they must appear, but it is common to see `name` and `property` at the top while `notes` at the bottom.
 
 ## Item description
-|                  | Necesity |                      Description                     |                           Notes                           |
-|------------------|:--------:|:----------------------------------------------------:|:---------------------------------------------------------:|
-| `name`           | required |             Name of the feature detection            |                                                           |
-| `property`       | required | The property name established in `Modernizr.addTest` |     Preferably just lowercase, without any punctuation    |
-| `tags`           | optional |    A group that encapsulates many feature detects    |                                                           |
-| `caniuse`        | optional |      A conversion table of caniuse and Modernizr     | Consider adding it to test/browser/integration/caniuse.js |
-| `authors`        | optional |          List of contributors of the script          |          There are a couple of ways to express it         |
-| `builderAliases` | optional |     Used by CI and the web when tests are renamed    |                                                           |
-| `polyfills`      | optional |     Available polyfills for not working versions     |               Add them in lib/polyfills.json              |
-| `aliases`        | optional |   Used if a feature has more than a canonical name   |             Should not be needed in new tests             |
-| `async`          | optional |       If the test supports async functionality       |                     Defaults to false                     |
-| `warnings`       | optional |        Notes to the developer using the script       |               Don't mistake it for knownBugs              |
-| `knownBugs`      | optional |  Bugs known of the test (e.g.: doesn't work in IE6)  |                                                           |
-| `notes`          | optional |                  Links to resources                  |                                                           |
+|                  | Necesity |                      Description                     |                                  Notes                                  |
+|------------------|:--------:|:----------------------------------------------------:|:-----------------------------------------------------------------------:|
+| `name`           | required |             Name of the feature detection            |                                                                         |
+| `property`       | required | The property name established in `Modernizr.addTest` |            Preferably just lowercase, without any punctuation           |
+| `tags`           | optional |    A group that encapsulates many feature detects    |                                                                         |
+| `caniuse`        | optional |      A conversion table of caniuse and Modernizr     | Consider adding it to [caniuse.js](test/browser/integration/caniuse.js) |
+| `authors`        | optional |          List of contributors of the script          |                 There are a couple of ways to express it                |
+| `builderAliases` | optional |     Used by CI and the web when tests are renamed    |                    Should not be needed in new tests                    |
+| `polyfills`      | optional |     Available polyfills for not working versions     |             Add them in [polyfills.json](lib/polyfills.json)            |
+| `aliases`        | optional |   Used if a feature has more than a canonical name   |                    Should not be needed in new tests                    |
+| `async`          | optional |       If the test supports async functionality       |                            Defaults to false                            |
+| `warnings`       | optional |        Notes to the developer using the script       |                      Don't mistake it for knownBugs                     |
+| `knownBugs`      | optional |  Bugs known of the test (e.g.: doesn't work in IE6)  |                                                                         |
+| `notes`          | optional |                  Links to resources                  |                                                                         |

--- a/metadata.md
+++ b/metadata.md
@@ -41,7 +41,7 @@ Here it would go a description of the feature test. You can use **markdown** her
 | `authors`        | optional |          List of contributors of the script          |          There are a couple of ways to express it         |
 | `builderAliases` | optional |     Used by CI and the web when tests are renamed    |                                                           |
 | `polyfills`      | optional |     Available polyfills for not working versions     |               Add them in lib/polyfills.json              |
-| `aliases`        | optional |         Other names that the feature goes by         |                                                           |
+| `aliases`        | optional |   Used if a feature has more than a canonical name   |             Should not be needed in new tests             |
 | `async`          | optional |       If the test supports async functionality       |                     Defaults to false                     |
 | `warnings`       | optional |        Notes to the developer using the script       |               Don't mistake it for knownBugs              |
 | `knownBugs`      | optional |  Bugs known of the test (e.g.: doesn't work in IE6)  |                                                           |

--- a/metadata.md
+++ b/metadata.md
@@ -32,17 +32,17 @@ Here it would go a description of the feature test. You can use **markdown** her
 > There is no set order in which they must appear, but it is common to see `name` and `property` at the top while `notes` at the bottom.
 
 ## Item description
-|                  | Necesity |                      Description                     |                                  Notes                                  |
-|------------------|:--------:|:----------------------------------------------------:|:-----------------------------------------------------------------------:|
-| `name`           | required |             Name of the feature detection            |                                                                         |
-| `property`       | required | The property name established in `Modernizr.addTest` |            Preferably just lowercase, without any punctuation           |
-| `tags`           | optional |    A group that encapsulates many feature detects    |                                                                         |
-| `caniuse`        | optional |      A conversion table of caniuse and Modernizr     | Consider adding it to [caniuse.js](test/browser/integration/caniuse.js) |
-| `authors`        | optional |          List of contributors of the script          |                 There are a couple of ways to express it                |
-| `builderAliases` | optional |     Used by CI and the web when tests are renamed    |                    Should not be needed in new tests                    |
-| `polyfills`      | optional |     Available polyfills for not working versions     |             Add them in [polyfills.json](lib/polyfills.json)            |
-| `aliases`        | optional |   Used if a feature has more than a canonical name   |                    Should not be needed in new tests                    |
-| `async`          | optional |       If the test supports async functionality       |                            Defaults to false                            |
-| `warnings`       | optional |        Notes to the developer using the script       |                      Don't mistake it for knownBugs                     |
-| `knownBugs`      | optional |  Bugs known of the test (e.g.: doesn't work in IE6)  |                                                                         |
-| `notes`          | optional |                  Links to resources                  |                                                                         |
+|                  | Necesity |                      Description                     |                                       Notes                                      |
+|------------------|:--------:|:----------------------------------------------------:|:--------------------------------------------------------------------------------:|
+| `name`           | required |             Name of the feature detection            |                                                                                  |
+| `property`       | required | The property name established in `Modernizr.addTest` |                   It must be lowercase, without any punctuation                  |
+| `tags`           | optional |    A group that encapsulates many feature detects    |                                                                                  |
+| `caniuse`        | optional |      A conversion table of caniuse and Modernizr     |      Consider adding it to [caniuse.js](test/browser/integration/caniuse.js)     |
+| `authors`        | optional |          List of contributors of the script          |                     There are a couple of ways to express it                     |
+| `builderAliases` | optional |     Used by CI and the web when tests are renamed    |                         Should not be needed in new tests                        |
+| `polyfills`      | optional |     Available polyfills for not working versions     | Any polyfill listed needs to be included in [polyfills.json](lib/polyfills.json) |
+| `aliases`        | optional |   Used if a feature has more than a canonical name   |                             Legacy only - do not use                             |
+| `async`          | optional |       If the test supports async functionality       |                                 Defaults to false                                |
+| `warnings`       | optional |        Notes to the developer using the script       |                          Don't mistake it for knownBugs                          |
+| `knownBugs`      | optional |  Bugs known of the test (e.g.: doesn't work in IE6)  |                                                                                  |
+| `notes`          | optional |                  Links to resources                  |                                                                                  |

--- a/metadata.md
+++ b/metadata.md
@@ -1,0 +1,48 @@
+# Metadata
+At the top of every feature detect in Modernizr there is a JSON fragment that represents the metadata of the test. This data is used to build the webpage, for example.
+This is an example of this schema and does not represent a real test: 
+## Schema
+```json
+/*!
+{
+  "name": "JPEG 2000",
+  "property": "jpeg2000",
+  "tags": ["media", "attribute"],
+  "caniuse": "jpeg2000",
+  "authors": ["Markel Ferro (@MarkelFe)", "@rejas", "Brandom Aaron"],
+  "builderAliases": ["a_download"],
+  "polyfills": ["xaudiojs"],
+  "aliases": ["jpeg-2000", "jpg2"],
+  "async": true,
+  "warnings": ["These tests currently require document.body to be present"],
+  "knownBugs": ["This will false positive in IE6"],
+  "notes": [{
+    "name": "Specification",
+    "href": "https://www.w3.org/"
+  }, {
+    "name": "Github issue",
+    "href": "https://github.com/Modernizr/"
+  }]
+}
+!*/
+/* DOC
+Here it would go a description of the feature test. You can use **markdown** here :)
+*/
+```
+> There is no set order in which they must appear, but it is common to see `name` and `property` at the top while `notes` at the bottom.
+
+## Item description
+|                  | Necesity |                      Description                     |                        Notes                       |
+|------------------|:--------:|:----------------------------------------------------:|:--------------------------------------------------:|
+| `name`           | required |             Name of the feature detection            |                                                    |
+| `property`       | required | The property name established in `Modernizr.addTest` | Preferably just lowercase, without any punctuation |
+| `tags`           | optional |                                                      |                                                    |
+| `caniuse`        | optional |                                                      |                                                    |
+| `authors`        | optional |          List of contributors of the script          |      There are a couple of ways to express it      |
+| `builderAliases` | optional |                                                      |                                                    |
+| `polyfills`      | optional |     Available polyfills for not working versions     |           Add them in lib/polyfills.json           |
+| `aliases`        | optional |         Other names that the feature goes by         |                   Used for search                  |
+| `async`          | optional |       If the test supports async functionality       |                  Defaults to false                 |
+| `warnings`       | optional |        Notes to the developer using the script       |           Don't mistake it for knownBugs           |
+| `knownBugs`      | optional |  Bugs known of the test (e.g.: doesn't work in IE6)  |                                                    |
+| `notes`          | optional |                  Links to resources                  |                                                    |


### PR DESCRIPTION
I found out that there was no documentation for the metadata of the files, so I created a little Markdown file explaining what every piece of metadata represents + putting all of them together, as all the detects don't have the same amount of metadata.

I didn't know where to put this information, so I created a new file, feel free to suggest any other location.

There is also some of them that I don't know their functionality, I'll comment them on line comments.
