### PR TITLE
Use require() to lookup path to lodash, rather than guess

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -145,7 +145,7 @@ if (inBrowser) {
 
   baseRequireConfig.baseUrl = __dirname + '/../src';
   baseRequireConfig.paths = {
-    lodash: __dirname + '/../node_modules/lodash/lodash',
+    lodash: require.resolve('lodash'),
     test: __dirname + '/../feature-detects',
     lib: __dirname
   };


### PR DESCRIPTION
fixes #2556