### PR TITLE
Set SameSite in cookie test

### DIFF
--- a/feature-detects/cookies.js
+++ b/feature-detects/cookies.js
@@ -24,10 +24,10 @@ define(['Modernizr'], function(Modernizr) {
     // or in sandboxed iframes (depending on flags/context)
     try {
       // Create cookie
-      document.cookie = 'cookietest=1';
+      document.cookie = 'cookietest=1; SameSite=Lax';
       var ret = document.cookie.indexOf('cookietest=') !== -1;
       // Delete cookie
-      document.cookie = 'cookietest=1; expires=Thu, 01-Jan-1970 00:00:01 GMT';
+      document.cookie = 'cookietest=1; SameSite=Lax; expires=Thu, 01-Jan-1970 00:00:01 GMT';
       return ret;
     }
     catch (e) {


### PR DESCRIPTION
Solves #2589 , kinda, but yes (feel free not to close the issue if you want)

The PR basically does what the title says, it really shouldn't affect as the cookie it's deleted once the test is performed, but hey the [Chromium team recommends it](https://blog.chromium.org/2019/10/developers-get-ready-for-new.html)

> However we strongly recommend you apply an appropriate SameSite value (Lax or Strict) and not rely on default browser behavior since not all browsers protect same-site cookies by default.

Moreover, the [caniuse page shows us](https://caniuse.com/#feat=same-site-cookie-attribute) that this feature is backwards compatible so it shouldn't result on any errors in old browsers

> This feature is backwards compatible. Browsers not supporting this feature will simply use the cookie as a regular cookie. There is no need to deliver different cookies to clients.

And if you are asking why I used `Lax` instead of `Strict` is because I prefer to be safe than sorry even if it shouldn't make any difference 😅