### PR TITLE
ci(workflow): add cache to workflows using actions/setup-node

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -10,17 +10,18 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
         node-version: [12.x, 14.x, 16.x]
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v2
-    - name: Installing Node ${{ matrix.node-version }}
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ matrix.node-version }}
-    - name: Installing dependencies
-      run: npm ci
-    - name: Installing gulp command line interface
-      run: npm install gulp-cli
-    - name: Testing Modernizr
-      run: npm test
-    - name: Sending Coverage
-      run: ./node_modules/.bin/nyc report --reporter=text-lcov | ./node_modules/.bin/codecov --pipe
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Installing Node ${{ matrix.node-version }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: npm
+      - name: Installing dependencies
+        run: npm ci
+      - name: Installing gulp command line interface
+        run: npm install gulp-cli
+      - name: Testing Modernizr
+        run: npm test
+      - name: Sending Coverage
+        run: ./node_modules/.bin/nyc report --reporter=text-lcov | ./node_modules/.bin/codecov --pipe


### PR DESCRIPTION
## Description

Add `cache` to workflows using `actions/setup-node`

## Context

`setup-node` GitHub Action just released a new option to add cache to steps using it.

You can find the details here: https://github.blog/changelog/2021-07-02-github-actions-setup-node-now-supports-dependency-caching/

---

🤖 This PR has been generated automatically by [this octoherd script](https://github.com/oscard0m/octoherd-script-add-cache-to-node-github-action), feel free to run it in your GitHub user/org repositories! 💪🏾
