### PR TITLE
Require changes for codecov comment

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,2 @@
+comment:
+  require_changes: true


### PR DESCRIPTION
[I know you like the comment from codecov](https://github.com/Modernizr/Modernizr/pull/2554#issuecomment-623045044) but I don't know, I find the idea of adding a comment to a PR which does not change the coverage at all to be a little bit annoying (specially because it counts as a notification to Github). This PR adds the necessity of having a coverage change for the comment to be posted. 