### PR TITLE
Fix `Undefined identifier` error in es6symbol in IE8

### DIFF
--- a/feature-detects/es6/symbol.js
+++ b/feature-detects/es6/symbol.js
@@ -20,7 +20,7 @@ Check if browser implements ECMAScript 6 Symbol per specification.
 */
 define(['Modernizr'], function(Modernizr) {
   Modernizr.addTest('es6symbol', !!(typeof(Symbol)==="function" &&
-    Symbol.for &&
+    Symbol['for'] &&
     Symbol.hasInstance &&
     Symbol.isConcatSpreadable &&
     Symbol.iterator &&


### PR DESCRIPTION
Keyword 'for' in `Symbol.for` caused `Undefined identifier` error in IE8.

https://github.com/Modernizr/Modernizr/blob/3514072f7ffab2b4e222c1be190c3bcb74ee83e5/feature-detects/es6/symbol.js#L23
