### PR TITLE
Add valid chars test for the property of metadata

### DIFF
--- a/lib/metadata.js
+++ b/lib/metadata.js
@@ -84,11 +84,11 @@ function metadata(cb) {
         });
       }
 
-      //Raise error if metadata.property is NOT a lowercase string
+      //metadata.property can only have lowercase alphanumeric and dashes
       const properties = Array.isArray(metadata.property) ? metadata.property : [metadata.property];
       properties.forEach(function (property) {
-        if (property.match(/[A-Z]/)) {
-          throw new Error(metadata.name + ' : ' + property + ': Property must be a lowercase string ' )
+        if (!property.match(/^[a-z0-9-]+$/)) {
+          throw new Error(metadata.name + ' : ' + property + ': Property can only have lowercase alphanumeric characters and dashes ' )
         }
       })
 

--- a/lib/metadata.js
+++ b/lib/metadata.js
@@ -83,6 +83,7 @@ function metadata(cb) {
           }
         });
       }
+      metadata.polyfills = pfs;
 
       //metadata.property can only have lowercase alphanumeric and dashes
       const properties = Array.isArray(metadata.property) ? metadata.property : [metadata.property];
@@ -91,8 +92,6 @@ function metadata(cb) {
           throw new Error(metadata.name + ' : ' + property + ': Property can only have lowercase alphanumeric characters and dashes ' )
         }
       })
-
-      metadata.polyfills = pfs;
 
       if (!metadata.async) {
         metadata.async = false;

--- a/lib/metadata.js
+++ b/lib/metadata.js
@@ -83,6 +83,15 @@ function metadata(cb) {
           }
         });
       }
+
+      //Raise error if metadata.property is NOT a lowercase string
+      const properties = Array.isArray(metadata.property) ? metadata.property : [metadata.property];
+      properties.forEach(function (property) {
+        if (property.match(/[A-Z]/)) {
+          throw new Error(metadata.name + ' : ' + property + ': Property must be a lowercase string ' )
+        }
+      })
+
       metadata.polyfills = pfs;
 
       if (!metadata.async) {

--- a/test/node/lib/metadata.js
+++ b/test/node/lib/metadata.js
@@ -102,7 +102,7 @@ describe('cli/metadata', function() {
     expect(metadata).to.throw(/Minimal metadata not found/);
   });
 
-  it('should throw if property is an uppercase string', function() {
+  it('should throw if property contains uppercase characters and/or special symbols except dashes', function() {
 
     var metadata = proxyquire(root + 'lib/metadata', {
       'fs': {
@@ -111,7 +111,7 @@ describe('cli/metadata', function() {
         }
       }
     });
-    expect(metadata).to.throw(/Property must be a lowercase string/);
+    expect(metadata).to.throw(/Property can only have lowercase alphanumeric characters and dashes/);
   });
 
   it('should throw if polyfill is incorrectly configured', function() {

--- a/test/node/lib/metadata.js
+++ b/test/node/lib/metadata.js
@@ -102,6 +102,18 @@ describe('cli/metadata', function() {
     expect(metadata).to.throw(/Minimal metadata not found/);
   });
 
+  it('should throw if property is an uppercase string', function() {
+
+    var metadata = proxyquire(root + 'lib/metadata', {
+      'fs': {
+        'readFileSync': function() {
+          return '/*! { "name": "fake", "property": "U_pper-case123"}!*/ define([],';
+        }
+      }
+    });
+    expect(metadata).to.throw(/Property must be a lowercase string/);
+  });
+
   it('should throw if polyfill is incorrectly configured', function() {
 
     var metadata = proxyquire(root + 'lib/metadata', {


### PR DESCRIPTION
Refers to issue #2595

As per our discussion, `metadata.property` can contain only `lowercase alphanumeric characters and dashes`.
PR adds a test for the same, which raises an error if `metadata.property` values doesn't have valid characters. 

Please have a look. Thanks!