### PR TITLE
Implement issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/---bug-report.md
+++ b/.github/ISSUE_TEMPLATE/---bug-report.md
@@ -1,0 +1,26 @@
+---
+name: "\U0001F41B Bug report"
+about: Report errors with this template
+title: ''
+labels: 
+assignees: ''
+
+---
+
+**Type of bug**
+
+- [ ] Differences between Can I use & Modernizr
+- [ ] False positive
+- [ ] Modernizr error
+
+**Describe the bug**
+<!-- A clear and concise description of what the bug is. The error code or message is helpful-->
+
+**How to Reproduce**
+<!-- Steps to reproduce. Don't forget the version of node or browser -->
+
+**Expected behavior**
+<!-- What did you expect -->
+
+**Additional context**
+<!-- Add anything else you want to say here -->

--- a/.github/ISSUE_TEMPLATE/---test-request.md
+++ b/.github/ISSUE_TEMPLATE/---test-request.md
@@ -1,0 +1,21 @@
+---
+name: "\U0001F680 Test request"
+about: Suggest a new feature detect
+title: ''
+labels: detect needed
+assignees: ''
+
+---
+
+**Which feature do you want to detect?**
+<!-- Explain what the feature is about, throw a MDN link or similar -->
+
+**Which browsers do support this feature?**
+<!-- A brief explanation followed by a compatibility table like caniuse -->
+
+**How could it be implemented?**
+<!-- Is there a similar test? A stackoverflow answer? Maybe a variable is set on the browser?-->
+<!-- Delete if you don't know -->
+
+**Additional context**
+<!-- Add anything else you want to say here -->

--- a/.github/ISSUE_TEMPLATE/good-first-issue.md
+++ b/.github/ISSUE_TEMPLATE/good-first-issue.md
@@ -1,0 +1,21 @@
+---
+name: Good First Issue
+about: Intended for explaining little issues. Not intended to be created without knowledge.
+title: ''
+labels: good first issue
+assignees: ''
+
+---
+
+<!-- Please, do NOT post with this template if you are a beginner. Do NOT post with this proposal either if you are searching for a feature to be implemented, use the test request proposal for that -->
+
+Hi 👋!
+This issue is intended for new contributors and will help you implement your first changes to the Modernizr project.
+
+**What is proposed**
+<!-- Explain the things that are related with the changes the issue requests. If you request new caniuse metadata tags explain how metadata work, the caniuse tag and what it is for -->
+
+**How to do it**
+<!-- Explain which files need to be updated, for example in the previous example you would need to explain that the \test\browser\integration\caniuse.js needs to be updated along the tests files. You may link to documentation, to similar PRs or resources that you think that may be helpful. Don't feel afraid of almost doing the PR for them, the idea is to steer them in the right direction so the first contact with the repository is easier (with hopes of bringing more collaborators in :) -->
+
+**Feel free to raise any question in this issue if you stumble with problems and good luck 💪!**

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,14 @@
+---
+name: Questions
+about: You don't undestand something? Create an issue!
+title: ''
+labels: 
+assignees: ''
+
+---
+
+**The question**
+<!-- Try to be concise and specific, you may introduce code if you need it -->
+
+**Do maintainers need to follow some steps to help you out?**
+<!-- Explain the steps if the answer is yes -->


### PR DESCRIPTION
As we discussed in #2595 I've worked in some issue templates (haven't done anything about PR templates)

I've included 3 templates:
- Bug reports (caniuse errors, false positives & general bugs)
- Test requests
- Good first issues (although it may be used as a template for answers)

Another template that could be implemented is general requests (like coverage implementations or others), but they are not very common so I tried to minimize the decision problem for new contributors. Also, in the bug reports, maybe a Github Actions or something could be use to auto-assign labels to the issues (as multiple labels could be use for that template)