### PR TITLE
Require minimal values for metadata

### DIFF
--- a/lib/metadata.js
+++ b/lib/metadata.js
@@ -66,17 +66,10 @@ function metadata(cb) {
       metadata.path = './' + (start + '/' + file).replace(baseDir, '').replace(/\\/g, '/');
       metadata.amdPath = metadata.path.replace(/^\.\/feature\-detects/, 'test').replace(/\.js$/i, '');
 
-      // Force minimal metadata #2548
+      // Force minimal metadata #2551
+      // Consider adding new tests in test/node/lib/metadata.js if you add new minimal requirements
       if (!metadata.name || !metadata.property) {
-        process.emitWarning('\x1b[31mRequired values missing', {
-          code: 'MINIMAL_METADATA',
-          detail: file + ' is missing required values of metadata please refer to HOW_TO_WRITE_FEATURE_DETECTS.md. Check for typos too.\x1b[0m'
-        });
-      }
-
-      // Preserve to reduce number of errors
-      if (!metadata.name) {
-        metadata.name = metadata.amdPath;
+        throw new Error('Minimal metadata not found in `' + file + '`')
       }
 
       var pfs = [];

--- a/lib/metadata.js
+++ b/lib/metadata.js
@@ -70,11 +70,11 @@ function metadata(cb) {
       if (!metadata.name || !metadata.property) {
         process.emitWarning('\x1b[31mRequired values missing', {
           code: 'MINIMAL_METADATA',
-          detail: file + ' is missing required values of metadata please refer to HOW_TO_WRITE_FEATURE_DETECTS.md\x1b[0m'
+          detail: file + ' is missing required values of metadata please refer to HOW_TO_WRITE_FEATURE_DETECTS.md. Check for typos too.\x1b[0m'
         });
       }
 
-      // Preserve reduce number of errors
+      // Preserve to reduce number of errors
       if (!metadata.name) {
         metadata.name = metadata.amdPath;
       }

--- a/lib/metadata.js
+++ b/lib/metadata.js
@@ -66,6 +66,15 @@ function metadata(cb) {
       metadata.path = './' + (start + '/' + file).replace(baseDir, '').replace(/\\/g, '/');
       metadata.amdPath = metadata.path.replace(/^\.\/feature\-detects/, 'test').replace(/\.js$/i, '');
 
+      // Force minimal metadata #2548
+      if (!metadata.name || !metadata.property) {
+        process.emitWarning('\x1b[31mRequired values missing', {
+          code: 'MINIMAL_METADATA',
+          detail: file + ' is missing required values of metadata please refer to HOW_TO_WRITE_FEATURE_DETECTS.md\x1b[0m'
+        });
+      }
+
+      // Preserve reduce number of errors
       if (!metadata.name) {
         metadata.name = metadata.amdPath;
       }

--- a/test/node/lib/metadata.js
+++ b/test/node/lib/metadata.js
@@ -76,8 +76,7 @@ describe('cli/metadata', function() {
     expect(metadata).to.throw(/Couldn't find the define/);
   });
 
-  // Checks for missing names
-  it('should throw if we can\'t find the define', function() {
+  it('should throw if no name is defined', function() {
 
     var metadata = proxyquire(root + 'lib/metadata', {
       'fs': {
@@ -90,8 +89,7 @@ describe('cli/metadata', function() {
     expect(metadata).to.throw(/Minimal metadata not found/);
   });
 
-  // Checks for missing properties
-  it('should throw if we can\'t find the define', function() {
+  it('should throw if no property is defined', function() {
 
     var metadata = proxyquire(root + 'lib/metadata', {
       'fs': {
@@ -104,8 +102,7 @@ describe('cli/metadata', function() {
     expect(metadata).to.throw(/Minimal metadata not found/);
   });
 
-  // Checks for incorrect polyfills
-  it('should throw if we can\'t find the define', function() {
+  it('should throw if polyfill is incorrectly configured', function() {
 
     var metadata = proxyquire(root + 'lib/metadata', {
       'fs': {
@@ -118,7 +115,7 @@ describe('cli/metadata', function() {
     expect(metadata).to.throw(/Polyfill not found/);
   });
 
-  it('should throw if we can\'t find the define', function() {
+  it('should return null if cssclass is incorrectly configured', function() {
 
     var metadata = proxyquire(root + 'lib/metadata', {
       'fs': {

--- a/test/node/lib/metadata.js
+++ b/test/node/lib/metadata.js
@@ -76,31 +76,41 @@ describe('cli/metadata', function() {
     expect(metadata).to.throw(/Couldn't find the define/);
   });
 
-  it('should use amdPath as a fallback for name', function() {
+  // Checks for missing names
+  it('should throw if we can\'t find the define', function() {
 
     var metadata = proxyquire(root + 'lib/metadata', {
-      'file': {
-        'walkSync': function(dir, cb) {
-          cb('/', [], ['fakeDetect.js']);
-        }
-      },
       'fs': {
         'readFileSync': function() {
           return '/*! { "property": "fake"}!*/ define([],';
         }
       }
     });
-    var result = metadata();
 
-    expect(result.name).to.be.equal(result.amdPath);
+    expect(metadata).to.throw(/Minimal metadata not found/);
   });
 
+  // Checks for missing properties
   it('should throw if we can\'t find the define', function() {
 
     var metadata = proxyquire(root + 'lib/metadata', {
       'fs': {
         'readFileSync': function() {
-          return '/*! { "polyfills": ["fake"]}!*/ define([],';
+          return '/*! { "name": "fake"}!*/ define([],';
+        }
+      }
+    });
+
+    expect(metadata).to.throw(/Minimal metadata not found/);
+  });
+
+  // Checks for incorrect polyfills
+  it('should throw if we can\'t find the define', function() {
+
+    var metadata = proxyquire(root + 'lib/metadata', {
+      'fs': {
+        'readFileSync': function() {
+          return '/*! { "name": "fake", "property": "fake", "polyfills": ["fake"]}!*/ define([],';
         }
       }
     });
@@ -113,7 +123,7 @@ describe('cli/metadata', function() {
     var metadata = proxyquire(root + 'lib/metadata', {
       'fs': {
         'readFileSync': function() {
-          return '/*! { "property": "fake", "cssclass": "realFake"}!*/ define([],';
+          return '/*! { "name": "fake", "property": "fake", "cssclass": "realFake"}!*/ define([],';
         }
       }
     });
@@ -128,7 +138,7 @@ describe('cli/metadata', function() {
     var metadata = proxyquire(root + 'lib/metadata', {
       'fs': {
         'readFileSync': function() {
-          return '/*! { "docs": "originally docs" }!*/ define([],';
+          return '/*! { "name": "fake", "property": "fake", "docs": "originally docs" }!*/ define([],';
         }
       }
     });


### PR DESCRIPTION
This PR closes #2548. 

Check the history if you want to see the original description.

Basically it requires the "name" and "property" values of the metadata to be filled. If they are null an error will be thrown.

The old system did `metadata.name = metadata.amdPath` if the name value was empty but `audio/ambientlight.js` is a horrible name for a feature detect.

The PR also edits the mocha:node tests in order to accommodate these changes (I've learnt that debugging tests is horrible)