### PR TITLE
Fix naming of es6class test

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,13 +21,17 @@ Modernizr tests which native CSS3 and HTML5 features are available in the curren
 
 - Dropped Node 8 Support, please upgrade to Node v10
 
-- These tests got removed:
+- Following tests got renamed:
+  
+  - `class` to `esclass` to keep in line with the rest of the es-tests
 
-    - `touchevents`: [discussion](https://github.com/Modernizr/Modernizr/pull/2432) 
-    - `unicode`: [discussion](https://github.com/Modernizr/Modernizr/issues/2468) 
-    - `templatestrings`: duplicate of the es6 detect `stringtemplate`
-    - `contains`: duplicate of the es6 detect `es6string`
-    - `datalistelem`: A dupe of Modernizr.input.list
+- These tests got removed:
+  
+  - `touchevents`: [discussion](https://github.com/Modernizr/Modernizr/pull/2432)
+  - `unicode`: [discussion](https://github.com/Modernizr/Modernizr/issues/2468)
+  - `templatestrings`: duplicate of the es6 detect `stringtemplate`
+  - `contains`: duplicate of the es6 detect `es6string`
+  - `datalistelem`: A dupe of Modernizr.input.list
 
 ## New Asynchronous Event Listeners
 

--- a/feature-detects/es6/class.js
+++ b/feature-detects/es6/class.js
@@ -8,7 +8,7 @@
   }],
   "caniuse": "es6-class",
   "authors": ["dabretin"],
-  "tags": ["es6"]
+  "tags": ["es6"],
   "builderAliases": ["class"]
 }
 !*/

--- a/feature-detects/es6/class.js
+++ b/feature-detects/es6/class.js
@@ -9,13 +9,14 @@
   "caniuse": "es6-class",
   "authors": ["dabretin"],
   "tags": ["es6"]
+  "builderAliases": ["class"]
 }
 !*/
 /* DOC
 Check if browser implements ECMAScript 6 class.
 */
 define(['Modernizr'], function(Modernizr) {
-  Modernizr.addTest('class', function() {
+  Modernizr.addTest('es6class', function() {
     try {
       // eslint-disable-next-line
       eval('class A{}');


### PR DESCRIPTION
Prefix it with es6 to keep it in sync with the other esX-tests. Fixes #2619