### PR TITLE
`indexeddbblob`: Fix test not triggering, update metadata

### DIFF
--- a/feature-detects/indexeddbblob.js
+++ b/feature-detects/indexeddbblob.js
@@ -14,54 +14,52 @@ define(['Modernizr', 'addTest', 'prefixed', 'test/indexeddb'], function(Moderniz
   // For speed, we don't test the legacy (and beta-only) indexedDB
 
   Modernizr.addAsyncTest(function() {
-    var indexeddb;
-    var dbname = 'detect-blob-support';
-    var supportsBlob = false;
-    var openRequest;
-    var db;
-    var putRequest;
+    Modernizr.on('indexeddb.deletedatabase', function(result) {
+      if (!result) return;
 
-    try {
-      indexeddb = prefixed('indexedDB', window);
-    } catch (e) {
-    }
+      var indexeddb;
+      var dbname = 'detect-blob-support';
+      var openRequest;
+      var db;
+      var putRequest;
 
-    if (!(Modernizr.indexeddb && Modernizr.indexeddb.deletedatabase)) {
-      return false;
-    }
+      try {
+        indexeddb = prefixed('indexedDB', window);
+      } catch (e) {
+      }
 
-    // Calling `deleteDatabase` in a try…catch because some contexts (e.g. data URIs)
-    // will throw a `SecurityError`
-    try {
-      indexeddb.deleteDatabase(dbname).onsuccess = function() {
-        openRequest = indexeddb.open(dbname, 1);
-        openRequest.onupgradeneeded = function() {
-          openRequest.result.createObjectStore('store');
+      // Calling `deleteDatabase` in a try…catch because some contexts (e.g. data URIs)
+      // will throw a `SecurityError`
+      try {
+        indexeddb.deleteDatabase(dbname).onsuccess = function() {
+          openRequest = indexeddb.open(dbname, 1);
+          openRequest.onupgradeneeded = function() {
+            openRequest.result.createObjectStore('store');
+          };
+          openRequest.onsuccess = function() {
+            db = openRequest.result;
+            try {
+              putRequest = db.transaction('store', 'readwrite').objectStore('store').put(new Blob(), 'key');
+              putRequest.onsuccess = function() {
+                addTest('indexeddbblob', true);
+              };
+              putRequest.onerror = function() {
+                addTest('indexeddbblob', false);
+              };
+            }
+            catch (e) {
+              addTest('indexeddbblob', false);
+            }
+            finally {
+              db.close();
+              indexeddb.deleteDatabase(dbname);
+            }
+          };
         };
-        openRequest.onsuccess = function() {
-          db = openRequest.result;
-          try {
-            putRequest = db.transaction('store', 'readwrite').objectStore('store').put(new Blob(), 'key');
-            putRequest.onsuccess = function() {
-              supportsBlob = true;
-            };
-            putRequest.onerror = function() {
-              supportsBlob = false;
-            };
-          }
-          catch (e) {
-            supportsBlob = false;
-          }
-          finally {
-            addTest('indexeddbblob', supportsBlob);
-            db.close();
-            indexeddb.deleteDatabase(dbname);
-          }
-        };
-      };
-    }
-    catch (e) {
-      addTest('indexeddbblob', false);
-    }
+      }
+      catch (e) {
+        addTest('indexeddbblob', false);
+      }
+    });
   });
 });

--- a/feature-detects/indexeddbblob.js
+++ b/feature-detects/indexeddbblob.js
@@ -1,7 +1,9 @@
 /*!
 {
   "name": "IndexedDB Blob",
-  "property": "indexeddbblob"
+  "property": "indexeddbblob",
+  "tags": ["storage"],
+  "async": true
 }
 !*/
 /* DOC


### PR DESCRIPTION
* `indexeddbblob`: Fix test never triggering

	The `indexedbblob` test never triggers, even on platforms that support
	IndexedDB or blobs in IndexedDB databases.
	
	This is because in 164e757, `indexeddb` was changed to an async test,
	but `indexeddbblob` still assumes that `indexeddb` test is synchronous.
	Therefore, the `indexeddb` check is never true and `indexedbblob` never
	triggers.
	
	The `onsuccess` / `onerror` / exception handlers also assign the test
	result to a shared variable before calling `addTest()`, which results
	in the test result being always false as the variable will not be
	updated synchronously before `addTest()`.
	
	Let's:
	* wrap the `indexeddbblob` test in a `on('indexeddb.deletedatabase')`
	listener, so that it will trigger when `indexeddb` and
	`indexeddb.deletedatabase` pass
	* call `addTest()` in the `onsuccess` / `onerror` / exception handlers
	instead of assigning to a shared variable

* indexeddbblob: Add missing metadata properties

	* add `storage` tag
	* mark as `async`