### PR TITLE
Avoid testing in only docs files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,14 @@ node_js:
 before_install:
   - npm install -g npm@latest
 before_script:
+  - |
+      if ! git diff --name-only $TRAVIS_COMMIT_RANGE | grep -qvE '(.md)|(.png)|(.ai)|(.svg)|(.jpg)|(.pdf)|^(LICENSE)|^(docs)|^(media)'
+      then
+        echo "Only doc files were updated, not running the CI."
+        exit
+      fi
   - npm install -g gulp-cli
 after_success:
   - ./node_modules/.bin/nyc report --reporter=text-lcov | ./node_modules/.bin/codecov --pipe
 script:
   - npm test
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_install:
   - npm install -g npm@latest
 before_script:
   - |
-      if ! git diff --name-only $TRAVIS_COMMIT_RANGE | grep -qvE '(.md)|(.png)|(.ai)|(.svg)|(.jpg)|(.pdf)|^(LICENSE)|^(docs)|^(media)'
+      if ! git diff --name-only $TRAVIS_COMMIT_RANGE | grep -qvE '(.md)'
       then
         echo "Only doc files were updated, not running the CI."
         exit

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,6 +13,19 @@ build: off
 before_test:
   - npm install -g gulp-cli
 
+# Skipping specific commit files: https://www.appveyor.com/docs/appveyor-yml and https://www.appveyor.com/docs/how-to/filtering-commits
+skip_commits:
+  files:
+    - '**/*.md'
+    - '**/*.png'
+    - '**/*.ai'
+    - '**/*.svg'
+    - '**/*.jpg'
+    - '**/*.pdf'
+    - LICENSE
+    - docs/*
+    - media/*
+
 test_script:
   - node --version
   - npm --version

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,14 +17,6 @@ before_test:
 skip_commits:
   files:
     - '**/*.md'
-    - '**/*.png'
-    - '**/*.ai'
-    - '**/*.svg'
-    - '**/*.jpg'
-    - '**/*.pdf'
-    - LICENSE
-    - docs/*
-    - media/*
 
 test_script:
   - node --version


### PR DESCRIPTION
This will avoid testing if only .md files (and another bunch) are edited. I know that [skip ci] exists but that makes the git log ugly.

Travis CI skip extracted from here: [https://github.com/google/EarlGrey/pull/383/files/3b38a5dea36a88aba42a42931e77a7c5429a1837](https://github.com/google/EarlGrey/pull/383/files/3b38a5dea36a88aba42a42931e77a7c5429a1837)