### PR TITLE
Fix datachannel test breaking Modernizr on PS4

### DIFF
--- a/feature-detects/webrtc/datachannel.js
+++ b/feature-detects/webrtc/datachannel.js
@@ -19,8 +19,12 @@ define(['Modernizr', 'prefixed', 'domPrefixesAll', 'test/webrtc/peerconnection']
     for (var i = 0, len = domPrefixesAll.length; i < len; i++) {
       var PeerConnectionConstructor = window[domPrefixesAll[i] + 'RTCPeerConnection'];
       if (PeerConnectionConstructor) {
-        var peerConnection = new PeerConnectionConstructor(null);
-        return 'createDataChannel' in peerConnection;
+        // Wrapped in a try catch to avoid "Error creating RTCPeerConnection" #2599 & #2221
+        try {
+          var peerConnection = new PeerConnectionConstructor({});
+          return 'createDataChannel' in peerConnection;
+        } catch (e) {
+        }
       }
     }
     return false;


### PR DESCRIPTION
On PS4 the following happens:

> new webkitRTCPeerConnection(null)
> TypeError: RTCPeerConnection argument must be a valid Dictionary
>
> new webkitRTCPeerConnection({})
> TypeError: Error creating RTCPeerConnection

Screenshot:
<img width="582" alt="Screenshot 2020-09-04 at 15 06 59" src="https://user-images.githubusercontent.com/531168/92248792-2419f080-eec1-11ea-88d4-4bae97a274d0.png">

Duplicate of https://github.com/Modernizr/Modernizr/pull/2221, but that PR has been open for 2 years and has conflicts.