### PR TITLE
Solve `Command exited with code -1073741819` in AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,7 @@ environment:
     - nodejs_version: 14
 
 install:
-  - ps: Install-Product node $env:nodejs_version
+  - ps: Install-Product node $env:nodejs_version x64
   - npm install
 
 build: off


### PR DESCRIPTION
Fixes #2583 (finally)

It basically uses the x64 version of node as the x86 version seems to have a bug that causes the `code -1073741819` error which has been making tests to fail since node 14's introduction. I just hope that this works, it is really annoying to see all tests fail 😢

The solution comes from here: https://help.appveyor.com/discussions/problems/28111-code-1073741819