### PR TITLE
Set gulp connect to listen on any IP addresses available

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -143,7 +143,8 @@ gulp.task('pug', () => {
 
 gulp.task('serve:gh-pages', gulp.series('clean', 'generate', 'pug',  'copy:gh-pages', (done) => {
   connect.server({
-    root: 'gh-pages/'
+    host: '0.0.0.0',
+    root: 'gh-pages/',
   });
   done();
 }));


### PR DESCRIPTION
Set gulp connect to listen on any IP addresses available, i.e., the gh-pages and browser tests can be accessed from localhost and virtual machines when pointing to the host IP address.

https://www.npmjs.com/package/gulp-connect#optionshost