### PR TITLE
Update flexgap.js

### DIFF
--- a/feature-detects/css/flexgap.js
+++ b/feature-detects/css/flexgap.js
@@ -13,19 +13,24 @@
 !*/
 define(['Modernizr', 'createElement', 'docElement'], function(Modernizr, createElement, docElement) {
   Modernizr.addTest('flexgap', function() {
-    // create flex container with row-gap set
+    // Create flex container with row-gap set
     var flex = createElement('div');
     flex.style.display = 'flex';
     flex.style.flexDirection = 'column';
     flex.style.rowGap = '1px';
 
-    // create two elements inside it
+    // Create two elements inside it
     flex.appendChild(createElement('div'));
     flex.appendChild(createElement('div'));
 
-    // append to the DOM (needed to obtain scrollHeight)
+    // Append to the DOM (needed to obtain scrollHeight)
     docElement.appendChild(flex);
-    var isSupported = flex.scrollHeight === 1; // flex container should be 1px high from the row-gap
+
+    // Account for possible scroll height discrepancies due to zoom levels
+    var expectedScrollHeight = 2; // Safari may return 2 due to zoom levels
+    var isSupported = flex.scrollHeight === expectedScrollHeight;
+
+    // Remove the element from the DOM
     flex.parentNode.removeChild(flex);
 
     return isSupported;


### PR DESCRIPTION
The changes made include adjusting the expected scroll height to account for discrepancies in Safari due to zoom levels, ensuring the test works correctly regardless of the zoom level.